### PR TITLE
Adding FlutterLocalNotificationsPlugin as a dependency injection into WidgetTree

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,8 +21,11 @@ void main() async {
   // var notificationAppLaunchDetails =
   //     await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
   runApp(
-    MaterialApp(
-      home: HomePage(),
+    NotificationProvider(
+      service: flutterLocalNotificationsPlugin,
+      child: MaterialApp(
+        home: HomePage(),
+      ),
     ),
   );
 }
@@ -51,204 +54,201 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return NotificationProvider(
-      service: flutterLocalNotificationsPlugin,
-      child: MaterialApp(
-        home: Scaffold(
-          appBar: AppBar(
-            title: Text('Plugin example app'),
-          ),
-          body: SingleChildScrollView(
-            scrollDirection: Axis.vertical,
-            child: Padding(
-              padding: EdgeInsets.all(8.0),
-              child: Center(
-                child: Column(
-                  children: <Widget>[
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Plugin example app'),
+        ),
+        body: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Center(
+              child: Column(
+                children: <Widget>[
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: Text(
+                        'Tap on a notification when it appears to trigger navigation'),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show plain notification with payload'),
+                      onPressed: () async {
+                        await _showNotification();
+                      },
+                    ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
                       child: Text(
-                          'Tap on a notification when it appears to trigger navigation'),
+                          'Show plain notification with payload and update channel description'),
+                      onPressed: () async {
+                        await _showNotificationWithUpdatedChannelDescription();
+                      },
                     ),
-                    Padding(
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Cancel notification'),
+                      onPressed: () async {
+                        await _cancelNotification();
+                      },
+                    ),
+                  ),
+                  Padding(
                       padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
                       child: RaisedButton(
-                        child: Text('Show plain notification with payload'),
-                        onPressed: () async {
-                          await _showNotification();
-                        },
-                      ),
+                          child: Text(
+                              'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
+                          onPressed: () async {
+                            await _scheduleNotification();
+                          })),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Repeat notification every minute'),
+                      onPressed: () async {
+                        await _repeatNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Show plain notification with payload and update channel description'),
-                        onPressed: () async {
-                          await _showNotificationWithUpdatedChannelDescription();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Repeat notification every day at approximately 10:00:00 am'),
+                      onPressed: () async {
+                        await _showDailyAtTime();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Cancel notification'),
-                        onPressed: () async {
-                          await _cancelNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Repeat notification weekly on Monday at approximately 10:00:00 am'),
+                      onPressed: () async {
+                        await _showWeeklyAtDayAndTime();
+                      },
                     ),
-                    Padding(
-                        padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                        child: RaisedButton(
-                            child: Text(
-                                'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
-                            onPressed: () async {
-                              await _scheduleNotification();
-                            })),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Repeat notification every minute'),
-                        onPressed: () async {
-                          await _repeatNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show notification with no sound'),
+                      onPressed: () async {
+                        await _showNotificationWithNoSound();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Repeat notification every day at approximately 10:00:00 am'),
-                        onPressed: () async {
-                          await _showDailyAtTime();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show big picture notification [Android]'),
+                      onPressed: () async {
+                        await _showBigPictureNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Repeat notification weekly on Monday at approximately 10:00:00 am'),
-                        onPressed: () async {
-                          await _showWeeklyAtDayAndTime();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Show big picture notification, hide large icon on expand [Android]'),
+                      onPressed: () async {
+                        await _showBigPictureNotificationHideExpandedLargeIcon();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show notification with no sound'),
-                        onPressed: () async {
-                          await _showNotificationWithNoSound();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show big text notification [Android]'),
+                      onPressed: () async {
+                        await _showBigTextNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show big picture notification [Android]'),
-                        onPressed: () async {
-                          await _showBigPictureNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show inbox notification [Android]'),
+                      onPressed: () async {
+                        await _showInboxNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Show big picture notification, hide large icon on expand [Android]'),
-                        onPressed: () async {
-                          await _showBigPictureNotificationHideExpandedLargeIcon();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show messaging notification [Android]'),
+                      onPressed: () async {
+                        await _showMessagingNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show big text notification [Android]'),
-                        onPressed: () async {
-                          await _showBigTextNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show grouped notifications [Android]'),
+                      onPressed: () async {
+                        await _showGroupedNotifications();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show inbox notification [Android]'),
-                        onPressed: () async {
-                          await _showInboxNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('Show ongoing notification [Android]'),
+                      onPressed: () async {
+                        await _showOngoingNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show messaging notification [Android]'),
-                        onPressed: () async {
-                          await _showMessagingNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Show notification with no badge, alert only once [Android]'),
+                      onPressed: () async {
+                        await _showNotificationWithNoBadge();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show grouped notifications [Android]'),
-                        onPressed: () async {
-                          await _showGroupedNotifications();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Show progress notification - updates every second [Android]'),
+                      onPressed: () async {
+                        await _showProgressNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('Show ongoing notification [Android]'),
-                        onPressed: () async {
-                          await _showOngoingNotification();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text(
+                          'Show indeterminate progress notification [Android]'),
+                      onPressed: () async {
+                        await _showIndeterminateProgressNotification();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Show notification with no badge, alert only once [Android]'),
-                        onPressed: () async {
-                          await _showNotificationWithNoBadge();
-                        },
-                      ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                    child: RaisedButton(
+                      child: Text('cancel all notifications'),
+                      onPressed: () async {
+                        await _cancelAllNotifications();
+                      },
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Show progress notification - updates every second [Android]'),
-                        onPressed: () async {
-                          await _showProgressNotification();
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text(
-                            'Show indeterminate progress notification [Android]'),
-                        onPressed: () async {
-                          await _showIndeterminateProgressNotification();
-                        },
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                      child: RaisedButton(
-                        child: Text('cancel all notifications'),
-                        onPressed: () async {
-                          await _cancelAllNotifications();
-                        },
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_local_notifications_example/second_page.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 
@@ -50,201 +51,204 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: Text('Plugin example app'),
-        ),
-        body: SingleChildScrollView(
-          scrollDirection: Axis.vertical,
-          child: Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Center(
-              child: Column(
-                children: <Widget>[
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: Text(
-                        'Tap on a notification when it appears to trigger navigation'),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show plain notification with payload'),
-                      onPressed: () async {
-                        await _showNotification();
-                      },
-                    ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
+    return NotificationProvider(
+      service: flutterLocalNotificationsPlugin,
+      child: MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: Text('Plugin example app'),
+          ),
+          body: SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Center(
+                child: Column(
+                  children: <Widget>[
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
                       child: Text(
-                          'Show plain notification with payload and update channel description'),
-                      onPressed: () async {
-                        await _showNotificationWithUpdatedChannelDescription();
-                      },
+                          'Tap on a notification when it appears to trigger navigation'),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Cancel notification'),
-                      onPressed: () async {
-                        await _cancelNotification();
-                      },
-                    ),
-                  ),
-                  Padding(
+                    Padding(
                       padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
                       child: RaisedButton(
-                          child: Text(
-                              'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
-                          onPressed: () async {
-                            await _scheduleNotification();
-                          })),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Repeat notification every minute'),
-                      onPressed: () async {
-                        await _repeatNotification();
-                      },
+                        child: Text('Show plain notification with payload'),
+                        onPressed: () async {
+                          await _showNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Repeat notification every day at approximately 10:00:00 am'),
-                      onPressed: () async {
-                        await _showDailyAtTime();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Show plain notification with payload and update channel description'),
+                        onPressed: () async {
+                          await _showNotificationWithUpdatedChannelDescription();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Repeat notification weekly on Monday at approximately 10:00:00 am'),
-                      onPressed: () async {
-                        await _showWeeklyAtDayAndTime();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Cancel notification'),
+                        onPressed: () async {
+                          await _cancelNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show notification with no sound'),
-                      onPressed: () async {
-                        await _showNotificationWithNoSound();
-                      },
+                    Padding(
+                        padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                        child: RaisedButton(
+                            child: Text(
+                                'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon'),
+                            onPressed: () async {
+                              await _scheduleNotification();
+                            })),
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Repeat notification every minute'),
+                        onPressed: () async {
+                          await _repeatNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show big picture notification [Android]'),
-                      onPressed: () async {
-                        await _showBigPictureNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Repeat notification every day at approximately 10:00:00 am'),
+                        onPressed: () async {
+                          await _showDailyAtTime();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Show big picture notification, hide large icon on expand [Android]'),
-                      onPressed: () async {
-                        await _showBigPictureNotificationHideExpandedLargeIcon();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Repeat notification weekly on Monday at approximately 10:00:00 am'),
+                        onPressed: () async {
+                          await _showWeeklyAtDayAndTime();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show big text notification [Android]'),
-                      onPressed: () async {
-                        await _showBigTextNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show notification with no sound'),
+                        onPressed: () async {
+                          await _showNotificationWithNoSound();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show inbox notification [Android]'),
-                      onPressed: () async {
-                        await _showInboxNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show big picture notification [Android]'),
+                        onPressed: () async {
+                          await _showBigPictureNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show messaging notification [Android]'),
-                      onPressed: () async {
-                        await _showMessagingNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Show big picture notification, hide large icon on expand [Android]'),
+                        onPressed: () async {
+                          await _showBigPictureNotificationHideExpandedLargeIcon();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show grouped notifications [Android]'),
-                      onPressed: () async {
-                        await _showGroupedNotifications();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show big text notification [Android]'),
+                        onPressed: () async {
+                          await _showBigTextNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('Show ongoing notification [Android]'),
-                      onPressed: () async {
-                        await _showOngoingNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show inbox notification [Android]'),
+                        onPressed: () async {
+                          await _showInboxNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Show notification with no badge, alert only once [Android]'),
-                      onPressed: () async {
-                        await _showNotificationWithNoBadge();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show messaging notification [Android]'),
+                        onPressed: () async {
+                          await _showMessagingNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Show progress notification - updates every second [Android]'),
-                      onPressed: () async {
-                        await _showProgressNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show grouped notifications [Android]'),
+                        onPressed: () async {
+                          await _showGroupedNotifications();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text(
-                          'Show indeterminate progress notification [Android]'),
-                      onPressed: () async {
-                        await _showIndeterminateProgressNotification();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('Show ongoing notification [Android]'),
+                        onPressed: () async {
+                          await _showOngoingNotification();
+                        },
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
-                    child: RaisedButton(
-                      child: Text('cancel all notifications'),
-                      onPressed: () async {
-                        await _cancelAllNotifications();
-                      },
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Show notification with no badge, alert only once [Android]'),
+                        onPressed: () async {
+                          await _showNotificationWithNoBadge();
+                        },
+                      ),
                     ),
-                  ),
-                ],
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Show progress notification - updates every second [Android]'),
+                        onPressed: () async {
+                          await _showProgressNotification();
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text(
+                            'Show indeterminate progress notification [Android]'),
+                        onPressed: () async {
+                          await _showIndeterminateProgressNotification();
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 8.0),
+                      child: RaisedButton(
+                        child: Text('cancel all notifications'),
+                        onPressed: () async {
+                          await _cancelAllNotifications();
+                        },
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -712,39 +716,6 @@ class _HomePageState extends State<HomePage> {
               )
             ],
           ),
-    );
-  }
-}
-
-class SecondScreen extends StatefulWidget {
-  final String payload;
-  SecondScreen(this.payload);
-  @override
-  State<StatefulWidget> createState() => SecondScreenState();
-}
-
-class SecondScreenState extends State<SecondScreen> {
-  String _payload;
-  @override
-  void initState() {
-    super.initState();
-    _payload = widget.payload;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Second Screen with payload: " + _payload),
-      ),
-      body: Center(
-        child: RaisedButton(
-          onPressed: () {
-            Navigator.pop(context);
-          },
-          child: Text('Go back!'),
-        ),
-      ),
     );
   }
 }

--- a/example/lib/second_page.dart
+++ b/example/lib/second_page.dart
@@ -42,7 +42,7 @@ class SecondScreenState extends State<SecondScreen> {
             var platformChannelSpecifics = NotificationDetails(
                 androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
             await plugin.show(0, 'Other page',
-                'insied second page', platformChannelSpecifics);
+                'Inside second page', platformChannelSpecifics);
           },
           child: Text('Other notification'),
         ),

--- a/example/lib/second_page.dart
+++ b/example/lib/second_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class SecondScreen extends StatefulWidget {
+  final String payload;
+  SecondScreen(this.payload);
+  @override
+  State<StatefulWidget> createState() => SecondScreenState();
+}
+
+class SecondScreenState extends State<SecondScreen> {
+  String _payload;
+  @override
+  void initState() {
+    super.initState();
+    _payload = widget.payload;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Second Screen with payload: " + _payload),
+      ),
+      body: Column(children: [
+        RaisedButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          child: Text('Go back!'),
+        ),
+        RaisedButton(
+          onPressed: () async {
+            var plugin = NotificationProvider.of(context);
+            var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+                'your channel id',
+                'your channel name',
+                'your channel description',
+                importance: Importance.Max,
+                priority: Priority.High);
+            var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+            var platformChannelSpecifics = NotificationDetails(
+                androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+            await plugin.show(0, 'Other page',
+                'insied second page', platformChannelSpecifics);
+          },
+          child: Text('Other notification'),
+        ),
+      ]),
+    );
+  }
+}

--- a/lib/flutter_local_notifications.dart
+++ b/lib/flutter_local_notifications.dart
@@ -17,4 +17,5 @@ export 'src/notification_details.dart';
 export 'src/initialization_settings.dart';
 export 'src/flutter_local_notifications.dart';
 export 'src/notification_app_launch_details.dart';
+export 'src/notification_provider.dart';
 // export 'src/callback_dispatcher.dart';

--- a/lib/src/notification_provider.dart
+++ b/lib/src/notification_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class NotificationProvider extends InheritedWidget {
+  /// The [FlutterLocalNotificationsPlugin] which is to be made available throughout the subtree
+  final FlutterLocalNotificationsPlugin service;
+
+  /// The [Widget] and its descendants which will have access to the [FlutterLocalNotificationsPlugin].
+  final Widget child;
+
+  NotificationProvider({
+    Key key,
+    @required this.service,
+    this.child,
+  })  : assert(service != null),
+        super(key: key);
+
+  /// Method that allows widgets to access the bloc as long as their `BuildContext`
+  /// contains a `NotificationProvider` instance.
+  static FlutterLocalNotificationsPlugin of(BuildContext context) {
+
+    final NotificationProvider provider = context
+        .ancestorInheritedElementForWidgetOfExactType(NotificationProvider)
+        ?.widget as NotificationProvider;
+
+    if (provider == null) {
+      throw FlutterError(
+        """
+        NotificationProvider.of() called with a context that does not contain a NotificationProvider.
+        No ancestor could be found starting from the context that was passed to NotificationProvider.of().
+        This can happen if the context you use comes from a widget above the NotificationProvider.
+        This can also happen.
+        The context used was: $context
+        """,
+      );
+    }
+    return provider?.service;
+  }
+
+  @override
+  bool updateShouldNotify(NotificationProvider oldWidget) => false;
+}


### PR DESCRIPTION
Hello,

What do you think about adding dependency injection into the widget tree ?
It adds *FlutterLocalNotificationsPlugin* into the widget tree.
 
Injecting example:

```dart
main.dart
...
  @override
  Widget build(BuildContext context) {
    return NotificationProvider(
      service: flutterLocalNotificationsPlugin,
      child: MaterialApp(
          title: 'Jogo de memória',
          // showPerformanceOverlay: true,
          theme: new ThemeData(
            primarySwatch: Colors.blue,
          ),
          home: widget.home),
    );
  }
```

Other pages wanna access the plugin:

```dart
other_page.dart
...
        child: RaisedButton(
          onPressed: () async {
            await _showNotification(context);
          },
          child: Text('Testar com notificação'),
        ),
....

  Future _showNotification(BuildContext context) async {
    var plugin = NotificationProvider.of(context);
    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
        'your channel id', 'your channel name', 'your channel description',
        importance: Importance.Max, priority: Priority.High);
    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
    var platformChannelSpecifics = NotificationDetails(
        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
    await plugin.show(0, 'Hora de exercitar', 'Que tal brincar um pouco ?',
        platformChannelSpecifics);
  }
```

This page just needs to call `NotificationProvider.of(context)`
