### PR TITLE
Example fix: Added listview to the column to prevent overflowing

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,129 +45,134 @@ class _MyAppState extends State<MyApp> {
         body: new Padding(
           padding: new EdgeInsets.all(8.0),
           child: new Center(
-            child: new Column(
+            child: new ListView(
+              scrollDirection: Axis.vertical,
               children: <Widget>[
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new Text(
-                      'Tap on a notification when it appears to trigger navigation'),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show plain notification with payload'),
-                    onPressed: () async {
-                      await _showNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Cancel notification'),
-                    onPressed: () async {
-                      await _cancelNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                    padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: new RaisedButton(
+                Column(
+                  children: <Widget>[
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new Text(
+                          'Tap on a notification when it appears to trigger navigation'),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show plain notification with payload'),
+                        onPressed: () async {
+                          await _showNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Cancel notification'),
+                        onPressed: () async {
+                          await _cancelNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                        padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                        child: new RaisedButton(
+                            child: new Text(
+                                'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
+                            onPressed: () async {
+                              await _scheduleNotification();
+                            })),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Repeat notification every minute'),
+                        onPressed: () async {
+                          await _repeatNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
                         child: new Text(
-                            'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
+                            'Repeat notification every day at approximately 10:00:00 am'),
                         onPressed: () async {
-                          await _scheduleNotification();
-                        })),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Repeat notification every minute'),
-                    onPressed: () async {
-                      await _repeatNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text(
-                        'Repeat notification every day at approximately 10:00:00 am'),
-                    onPressed: () async {
-                      await _showDailyAtTime();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text(
-                        'Repeat notification weekly on Monday at approximately 10:00:00 am'),
-                    onPressed: () async {
-                      await _showWeeklyAtDayAndTime();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show notification with no sound'),
-                    onPressed: () async {
-                      await _showNotificationWithNoSound();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show big picture notification [Android]'),
-                    onPressed: () async {
-                      await _showBigPictureNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show big text notification [Android]'),
-                    onPressed: () async {
-                      await _showBigTextNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show inbox notification [Android]'),
-                    onPressed: () async {
-                      await _showInboxNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show grouped notifications [Android]'),
-                    onPressed: () async {
-                      await _showGroupedNotifications();
-                    },
-                  ),
-                ),
-                new Padding(
-                  padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                  child: new RaisedButton(
-                    child: new Text('Show ongoing notification [Android]'),
-                    onPressed: () async {
-                      await _showOngoingNotification();
-                    },
-                  ),
-                ),
-                new Padding(
-                    padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: new RaisedButton(
-                        child: new Text('cancel all notifications'),
+                          await _showDailyAtTime();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text(
+                            'Repeat notification weekly on Monday at approximately 10:00:00 am'),
                         onPressed: () async {
-                          await _cancelAllNotifications();
-                        })),
+                          await _showWeeklyAtDayAndTime();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show notification with no sound'),
+                        onPressed: () async {
+                          await _showNotificationWithNoSound();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show big picture notification [Android]'),
+                        onPressed: () async {
+                          await _showBigPictureNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show big text notification [Android]'),
+                        onPressed: () async {
+                          await _showBigTextNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show inbox notification [Android]'),
+                        onPressed: () async {
+                          await _showInboxNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show grouped notifications [Android]'),
+                        onPressed: () async {
+                          await _showGroupedNotifications();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                      padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: new RaisedButton(
+                        child: new Text('Show ongoing notification [Android]'),
+                        onPressed: () async {
+                          await _showOngoingNotification();
+                        },
+                      ),
+                    ),
+                    new Padding(
+                        padding: new EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                        child: new RaisedButton(
+                            child: new Text('cancel all notifications'),
+                            onPressed: () async {
+                              await _cancelAllNotifications();
+                            })),
+                  ],
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
This is my first time creating a pull request on a public repo so i hope this is the correct way to do so :)

While running the example code on my device, i noticed that the bottom of the page was having an issue rendering as the list of buttons was longer than the height of the screen, causing an overflow error. I have just added a fix for this by wrapping the column in a listview which allows the user to scroll if page overflows.

an screenshot of the bug:
![screenshot_20180715-011256](https://user-images.githubusercontent.com/8235815/42729351-fc83c904-87cc-11e8-9e1d-db43bc95dba1.png)
