### PR TITLE
Instance variables

### DIFF
--- a/ios/Classes/FlutterLocalNotificationsPlugin.h
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.h
@@ -2,6 +2,4 @@
 #import <UserNotifications/UserNotifications.h>
 
 @interface FlutterLocalNotificationsPlugin : NSObject <FlutterPlugin, UNUserNotificationCenterDelegate>
-+ (bool) resumingFromBackground;
-+ (void)handleSelectNotification:(NSString *)payload;
 @end

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -90,10 +90,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         appResumingFromBackground = YES;
         
         persistentState = [NSUserDefaults standardUserDefaults];
-        if(@available(iOS 10.0, *)) {
-            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-            center.delegate = self;
-        }
     }
     return self;
 }
@@ -131,6 +127,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
 
 - (void)initialize:(FlutterMethodCall * _Nonnull)call result:(FlutterResult _Nonnull)result {
     appResumingFromBackground = false;
+    
     NSDictionary *arguments = [call arguments];
     if(arguments[DEFAULT_PRESENT_ALERT] != [NSNull null]) {
         displayAlert = [[arguments objectForKey:DEFAULT_PRESENT_ALERT] boolValue];
@@ -159,8 +156,11 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     } else {
         [persistentState removeObjectForKey:ON_NOTIFICATION_CALLBACK_DISPATCHER];
     }*/
+    
     if(@available(iOS 10.0, *)) {
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        center.delegate = self;
+        
         UNAuthorizationOptions authorizationOptions = 0;
         if (requestedSoundPermission) {
             authorizationOptions += UNAuthorizationOptionSound;


### PR DESCRIPTION
Related: #278 

This PR moves class variables to instance variables to address issues when this plugin is registered multiple times.

Previously, when the plugin is registered a second time, the channel, registrar, and UNUserNotificationCenter delegate would be recreated/set to the new plugin. As these variables were class variables this would affect all instances of the plugin.

