### PR TITLE
#140 Fixed a problem in which scheduled notifications are immediately notified on devices with pre-iOS 10 devices

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -116,10 +116,12 @@ public class NotificationDetails {
         notificationDetails.title = (String) arguments.get(TITLE);
         notificationDetails.body = (String) arguments.get(BODY);
         if (arguments.containsKey(MILLISECONDS_SINCE_EPOCH)) {
-            notificationDetails.millisecondsSinceEpoch = (Long) arguments.get(MILLISECONDS_SINCE_EPOCH);
+            String strMillisecondsSinceEpoch = (String) arguments.get(MILLISECONDS_SINCE_EPOCH);
+            notificationDetails.millisecondsSinceEpoch = Long.parseLong(strMillisecondsSinceEpoch, 10);
         }
         if (arguments.containsKey(CALLED_AT)) {
-            notificationDetails.calledAt = (Long) arguments.get(CALLED_AT);
+            String strCalledAt = (String) arguments.get(CALLED_AT);
+            notificationDetails.calledAt = Long.parseLong(strCalledAt, 10);
         }
         if (arguments.containsKey(REPEAT_INTERVAL)) {
             notificationDetails.repeatInterval = RepeatInterval.values()[(Integer) arguments.get(REPEAT_INTERVAL)];

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -430,7 +430,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -452,7 +451,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -181,7 +181,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         notificationDetails.sound = platformSpecifics[SOUND];
     }
     if([SCHEDULE_METHOD isEqualToString:call.method]) {
-        notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] integerValue] / 1000);
+        notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] longLongValue] / 1000);
     } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
         if (call.arguments[REPEAT_TIME]) {
             NSDictionary *timeArguments = (NSDictionary *) call.arguments[REPEAT_TIME];
@@ -345,7 +345,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                                                                          repeats:repeats];
         }
     } else {
-        NSDate *date = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch integerValue]];
+        NSDate *date = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch longLongValue]];
         NSCalendar *calendar = [NSCalendar currentCalendar];
         NSDateComponents *dateComponents    = [calendar components:(NSCalendarUnitYear  |
                                                                     NSCalendarUnitMonth |
@@ -423,7 +423,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         }
         [[UIApplication sharedApplication] presentLocalNotificationNow:notification];
     } else {
-        notification.fireDate = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch integerValue]];
+        notification.fireDate = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch longLongValue]];
         [[UIApplication sharedApplication] scheduleLocalNotification:notification];
     }
 }

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -132,7 +132,7 @@ class FlutterLocalNotificationsPlugin {
       'id': id,
       'title': title,
       'body': body,
-      'millisecondsSinceEpoch': scheduledDate.millisecondsSinceEpoch,
+      'millisecondsSinceEpoch': scheduledDate.millisecondsSinceEpoch.toString(),
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
     });
@@ -150,7 +150,7 @@ class FlutterLocalNotificationsPlugin {
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': new DateTime.now().millisecondsSinceEpoch,
+      'calledAt': new DateTime.now().millisecondsSinceEpoch.toString(),
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
@@ -168,7 +168,7 @@ class FlutterLocalNotificationsPlugin {
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': new DateTime.now().millisecondsSinceEpoch,
+      'calledAt': new DateTime.now().millisecondsSinceEpoch.toString(),
       'repeatInterval': RepeatInterval.Daily.index,
       'repeatTime': notificationTime.toMap(),
       'platformSpecifics': serializedPlatformSpecifics,
@@ -187,7 +187,7 @@ class FlutterLocalNotificationsPlugin {
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': new DateTime.now().millisecondsSinceEpoch,
+      'calledAt': new DateTime.now().millisecondsSinceEpoch.toString(),
       'repeatInterval': RepeatInterval.Weekly.index,
       'repeatTime': notificationTime.toMap(),
       'day': day.value,

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -58,7 +58,7 @@ void main() {
         'title': title,
         'body': body,
         'millisecondsSinceEpoch':
-            scheduledNotificationDateTime.millisecondsSinceEpoch,
+            scheduledNotificationDateTime.millisecondsSinceEpoch.toString(),
         'platformSpecifics': iOSPlatformChannelSpecifics.toMap(),
         'payload': ''
       }));
@@ -122,7 +122,7 @@ void main() {
         'title': title,
         'body': body,
         'millisecondsSinceEpoch':
-            scheduledNotificationDateTime.millisecondsSinceEpoch,
+            scheduledNotificationDateTime.millisecondsSinceEpoch.toString(),
         'platformSpecifics': androidPlatformChannelSpecifics.toMap(),
         'payload': ''
       }));


### PR DESCRIPTION
As we already told you ...

Fixed the problem that the value of `millisecondsSinceEpoch` is truncated between Flutter and Objective-C and in Objective-C code.

We changed that value to a string and fixed the problem that it is truncated between Flutter and Objective-C.

We also fixed a problem that would be truncated within Objective-C code using `longLongValue` instead of `integerValue`.

Along with that, on the Java side, we need to change this value from a character string to a long value, so we added that processing.

We confirmed that this change works correctly on iOS 10 and later devices, devices before iOS 10 and Android devices.

Perhaps this may be related to these.
https://github.com/flutter/flutter/issues/21313

We tried a method that does not use strings, but that could not be realized.

Also, it might be preferable to use Iso8601String for this string, but we did not adopt it because we were concerned about new bugs such as time zones.