### PR TITLE
feat(): Override toString() on Time

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -578,7 +578,7 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.showDailyAtTime(
         0,
         'show daily title',
-        'Daily notification shown at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        'Daily notification shown at approximately $time',
         time,
         platformChannelSpecifics);
   }
@@ -595,7 +595,7 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
         0,
         'show weekly title',
-        'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        'Weekly notification shown on Monday at approximately $time',
         Day.Monday,
         time,
         platformChannelSpecifics);
@@ -683,10 +683,6 @@ class _HomePageState extends State<HomePage> {
         'check settings to see updated channel description',
         platformChannelSpecifics,
         payload: 'item x');
-  }
-
-  String _toTwoDigitString(int value) {
-    return value.toString().padLeft(2, '0');
   }
 
   Future onDidRecieveLocalNotification(

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -52,6 +52,15 @@ class Time {
       'second': second,
     };
   }
+
+  @override
+  String toString() {
+    return hour.toString().padLeft(2, '0') +
+        ':' +
+        minute.toString().padLeft(2, '0') +
+        ':' +
+        second.toString().padLeft(2, '0');
+  }
 }
 
 class FlutterLocalNotificationsPlugin {


### PR DESCRIPTION
This pull request adds the override for toString() on the time class so that it automatically pads the hours, minutes, and seconds.  For a time of 8 minutes after 3 am, `print($time)` will produce `03:08:00`.

This will reduce the formatting in the existing example file.

For example:
`        'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
`

can be rewritten as:
`        'Weekly notification shown on Monday at approximately $time',
`

Thanks