### PR TITLE
Support multi plugins for background operation

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -88,13 +88,15 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     public static String NOTIFICATION = "notification";
     public static String NOTIFICATION_DETAILS = "notificationDetails";
     public static String REPEAT = "repeat";
-    private static MethodChannel channel;
+    private MethodChannel channel;
     private static int defaultIconResourceId;
     private final Registrar registrar;
 
     private FlutterLocalNotificationsPlugin(Registrar registrar) {
         this.registrar = registrar;
         this.registrar.addNewIntentListener(this);
+        this.channel = new MethodChannel(registrar.messenger(), METHOD_CHANNEL);
+        this.channel.setMethodCallHandler(this);
     }
 
     public static void rescheduleNotifications(Context context) {
@@ -182,9 +184,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
      * Plugin registration.
      */
     public static void registerWith(Registrar registrar) {
-        channel = new MethodChannel(registrar.messenger(), METHOD_CHANNEL);
         FlutterLocalNotificationsPlugin plugin = new FlutterLocalNotificationsPlugin(registrar);
-        channel.setMethodCallHandler(plugin);
     }
 
     public static void removeNotificationFromCache(Integer notificationId, Context context) {


### PR DESCRIPTION
Hi,

When you are running this plugin with multiple isolates, the use of a static method channel means that the first instance of the plugin for one of the isolates get over written by the instance for the new isolate.

Hence you can't send notification intents to both dart isolates. Moving the method channel within the plugin gets around this issue.

Not sure if it causes other issues however. I'm not fully sure I understand why you created it as static. There may be a very good reason!

Here is the PR.

Cheers