### PR TITLE
added feature to put end time in repeated reminders

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -64,6 +64,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     public static String NOTIFICATION_ID = "notification_id";
     public static String NOTIFICATION = "notification";
     public static String REPEAT = "repeat";
+    public static String REPEAT_TILL = "repeatTill";
     private static MethodChannel channel;
     private static int defaultIconResourceId;
     private final Registrar registrar;
@@ -171,6 +172,10 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         notificationIntent.putExtra(NOTIFICATION_ID, notificationDetails.id);
         notificationIntent.putExtra(NOTIFICATION, notification);
         notificationIntent.putExtra(REPEAT, true);
+
+        if( notificationDetails.endTime != null )
+            notificationIntent.putExtra(REPEAT_TILL, notificationDetails.endTime);
+            
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationDetails.id, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         AlarmManager alarmManager = getAlarmManager(context);

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
@@ -1,5 +1,8 @@
 package com.dexterous.flutterlocalnotifications;
 
+import java.util.Date;
+import java.util.GregorianCalendar;
+
 import android.app.Notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -20,9 +23,24 @@ public class ScheduledNotificationReceiver extends BroadcastReceiver {
         int notificationId = intent.getIntExtra(FlutterLocalNotificationsPlugin.NOTIFICATION_ID, 0);
         notificationManager.notify(notificationId, notification);
         boolean repeat = intent.getBooleanExtra(FlutterLocalNotificationsPlugin.REPEAT, false);
+
         if (repeat) {
+            Long repeatTillMS =  intent.getLongExtra( FlutterLocalNotificationsPlugin.REPEAT_TILL, -1L );
+            if( repeatTillMS != -1L ){
+                Date endDate = new Date( repeatTillMS );
+                Date currentTime = new Date( GregorianCalendar.getInstance().getTimeInMillis() );
+                if( endDate.after( currentTime ) ){
+
+                    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    AlarmManager alarmManager = getAlarmManager(context);
+                    alarmManager.cancel(pendingIntent);
+
+                    FlutterLocalNotificationsPlugin.removeNotificationFromCache(notificationId, context);
+                }
+            }
             return;
         }
+
         FlutterLocalNotificationsPlugin.removeNotificationFromCache(notificationId, context);
     }
 

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -22,6 +22,7 @@ public class NotificationDetails {
     private static final String CALLED_AT = "calledAt";
     private static final String REPEAT_INTERVAL = "repeatInterval";
     private static final String REPEAT_TIME = "repeatTime";
+    private static final String END_TIME = "endTime";
     private static final String PLATFORM_SPECIFICS = "platformSpecifics";
     private static final String AUTO_CANCEL = "autoCancel";
     private static final String ONGOING = "ongoing";
@@ -75,6 +76,7 @@ public class NotificationDetails {
     public RepeatInterval repeatInterval;
     public Time repeatTime;
     public Long millisecondsSinceEpoch;
+    public Long endTime;
     public Long calledAt;
     public String payload;
     public String groupKey;
@@ -108,6 +110,9 @@ public class NotificationDetails {
             @SuppressWarnings("unchecked")
             Map<String, Object> repeatTimeParams = (Map<String, Object>) arguments.get(REPEAT_TIME);
             notificationDetails.repeatTime = Time.from(repeatTimeParams);
+        }
+        if (arguments.containsKey(END_TIME)) {
+            notificationDetails.endTime = (Long) arguments.get(END_TIME);
         }
         if (arguments.containsKey(DAY)) {
             notificationDetails.day = (Integer) arguments.get(DAY);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -143,6 +143,14 @@ class _MyAppState extends State<MyApp> {
                         onPressed: () async {
                           await _cancelAllNotifications();
                         })),
+                new Padding(
+                    padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: new RaisedButton(
+                        child: new Text(
+                            'Repeat notification every minute for 3 minutes'),
+                        onPressed: () async {
+                          await _showRepeatEveryMinute();
+                        })),
               ],
             ),
           ),
@@ -372,6 +380,31 @@ class _MyAppState extends State<MyApp> {
         Day.Monday,
         time,
         platformChannelSpecifics);
+  }
+
+  Future _showRepeatEveryMinute() async {
+
+    var startTime = new DateTime.now().add(new Duration(seconds: 5));
+    var endTime = new DateTime.now().add(new Duration(minutes: 3));
+
+    var androidPlatformChannelSpecifics = 
+              new NotificationDetailsAndroid(
+                  'show minute channel id',
+                  'show minute channel name',
+                  'show minute description');
+
+    var iOSPlatformChannelSpecifics = new NotificationDetailsIOS();
+    var platformChannelSpecifics = new NotificationDetails(androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+
+    await flutterLocalNotificationsPlugin.periodicallyShowTill(
+        0,
+        'show every minute title',
+        'notification every minute',
+        startTime,
+        endTime,
+        RepeatInterval.EveryMinute,
+        platformChannelSpecifics
+      );
   }
 
   String _toTwoDigitString(int value) {

--- a/lib/flutter_local_notifications.dart
+++ b/lib/flutter_local_notifications.dart
@@ -146,6 +146,26 @@ class FlutterLocalNotificationsPlugin {
     });
   }
 
+  Future periodicallyShowTill(  int id, String title, String body, 
+                                DateTime scheduledDate, 
+                                DateTime scheduledTill,
+                                RepeatInterval repeatInterval, 
+                                NotificationDetails notificationDetails,
+                                {String payload}) async {
+
+    var serializedPlatformSpecifics =_retrievePlatformSpecificNotificationDetails(notificationDetails);
+    await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
+      'id': id,
+      'title': title,
+      'body': body,
+      'calledAt': scheduledDate.millisecondsSinceEpoch,
+      'endTime': scheduledTill.millisecondsSinceEpoch,
+      'repeatInterval': repeatInterval.index,
+      'platformSpecifics': serializedPlatformSpecifics,
+      'payload': payload ?? ''
+    });
+  }
+
   /// Shows a notification on a daily interval at the specified time
   Future showDailyAtTime(int id, String title, String body,
       Time notificationTime, NotificationDetails notificationDetails,

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -134,6 +134,39 @@ void main() {
       }));
     });
 
+    test('schedule repeat notifications on Android', () async {
+      var scheduledNotificationDateTime = new DateTime.now().add(new Duration(seconds: 5));
+      var scheduledNotificationEndTime = new DateTime.now().add(new Duration(minutes: 3));
+
+      NotificationDetailsAndroid androidPlatformChannelSpecifics =
+          new NotificationDetailsAndroid( 'your other channel id',
+                                          'your other channel name', 
+                                          'your other channel description');
+
+      NotificationDetails platformChannelSpecifics = new NotificationDetails(androidPlatformChannelSpecifics, null);
+      
+      await flutterLocalNotificationsPlugin.periodicallyShowTill(
+                  id, 
+                  title, 
+                  body,
+                  scheduledNotificationDateTime, 
+                  scheduledNotificationEndTime, 
+                  RepeatInterval.EveryMinute, 
+                  platformChannelSpecifics
+      );
+
+      verify(mockChannel.invokeMethod('periodicallyShow', <String, dynamic>{
+        'id': id,
+        'title': title,
+        'body': body,
+        'calledAt': scheduledNotificationDateTime.millisecondsSinceEpoch,
+        'endTime': scheduledNotificationEndTime.millisecondsSinceEpoch,
+        'repeatInterval': RepeatInterval.EveryMinute.index,
+        'platformSpecifics': androidPlatformChannelSpecifics.toMap(),
+        'payload': ''
+      }));
+    });
+
     test('delete notification on android', () async {
       await flutterLocalNotificationsPlugin.cancel(id);
       verify(mockChannel.invokeMethod('cancel', id));


### PR DESCRIPTION
i wanted a feature to give me a notification every 1 minute till 30 minutes only. i,e  to start at a given time and run till an end time with a repeat interval. It can now done this like below. 
Unfortunately i didn't have xcode setup hence couldn't complete the code for the iOS part.

   var startTime = new DateTime.now().add(new Duration(seconds: 5));
    var endTime = new DateTime.now().add(new Duration(minutes: 30));

    var androidPlatformChannelSpecifics = 
              new NotificationDetailsAndroid(
                  'show minute channel id',
                  'show minute channel name',
                  'show minute description');

    var platformChannelSpecifics = new NotificationDetails(androidPlatformChannelSpecifics);

    await flutterLocalNotificationsPlugin.periodicallyShowTill(
        0,
        'show every minute title',
        'notification every minute',
        startTime,
        endTime,
        RepeatInterval.EveryMinute,
        platformChannelSpecifics
      );