### PR TITLE
Payload as map

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -14,6 +14,7 @@ import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.text.Html;
 import android.text.Spanned;
 
@@ -48,6 +49,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -821,8 +823,11 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
 
     private Boolean sendNotificationPayloadMessage(Intent intent) {
         if (SELECT_NOTIFICATION.equals(intent.getAction())) {
-            String payload = intent.getStringExtra(PAYLOAD);
-            channel.invokeMethod("selectNotification", payload);
+
+            Map<String, Object> data = new HashMap();
+            data.put(PAYLOAD, intent.getStringExtra(PAYLOAD));
+
+            channel.invokeMethod("selectNotification", data);
             return true;
         }
         return false;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -523,9 +523,12 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.cancelAll();
   }
 
-  Future<void> onSelectNotification(String payload) async {
+  Future<void> onSelectNotification(String payload, Map<dynamic, dynamic> data) async {
     if (payload != null) {
       debugPrint('notification payload: ' + payload);
+    }
+    if (data != null) {
+      debugPrint('notification data: ' + payload.toString());
     }
 
     await Navigator.push(
@@ -684,7 +687,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> onDidReceiveLocalNotification(
-      int id, String title, String body, String payload) async {
+      int id, String title, String body, String payload, Map<dynamic, dynamic> data) async {
     // display a dialog with the notification details, tap ok to go to another page
     await showDialog(
       context: context,

--- a/ios/Classes/FlutterLocalNotificationsPlugin.h
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.h
@@ -3,5 +3,5 @@
 
 @interface FlutterLocalNotificationsPlugin : NSObject <FlutterPlugin, UNUserNotificationCenterDelegate>
 + (bool) resumingFromBackground;
-+ (void)handleSelectNotification:(NSString *)payload;
++ (void)handleSelectNotification:(NSDictionary *)data;
 @end

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -98,7 +98,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                                    @"title" : request.content.title,
                                    @"body" : request.content.body,
                                    @"payload": request.content.userInfo[PAYLOAD],
-                                   @"data": request.content.userInfo,
                                    }];
             }
             result(pendingNotificationRequests);
@@ -113,7 +112,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                                                      @"title" : localNotification.userInfo[TITLE],
                                                      @"body" : localNotification.alertBody,
                                                      @"payload": localNotification.userInfo[PAYLOAD],
-                                                     @"data": localNotification.userInfo
                                                      }];
         }
         result(pendingNotificationRequests);

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -237,8 +237,7 @@ class FlutterLocalNotificationsPlugin {
             pendingNotification['id'],
             pendingNotification['title'],
             pendingNotification['body'],
-            pendingNotification['payload'],
-            pendingNotification['data']))
+            pendingNotification['payload']))
         .toList();
   }
 

--- a/lib/src/notification_app_launch_details.dart
+++ b/lib/src/notification_app_launch_details.dart
@@ -5,6 +5,7 @@ class NotificationAppLaunchDetails {
   /// The payload of the notification that launched the app
   final String payload;
 
-  const NotificationAppLaunchDetails(
-      this.didNotificationLaunchApp, this.payload);
+  final Map<dynamic, dynamic> data;
+
+  const NotificationAppLaunchDetails(this.didNotificationLaunchApp, this.data, this.payload);
 }

--- a/lib/src/pending_notification_request.dart
+++ b/lib/src/pending_notification_request.dart
@@ -3,8 +3,7 @@ class PendingNotificationRequest {
   final String title;
   final String body;
   final String payload;
-  final Map<dynamic, dynamic> data;
 
   const PendingNotificationRequest(
-      this.id, this.title, this.body, this.payload, this.data);
+      this.id, this.title, this.body, this.payload);
 }

--- a/lib/src/pending_notification_request.dart
+++ b/lib/src/pending_notification_request.dart
@@ -3,7 +3,8 @@ class PendingNotificationRequest {
   final String title;
   final String body;
   final String payload;
+  final Map<dynamic, dynamic> data;
 
   const PendingNotificationRequest(
-      this.id, this.title, this.body, this.payload);
+      this.id, this.title, this.body, this.payload, this.data);
 }


### PR DESCRIPTION
I've implemented these changes so I can receive both Firebase messages and local notifications with the onSelected callback in my app.

This PR is to open a discussion around these changes and whether it might be something that should be merged.

Basically, because of the known issue around not being able to have multiple notification delegates on iOS, `local notifications` overrides Firebase Messaging callbacks.

When clicking on a Firebase notification, local notifications still gets invoked, but it only extracts and passes the payload back to the onSelected callback. A Firebase notification doesn't have a payload so the payload is null.

By passing back the userInfo dictionary, we can extract the payload on the dart side and add an extra parameter to onSelected which is all the (firebase) data from the notification - it allows the user to handle both Firebase and local notifications.

Android doesn't have the same problem (I think) so the payload is just passed back but within a map.