### PR TITLE
#140 Fixed secondsSinceEpoch being truncated on iOS

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -430,7 +430,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -452,7 +451,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -181,7 +181,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         notificationDetails.sound = platformSpecifics[SOUND];
     }
     if([SCHEDULE_METHOD isEqualToString:call.method]) {
-        notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] integerValue] / 1000);
+        notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] longLongValue] / 1000);
     } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
         if (call.arguments[REPEAT_TIME]) {
             NSDictionary *timeArguments = (NSDictionary *) call.arguments[REPEAT_TIME];
@@ -345,7 +345,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                                                                          repeats:repeats];
         }
     } else {
-        NSDate *date = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch integerValue]];
+        NSDate *date = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch longLongValue]];
         NSCalendar *calendar = [NSCalendar currentCalendar];
         NSDateComponents *dateComponents    = [calendar components:(NSCalendarUnitYear  |
                                                                     NSCalendarUnitMonth |
@@ -423,7 +423,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         }
         [[UIApplication sharedApplication] presentLocalNotificationNow:notification];
     } else {
-        notification.fireDate = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch integerValue]];
+        notification.fireDate = [NSDate dateWithTimeIntervalSince1970:[notificationDetails.secondsSinceEpoch longLongValue]];
         [[UIApplication sharedApplication] scheduleLocalNotification:notification];
     }
 }


### PR DESCRIPTION
On devices before iOS 10, scheduled notifications were immediately notified.

Switching Flutter from dev branch to master branch improved the problem of being truncated between Flutter and Objective-C.

However, the problem truncated within Objective-C still occurred.

We fixed this by replacing integerValue with longLongValue.

To check this fix you need to switch Flutter to master branch.

The example application was designed to work only with arm64 devices. Probably this plugin has been tested only on arm64 devices. This problem may only occur on 32 bit devices. We have made this application work on devices that are not arm64. When you test this change, we would like you to test even devices that are not arm64.