### PR TITLE
Implement precision on ScheduledAndroidNotificationDetails

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -242,17 +242,17 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationDetails.id, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         AlarmManager alarmManager = getAlarmManager(context);
-        switch (notificationDetails.precision) {
-            case 0:
+        switch (notificationDetails.scheduledNotificationPrecision) {
+            case Exact:
                 AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
                 break;
-            case 1:
+            case ExactAndAllowWhileIdle:
                 AlarmManagerCompat.setExactAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
                 break;
-            case 2:
-                AlarmManagerCompat.set(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+            case Inexact:
+                alarmManager.set(AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
                 break;
-            case 3:
+            case InexactAndAllowWhileIdle:
                 AlarmManagerCompat.setAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
                 break;
         }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -242,20 +242,12 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationDetails.id, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         AlarmManager alarmManager = getAlarmManager(context);
-        switch (notificationDetails.scheduledNotificationPrecision) {
-            case Exact:
-                AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-                break;
-            case ExactAndAllowWhileIdle:
-                AlarmManagerCompat.setExactAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-                break;
-            case Inexact:
-                alarmManager.set(AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-                break;
-            case InexactAndAllowWhileIdle:
-                AlarmManagerCompat.setAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-                break;
+        if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
+            AlarmManagerCompat.setExactAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+        } else {
+            AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
         }
+
         if (updateScheduledNotificationsCache) {
             saveScheduledNotification(context, notificationDetails);
         }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -19,6 +19,7 @@ import android.text.Spanned;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.AlarmManagerCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.Person;
 import androidx.core.graphics.drawable.IconCompat;
@@ -241,11 +242,19 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationDetails.id, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         AlarmManager alarmManager = getAlarmManager(context);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            alarmManager.setExact(AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-        } else {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
-
+        switch (notificationDetails.precision) {
+            case 0:
+                AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+                break;
+            case 1:
+                AlarmManagerCompat.setExactAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+                break;
+            case 2:
+                AlarmManagerCompat.set(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+                break;
+            case 3:
+                AlarmManagerCompat.setAndAllowWhileIdle(alarmManager, AlarmManager.RTC_WAKEUP, notificationDetails.millisecondsSinceEpoch, pendingIntent);
+                break;
         }
         if (updateScheduledNotificationsCache) {
             saveScheduledNotification(context, notificationDetails);

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationPrecision.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationPrecision.java
@@ -1,8 +1,0 @@
-package com.dexterous.flutterlocalnotifications;
-
-public enum ScheduledNotificationPrecision {
-    Exact,
-    ExactAndAllowWhileIdle,
-    Inexact,
-    InexactAndAllowWhileIdle
-}

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationPrecision.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationPrecision.java
@@ -1,0 +1,8 @@
+package com.dexterous.flutterlocalnotifications;
+
+public enum ScheduledNotificationPrecision {
+    Exact,
+    ExactAndAllowWhileIdle,
+    Inexact,
+    InexactAndAllowWhileIdle
+}

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -97,6 +97,8 @@ public class NotificationDetails {
     public static final String BODY = "body";
 
     public static final String TICKER = "ticker";
+    
+    public static final String PRECISION = "precision";
 
     public Integer id;
     public String title;
@@ -139,6 +141,7 @@ public class NotificationDetails {
     public Integer ledOnMs;
     public Integer ledOffMs;
     public String ticker;
+    public Integer precision;
 
 
     // Note: this is set on the Android to save details about the icon that should be used when re-hydrating scheduled notifications when a device has been restarted.
@@ -208,6 +211,9 @@ public class NotificationDetails {
                 }
             }
             notificationDetails.ticker = (String) platformChannelSpecifics.get(TICKER);
+            if (platformChannelSpecifics.containsKey(PRECISION)) {
+                notificationDetails.precision = (Integer) platformChannelSpecifics.get(PRECISION);
+            }
         }
         return notificationDetails;
     }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -6,7 +6,6 @@ import android.os.Build;
 import com.dexterous.flutterlocalnotifications.BitmapSource;
 import com.dexterous.flutterlocalnotifications.NotificationStyle;
 import com.dexterous.flutterlocalnotifications.RepeatInterval;
-import com.dexterous.flutterlocalnotifications.ScheduledNotificationPrecision;
 import com.dexterous.flutterlocalnotifications.models.styles.BigPictureStyleInformation;
 import com.dexterous.flutterlocalnotifications.models.styles.BigTextStyleInformation;
 import com.dexterous.flutterlocalnotifications.models.styles.DefaultStyleInformation;
@@ -98,8 +97,7 @@ public class NotificationDetails {
     public static final String BODY = "body";
 
     public static final String TICKER = "ticker";
-    
-    public static final String PRECISION = "scheduledAndroidNotificationPrecision";
+    public static final String ALLOW_WHILE_IDLE = "allowWhileIdle";
 
     public Integer id;
     public String title;
@@ -142,7 +140,7 @@ public class NotificationDetails {
     public Integer ledOnMs;
     public Integer ledOffMs;
     public String ticker;
-    public ScheduledNotificationPrecision scheduledNotificationPrecision;
+    public Boolean allowWhileIdle;
 
 
     // Note: this is set on the Android to save details about the icon that should be used when re-hydrating scheduled notifications when a device has been restarted.
@@ -212,12 +210,7 @@ public class NotificationDetails {
                 }
             }
             notificationDetails.ticker = (String) platformChannelSpecifics.get(TICKER);
-            if (platformChannelSpecifics.containsKey(PRECISION)) {
-                Integer argumentValue = (Integer) platformChannelSpecifics.get(PRECISION);
-                if (argumentValue != null) {
-                    notificationDetails.scheduledNotificationPrecision = ScheduledNotificationPrecision.values()[argumentValue];
-                }
-            }
+            notificationDetails.allowWhileIdle = (Boolean) platformChannelSpecifics.get(ALLOW_WHILE_IDLE);
         }
         return notificationDetails;
     }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import com.dexterous.flutterlocalnotifications.BitmapSource;
 import com.dexterous.flutterlocalnotifications.NotificationStyle;
 import com.dexterous.flutterlocalnotifications.RepeatInterval;
+import com.dexterous.flutterlocalnotifications.ScheduledNotificationPrecision;
 import com.dexterous.flutterlocalnotifications.models.styles.BigPictureStyleInformation;
 import com.dexterous.flutterlocalnotifications.models.styles.BigTextStyleInformation;
 import com.dexterous.flutterlocalnotifications.models.styles.DefaultStyleInformation;
@@ -98,7 +99,7 @@ public class NotificationDetails {
 
     public static final String TICKER = "ticker";
     
-    public static final String PRECISION = "precision";
+    public static final String PRECISION = "scheduledAndroidNotificationPrecision";
 
     public Integer id;
     public String title;
@@ -141,7 +142,7 @@ public class NotificationDetails {
     public Integer ledOnMs;
     public Integer ledOffMs;
     public String ticker;
-    public Integer precision;
+    public ScheduledNotificationPrecision scheduledNotificationPrecision;
 
 
     // Note: this is set on the Android to save details about the icon that should be used when re-hydrating scheduled notifications when a device has been restarted.
@@ -212,7 +213,10 @@ public class NotificationDetails {
             }
             notificationDetails.ticker = (String) platformChannelSpecifics.get(TICKER);
             if (platformChannelSpecifics.containsKey(PRECISION)) {
-                notificationDetails.precision = (Integer) platformChannelSpecifics.get(PRECISION);
+                Integer argumentValue = (Integer) platformChannelSpecifics.get(PRECISION);
+                if (argumentValue != null) {
+                    notificationDetails.scheduledNotificationPrecision = ScheduledNotificationPrecision.values()[argumentValue];
+                }
             }
         }
         return notificationDetails;

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -7,6 +7,8 @@ import 'initialization_settings.dart';
 import 'notification_app_launch_details.dart';
 import 'notification_details.dart';
 import 'pending_notification_request.dart';
+import 'platform_specifics/android/notification_details.dart' show ScheduledAndroidNotificationDetails;
+import 'platform_specifics/android/enums.dart' show ScheduledNotificationPrecision;
 
 /// Signature of callback passed to [initialize]. Callback triggered when user taps on a notification
 typedef SelectNotificationCallback = Future<dynamic> Function(String payload);
@@ -144,6 +146,11 @@ class FlutterLocalNotificationsPlugin {
     _validateId(id);
     var serializedPlatformSpecifics =
         _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    //TODO: This prevents breaking change but not sure if ideal. However the change to inexact as default may be breaking.
+    if (notificationDetails.android is! ScheduledAndroidNotificationDetails) {
+      print("AndroidNotificationDetails should instead be an instance of ScheduledAndroidNotificationDetails. The default inexact precision will be used.");
+      serializedPlatformSpecifics['precision'] = ScheduledNotificationPrecision.Inexact.index;
+    }
     await _channel.invokeMethod('schedule', <String, dynamic>{
       'id': id,
       'title': title,

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -7,8 +7,6 @@ import 'initialization_settings.dart';
 import 'notification_app_launch_details.dart';
 import 'notification_details.dart';
 import 'pending_notification_request.dart';
-import 'platform_specifics/android/notification_details.dart' show ScheduledAndroidNotificationDetails;
-import 'platform_specifics/android/enums.dart' show ScheduledNotificationPrecision;
 
 /// Signature of callback passed to [initialize]. Callback triggered when user taps on a notification
 typedef SelectNotificationCallback = Future<dynamic> Function(String payload);
@@ -146,11 +144,6 @@ class FlutterLocalNotificationsPlugin {
     _validateId(id);
     var serializedPlatformSpecifics =
         _retrievePlatformSpecificNotificationDetails(notificationDetails);
-    //TODO: This prevents breaking change but not sure if ideal. However the change to inexact as default may be breaking.
-    if (notificationDetails.android is! ScheduledAndroidNotificationDetails) {
-      print("AndroidNotificationDetails should instead be an instance of ScheduledAndroidNotificationDetails. The default inexact precision will be used.");
-      serializedPlatformSpecifics['precision'] = ScheduledNotificationPrecision.Inexact.index;
-    }
     await _channel.invokeMethod('schedule', <String, dynamic>{
       'id': id,
       'title': title,

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -66,15 +66,15 @@ class FlutterLocalNotificationsPlugin {
   factory FlutterLocalNotificationsPlugin() => _instance;
 
   @visibleForTesting
-  FlutterLocalNotificationsPlugin.private(
-      MethodChannel channel, Platform platform)
+  FlutterLocalNotificationsPlugin.private(MethodChannel channel,
+      Platform platform)
       : _channel = channel,
         _platform = platform;
 
   static final FlutterLocalNotificationsPlugin _instance =
-      FlutterLocalNotificationsPlugin.private(
-          const MethodChannel('dexterous.com/flutter/local_notifications'),
-          const LocalPlatform());
+  FlutterLocalNotificationsPlugin.private(
+      const MethodChannel('dexterous.com/flutter/local_notifications'),
+      const LocalPlatform());
 
   final MethodChannel _channel;
   final Platform _platform;
@@ -90,7 +90,7 @@ class FlutterLocalNotificationsPlugin {
     didReceiveLocalNotificationCallback =
         initializationSettings?.ios?.onDidReceiveLocalNotification;
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificInitializationSettings(initializationSettings);
+    _retrievePlatformSpecificInitializationSettings(initializationSettings);
     _channel.setMethodCallHandler(_handleMethod);
     /*final CallbackHandle callback =
         PluginUtilities.getCallbackHandle(_callbackDispatcher);
@@ -100,7 +100,7 @@ class FlutterLocalNotificationsPlugin {
           PluginUtilities.getCallbackHandle(onShowNotification).toRawHandle();
     }*/
     var result =
-        await _channel.invokeMethod('initialize', serializedPlatformSpecifics);
+    await _channel.invokeMethod('initialize', serializedPlatformSpecifics);
     return result;
   }
 
@@ -116,7 +116,7 @@ class FlutterLocalNotificationsPlugin {
       {String payload}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('show', <String, dynamic>{
       'id': id,
       'title': title,
@@ -138,12 +138,17 @@ class FlutterLocalNotificationsPlugin {
   }
 
   /// Schedules a notification to be shown at the specified time with an optional payload that is passed through when a notification is tapped
+  /// The [androidAllowWhileIdle] parameter is Android-specific and determines if the notification should still be shown at the specified time
+  /// even when in a low-power idle mode.
   Future<void> schedule(int id, String title, String body,
       DateTime scheduledDate, NotificationDetails notificationDetails,
-      {String payload}) async {
+      {String payload, bool androidAllowWhileIdle = false}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    if (_platform.isAndroid) {
+      serializedPlatformSpecifics['allowWhileIdle'] = androidAllowWhileIdle;
+    }
     await _channel.invokeMethod('schedule', <String, dynamic>{
       'id': id,
       'title': title,
@@ -161,12 +166,14 @@ class FlutterLocalNotificationsPlugin {
       {String payload}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': DateTime.now().millisecondsSinceEpoch,
+      'calledAt': DateTime
+          .now()
+          .millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
@@ -179,12 +186,14 @@ class FlutterLocalNotificationsPlugin {
       {String payload}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('showDailyAtTime', <String, dynamic>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': DateTime.now().millisecondsSinceEpoch,
+      'calledAt': DateTime
+          .now()
+          .millisecondsSinceEpoch,
       'repeatInterval': RepeatInterval.Daily.index,
       'repeatTime': notificationTime.toMap(),
       'platformSpecifics': serializedPlatformSpecifics,
@@ -198,12 +207,14 @@ class FlutterLocalNotificationsPlugin {
       {String payload}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    _retrievePlatformSpecificNotificationDetails(notificationDetails);
     await _channel.invokeMethod('showWeeklyAtDayAndTime', <String, dynamic>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': DateTime.now().millisecondsSinceEpoch,
+      'calledAt': DateTime
+          .now()
+          .millisecondsSinceEpoch,
       'repeatInterval': RepeatInterval.Weekly.index,
       'repeatTime': notificationTime.toMap(),
       'day': day.value,
@@ -215,9 +226,10 @@ class FlutterLocalNotificationsPlugin {
   /// Returns a list of notifications pending to be delivered/shown
   Future<List<PendingNotificationRequest>> pendingNotificationRequests() async {
     final List<Map<dynamic, dynamic>> pendingNotifications =
-        await _channel.invokeListMethod('pendingNotificationRequests');
+    await _channel.invokeListMethod('pendingNotificationRequests');
     return pendingNotifications
-        .map((pendingNotification) => PendingNotificationRequest(
+        .map((pendingNotification) =>
+        PendingNotificationRequest(
             pendingNotification['id'],
             pendingNotification['title'],
             pendingNotification['body'],

--- a/lib/src/platform_specifics/android/enums.dart
+++ b/lib/src/platform_specifics/android/enums.dart
@@ -48,5 +48,5 @@ class Priority {
 /// The available alert behaviours for grouped notifications
 enum GroupAlertBehavior { All, Summary, Children }
 
-/// The precision of scheduled notifications
-enum ScheduledNotificationPrecision { Exact, ExactAndAllowWhileIdle, Inexact, InexactAndAllowWhileIdle }
+/// The precision of scheduled notifications on android
+enum ScheduledAndroidNotificationPrecision { Exact, ExactAndAllowWhileIdle, Inexact, InexactAndAllowWhileIdle }

--- a/lib/src/platform_specifics/android/enums.dart
+++ b/lib/src/platform_specifics/android/enums.dart
@@ -47,3 +47,6 @@ class Priority {
 
 /// The available alert behaviours for grouped notifications
 enum GroupAlertBehavior { All, Summary, Children }
+
+/// The precision of scheduled notifications
+enum ScheduledNotificationPrecision { Exact, ExactAndAllowWhileIdle, Inexact, InexactAndAllowWhileIdle }

--- a/lib/src/platform_specifics/android/notification_details.dart
+++ b/lib/src/platform_specifics/android/notification_details.dart
@@ -104,6 +104,9 @@ class AndroidNotificationDetails {
   /// The action to take for managing notification channels. Defaults to creating the notification channel using the provided details if it doesn't exist
   AndroidNotificationChannelAction channelAction;
 
+  /// The precision on scheduled notifications on android
+  ScheduledAndroidNotificationPrecision scheduledAndroidNotificationPrecision;
+
   AndroidNotificationDetails(
       this.channelId, this.channelName, this.channelDescription,
       {this.icon,
@@ -134,7 +137,8 @@ class AndroidNotificationDetails {
       this.ledColor,
       this.ledOnMs,
       this.ledOffMs,
-      this.ticker});
+      this.ticker,
+      this.scheduledAndroidNotificationPrecision = ScheduledAndroidNotificationPrecision.Inexact});
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
@@ -177,87 +181,8 @@ class AndroidNotificationDetails {
       'ledColorBlue': ledColor?.blue,
       'ledOnMs': ledOnMs,
       'ledOffMs': ledOffMs,
-      'ticker': ticker
+      'ticker': ticker,
+      'scheduledAndroidNotificationPrecision': scheduledAndroidNotificationPrecision
     };
   }
-}
-
-/// Configures a scheduled notification on Android
-class ScheduledAndroidNotificationDetails extends AndroidNotificationDetails {
-
-  /// The precision of the scheduled notification.  
-  /// See [the AlarmManager documentation](https://developer.android.com/reference/android/app/AlarmManager.html).
-  ScheduledNotificationPrecision precision;
-
-  ScheduledAndroidNotificationDetails(
-    String channelId, String channelName, String channelDescription,
-    //Inexact is recommended to preserve battery
-    {this.precision = ScheduledNotificationPrecision.Inexact,
-    String icon,
-    Importance importance = Importance.Default,
-    Priority priority = Priority.Default,
-    AndroidNotificationStyle style = AndroidNotificationStyle.Default,
-    StyleInformation styleInformation,
-    bool playSound = true,
-    String sound,
-    bool enableVibration,
-    Int64List vibrationPattern,
-    String groupKey,
-    bool setAsGroupSummary,
-    GroupAlertBehavior groupAlertBehavior = GroupAlertBehavior.All,
-    bool autoCancel = true,
-    bool ongoing,
-    Color color,
-    String largeIcon,
-    BitmapSource largeIconBitmapSource,
-    bool onlyAlertOnce,
-    bool channelShowBadge = true,
-    bool showProgress = false,
-    int maxProgress = 0,
-    int progress = 0,
-    bool indeterminate = false,
-    AndroidNotificationChannelAction channelAction = AndroidNotificationChannelAction.CreateIfNotExists,
-    bool enableLights = false,
-    Color ledColor,
-    int ledOnMs,
-    int ledOffMs,
-    String ticker}) : 
-      // TODO: is there a better way to do this that is less verbose? And doesn't require re-specifying defaults?
-      super(
-        channelId, channelName, channelDescription,
-        icon: icon,
-        importance: importance,
-        priority: priority,
-        style: style,
-        styleInformation: styleInformation,
-        playSound: playSound,
-        sound: sound,
-        enableVibration: enableVibration,
-        vibrationPattern: vibrationPattern,
-        groupKey: groupKey,
-        setAsGroupSummary: setAsGroupSummary,
-        groupAlertBehavior: groupAlertBehavior,
-        autoCancel: autoCancel,
-        ongoing: ongoing,
-        color: color,
-        largeIcon: largeIcon,
-        largeIconBitmapSource: largeIconBitmapSource,
-        onlyAlertOnce: onlyAlertOnce,
-        channelShowBadge: channelShowBadge,
-        showProgress: showProgress,
-        maxProgress: maxProgress,
-        progress: progress,
-        indeterminate: indeterminate,
-        channelAction: channelAction,
-        enableLights: enableLights,
-        ledColor: ledColor,
-        ledOnMs: ledOnMs,
-        ledOffMs: ledOffMs,
-        ticker: ticker
-      );
-
-      @override
-      Map<String, dynamic> toMap() {
-        return super.toMap()..addEntries([MapEntry('precision', precision.index)]);
-      }
 }

--- a/lib/src/platform_specifics/android/notification_details.dart
+++ b/lib/src/platform_specifics/android/notification_details.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
 import 'enums.dart';
 import 'styles/style_information.dart';
 import 'styles/default_style_information.dart';
@@ -178,4 +180,84 @@ class AndroidNotificationDetails {
       'ticker': ticker
     };
   }
+}
+
+/// Configures a scheduled notification on Android
+class ScheduledAndroidNotificationDetails extends AndroidNotificationDetails {
+
+  /// The precision of the scheduled notification.  
+  /// See [the AlarmManager documentation](https://developer.android.com/reference/android/app/AlarmManager.html).
+  ScheduledNotificationPrecision precision;
+
+  ScheduledAndroidNotificationDetails(
+    String channelId, String channelName, String channelDescription,
+    //Inexact is recommended to preserve battery
+    {this.precision = ScheduledNotificationPrecision.Inexact,
+    String icon,
+    Importance importance = Importance.Default,
+    Priority priority = Priority.Default,
+    AndroidNotificationStyle style = AndroidNotificationStyle.Default,
+    StyleInformation styleInformation,
+    bool playSound = true,
+    String sound,
+    bool enableVibration,
+    Int64List vibrationPattern,
+    String groupKey,
+    bool setAsGroupSummary,
+    GroupAlertBehavior groupAlertBehavior = GroupAlertBehavior.All,
+    bool autoCancel = true,
+    bool ongoing,
+    Color color,
+    String largeIcon,
+    BitmapSource largeIconBitmapSource,
+    bool onlyAlertOnce,
+    bool channelShowBadge = true,
+    bool showProgress = false,
+    int maxProgress = 0,
+    int progress = 0,
+    bool indeterminate = false,
+    AndroidNotificationChannelAction channelAction = AndroidNotificationChannelAction.CreateIfNotExists,
+    bool enableLights = false,
+    Color ledColor,
+    int ledOnMs,
+    int ledOffMs,
+    String ticker}) : 
+      // TODO: is there a better way to do this that is less verbose? And doesn't require re-specifying defaults?
+      super(
+        channelId, channelName, channelDescription,
+        icon: icon,
+        importance: importance,
+        priority: priority,
+        style: style,
+        styleInformation: styleInformation,
+        playSound: playSound,
+        sound: sound,
+        enableVibration: enableVibration,
+        vibrationPattern: vibrationPattern,
+        groupKey: groupKey,
+        setAsGroupSummary: setAsGroupSummary,
+        groupAlertBehavior: groupAlertBehavior,
+        autoCancel: autoCancel,
+        ongoing: ongoing,
+        color: color,
+        largeIcon: largeIcon,
+        largeIconBitmapSource: largeIconBitmapSource,
+        onlyAlertOnce: onlyAlertOnce,
+        channelShowBadge: channelShowBadge,
+        showProgress: showProgress,
+        maxProgress: maxProgress,
+        progress: progress,
+        indeterminate: indeterminate,
+        channelAction: channelAction,
+        enableLights: enableLights,
+        ledColor: ledColor,
+        ledOnMs: ledOnMs,
+        ledOffMs: ledOffMs,
+        ticker: ticker
+      );
+
+      @override
+      Map<String, dynamic> toMap() {
+        return super.toMap()..addEntries([MapEntry('precision', precision.index)]);
+      }
 }

--- a/lib/src/platform_specifics/android/notification_details.dart
+++ b/lib/src/platform_specifics/android/notification_details.dart
@@ -104,9 +104,6 @@ class AndroidNotificationDetails {
   /// The action to take for managing notification channels. Defaults to creating the notification channel using the provided details if it doesn't exist
   AndroidNotificationChannelAction channelAction;
 
-  /// The precision on scheduled notifications on android
-  ScheduledAndroidNotificationPrecision scheduledAndroidNotificationPrecision;
-
   AndroidNotificationDetails(
       this.channelId, this.channelName, this.channelDescription,
       {this.icon,
@@ -137,8 +134,7 @@ class AndroidNotificationDetails {
       this.ledColor,
       this.ledOnMs,
       this.ledOffMs,
-      this.ticker,
-      this.scheduledAndroidNotificationPrecision = ScheduledAndroidNotificationPrecision.Inexact});
+      this.ticker});
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
@@ -181,8 +177,7 @@ class AndroidNotificationDetails {
       'ledColorBlue': ledColor?.blue,
       'ledOnMs': ledOnMs,
       'ledOffMs': ledOffMs,
-      'ticker': ticker,
-      'scheduledAndroidNotificationPrecision': scheduledAndroidNotificationPrecision
+      'ticker': ticker
     };
   }
 }

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -113,6 +113,8 @@ void main() {
 
       NotificationDetails platformChannelSpecifics =
           NotificationDetails(androidPlatformChannelSpecifics, null);
+      var androidPlatformChannelSpecificsMap = androidPlatformChannelSpecifics.toMap();
+      androidPlatformChannelSpecificsMap['allowWhileIdle'] = false;
       await flutterLocalNotificationsPlugin.schedule(id, title, body,
           scheduledNotificationDateTime, platformChannelSpecifics);
       verify(mockChannel.invokeMethod('schedule', <String, dynamic>{
@@ -121,7 +123,7 @@ void main() {
         'body': body,
         'millisecondsSinceEpoch':
             scheduledNotificationDateTime.millisecondsSinceEpoch,
-        'platformSpecifics': androidPlatformChannelSpecifics.toMap(),
+        'platformSpecifics': androidPlatformChannelSpecificsMap,
         'payload': ''
       }));
     });

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -108,7 +108,7 @@ void main() {
           DateTime.now().add(Duration(seconds: 5));
 
       AndroidNotificationDetails androidPlatformChannelSpecifics =
-          ScheduledAndroidNotificationDetails('your other channel id',
+          AndroidNotificationDetails('your other channel id',
               'your other channel name', 'your other channel description');
 
       NotificationDetails platformChannelSpecifics =

--- a/test/flutter_local_notifications_test.dart
+++ b/test/flutter_local_notifications_test.dart
@@ -108,7 +108,7 @@ void main() {
           DateTime.now().add(Duration(seconds: 5));
 
       AndroidNotificationDetails androidPlatformChannelSpecifics =
-          AndroidNotificationDetails('your other channel id',
+          ScheduledAndroidNotificationDetails('your other channel id',
               'your other channel name', 'your other channel description');
 
       NotificationDetails platformChannelSpecifics =


### PR DESCRIPTION
#216 and other pull request #239 

I tried to implement with a new class as you mentioned in that thread.

I wanted to avoid having 'exact' as the default, because the whole point of the change to inexact was so Android can manage wakelocks better etc.
I also wanted to avoid a breaking change, so I made it fall back to 'inexact' if not specified, but that basically does make it a breaking-ish change, because the old behavior was exact.

In extending the AndroidNotificationDetails class, I had to re-specify all the defaults, which seems not so good. I don't know if there's a better way to do it.

Finally, it would be good to have an enum in the java side like the dart, but it ended up converting between ints and the enum and it was a bit complicated.