### PR TITLE
[#61] iOS: Refactor date components used in repeat notification scheduling.

### DIFF
--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -276,13 +276,13 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         if (notificationDetails.repeatTime != nil) {
             NSDate *now = [NSDate date];
             NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
-            NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay fromDate:now];
+            NSDateComponents *dateComponents = [[NSDateComponents alloc] init];
+            if (notificationDetails.day != nil) {
+                [dateComponents setWeekday:[notificationDetails.day integerValue]];
+            }
             [dateComponents setHour:[notificationDetails.repeatTime.hour integerValue]];
             [dateComponents setMinute:[notificationDetails.repeatTime.minute integerValue]];
             [dateComponents setSecond:[notificationDetails.repeatTime.second integerValue]];
-            if(notificationDetails.day != nil) {
-                [dateComponents setWeekday:[notificationDetails.day integerValue]];
-            }
             trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats: repeats];
         } else {
             trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:timeInterval

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -277,6 +277,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
             NSDate *now = [NSDate date];
             NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
             NSDateComponents *dateComponents = [[NSDateComponents alloc] init];
+            [dateComponents setCalendar:calendar];
             if (notificationDetails.day != nil) {
                 [dateComponents setWeekday:[notificationDetails.day integerValue]];
             }


### PR DESCRIPTION
### Issue #61 

Description
---
- Notifications scheduled for a time earlier in the day than the time the code was called resulted in invalid triggers (never getting fired).
- For instance, it's noon and you are scheduling a morning notification to be shown daily. These wouldn't fire because our trigger is initialized with today's date resulting in the impossibility to be executed.

What Was Changed
---
- Drop `NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay` from the `NSDateComponents` we use for our `UNCalendarNotificationTrigger`. The trigger should ignore the year, month, and day and instead only be fired when it's the appropriate time and/or weekday.
- Specify the calendar on the `NSDateComponents` since we no longer init with components from a date and calendar.

Testing
---
- Regression tested scheduling daily notifications.
- Regression tested scheduling weekly at day and time notifications.
- Schedule a daily notification to be shown for a time earlier in the day; that is, schedule a notification to be shown daily at 8:00am if it's later than that already in the day when you schedule it with the plugin.

Little trick to test:
- [ ] Schedule a daily and weekly notification for an hour ago (and today's weekday). 
- [ ] Go into your iPhone's Settings -> General -> Date & Time. 
- [ ] Turn off `Set Automatically`.
- [ ] Move the time before each notification. As you drag the minute past it (and release) you should get your notification!