### PR TITLE
add custom day interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ await flutterLocalNotificationsPlugin.showDailyAtTime(
     platformChannelSpecifics);
 ```
 
+### Periodically show a notification on the given day interval at a specific time
+
+```dart
+var time = Time(10, 0, 0);
+var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+    'repeatEveryOtherDayAtTime channel id',
+    'repeatEveryOtherDayAtTime channel name',
+    'repeatEveryOtherDayAtTime description',);
+var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+var platformChannelSpecifics = NotificationDetails(
+    androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+await flutterLocalNotificationsPlugin.showDailyAtTime(
+    0,
+    'show every other day title',
+    'Every other day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+    time,
+    platformChannelSpecifics,
+    dayInterval: 2,
+);
+```
+
 ### Show a weekly notification on specific day and time
 
 ```dart
@@ -184,26 +205,6 @@ await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
     'show weekly title',
     'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
     Day.Monday,
-    time,
-    platformChannelSpecifics);
-```
-
-### Periodically show a notification on the given day interval at a specific time
-
-```dart
-var time = Time(10, 0, 0);
-var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-    'show custom day interval channel id',
-    'show custom day interval channel name',
-    'show custom day interval description');
-var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-var platformChannelSpecifics = NotificationDetails(
-    androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-await flutterLocalNotificationsPlugin.showCustomDayIntervalAtTime(
-    0,
-    'show custom day interval title',
-    'Custom day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
-    2,
     time,
     platformChannelSpecifics);
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A cross platform plugin for displaying local notifications.
 * Periodically show a notification (interval based)
 * Schedule a notification to be shown daily at a specified time
 * Schedule a notification to be shown weekly on a specified day and time
+* Schedule a notification to be shown on a custom day interval at a specified time
 * Retrieve a list of pending notification requests that have been scheduled to be shown in the future
 * Cancelling/removing notification by id or all of them
 * Specify a custom notification sound
@@ -183,6 +184,26 @@ await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
     'show weekly title',
     'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
     Day.Monday,
+    time,
+    platformChannelSpecifics);
+```
+
+### Periodically show a notification on the given day interval at a specific time
+
+```dart
+var time = Time(10, 0, 0);
+var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+    'show custom day interval channel id',
+    'show custom day interval channel name',
+    'show custom day interval description');
+var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+var platformChannelSpecifics = NotificationDetails(
+    androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+await flutterLocalNotificationsPlugin.showCustomDayIntervalAtTime(
+    0,
+    'show custom day interval title',
+    'Custom day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+    2,
     time,
     platformChannelSpecifics);
 ```

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -258,6 +258,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
 
         AlarmManager alarmManager = getAlarmManager(context);
         long repeatInterval = 0;
+        int dayInterval = notificationDetails.dayInterval == null ? 1 : notificationDetails.dayInterval;
         switch (notificationDetails.repeatInterval) {
             case EveryMinute:
                 repeatInterval = 60000;
@@ -266,7 +267,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 repeatInterval = 60000 * 60;
                 break;
             case Daily:
-                repeatInterval = 60000 * 60 * 24 * notificationDetails.dayInterval;
+                repeatInterval = 60000 * 60 * 24 * dayInterval;
                 break;
             case Weekly:
                 repeatInterval = 60000 * 60 * 24 * 7;

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -258,7 +258,6 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
 
         AlarmManager alarmManager = getAlarmManager(context);
         long repeatInterval = 0;
-        int dayInterval = notificationDetails.dayInterval == null ? 1 : notificationDetails.dayInterval;
         switch (notificationDetails.repeatInterval) {
             case EveryMinute:
                 repeatInterval = 60000;
@@ -267,7 +266,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 repeatInterval = 60000 * 60;
                 break;
             case Daily:
-                repeatInterval = 60000 * 60 * 24 * dayInterval;
+                repeatInterval = 60000 * 60 * 24 * (notificationDetails.dayInterval == null ? 1 : notificationDetails.dayInterval);
                 break;
             case Weekly:
                 repeatInterval = 60000 * 60 * 24 * 7;

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -74,7 +74,6 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
     private static final String SHOW_DAILY_AT_TIME_METHOD = "showDailyAtTime";
     private static final String SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD = "showWeeklyAtDayAndTime";
-    private static final String SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD = "showCustomDayIntervalAtTime";
     private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD = "getNotificationAppLaunchDetails";
     private static final String METHOD_CHANNEL = "dexterous.com/flutter/local_notifications";
     private static final String PAYLOAD = "payload";
@@ -267,13 +266,10 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 repeatInterval = 60000 * 60;
                 break;
             case Daily:
-                repeatInterval = 60000 * 60 * 24;
+                repeatInterval = 60000 * 60 * 24 * notificationDetails.dayInterval;
                 break;
             case Weekly:
                 repeatInterval = 60000 * 60 * 24 * 7;
-                break;
-            case CustomDayInterval:
-                repeatInterval = 60000 * 60 * 24 * notificationDetails.dayInterval;
                 break;
             default:
                 break;
@@ -630,8 +626,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             }
             case PERIODICALLY_SHOW_METHOD:
             case SHOW_DAILY_AT_TIME_METHOD:
-            case SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD:
-            case SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD: {
+            case SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD: {
                 repeat(call, result);
                 break;
             }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -74,6 +74,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
     private static final String SHOW_DAILY_AT_TIME_METHOD = "showDailyAtTime";
     private static final String SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD = "showWeeklyAtDayAndTime";
+    private static final String SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD = "showCustomDayIntervalAtTime";
     private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD = "getNotificationAppLaunchDetails";
     private static final String METHOD_CHANNEL = "dexterous.com/flutter/local_notifications";
     private static final String PAYLOAD = "payload";
@@ -270,6 +271,9 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 break;
             case Weekly:
                 repeatInterval = 60000 * 60 * 24 * 7;
+                break;
+            case CustomDayInterval:
+                repeatInterval = 60000 * 60 * 24 * notificationDetails.dayInterval;
                 break;
             default:
                 break;
@@ -626,7 +630,8 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             }
             case PERIODICALLY_SHOW_METHOD:
             case SHOW_DAILY_AT_TIME_METHOD:
-            case SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD: {
+            case SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD:
+            case SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD: {
                 repeat(call, result);
                 break;
             }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
@@ -4,5 +4,6 @@ public enum RepeatInterval {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly
+    Weekly,
+    CustomDayInterval
 }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
@@ -4,6 +4,5 @@ public enum RepeatInterval {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly,
-    CustomDayInterval
+    Weekly
 }

--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -23,6 +23,7 @@ public class NotificationDetails {
     private static final String CALLED_AT = "calledAt";
     private static final String REPEAT_INTERVAL = "repeatInterval";
     private static final String REPEAT_TIME = "repeatTime";
+    private static final String DAY_INTERVAL = "dayInterval";
     private static final String PLATFORM_SPECIFICS = "platformSpecifics";
     private static final String AUTO_CANCEL = "autoCancel";
     private static final String ONGOING = "ongoing";
@@ -126,6 +127,7 @@ public class NotificationDetails {
     public Boolean autoCancel;
     public Boolean ongoing;
     public Integer day;
+    public Integer dayInterval;
     public Integer color;
     public String largeIcon;
     public BitmapSource largeIconBitmapSource;
@@ -168,6 +170,9 @@ public class NotificationDetails {
         }
         if (arguments.containsKey(DAY)) {
             notificationDetails.day = (Integer) arguments.get(DAY);
+        }
+        if (arguments.containsKey(DAY_INTERVAL)) {
+            notificationDetails.dayInterval = (Integer) arguments.get(DAY_INTERVAL);
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> platformChannelSpecifics = (Map<String, Object>) arguments.get(PLATFORM_SPECIFICS);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -128,6 +128,13 @@ class _HomePageState extends State<HomePage> {
                     },
                   ),
                   PaddedRaisedButton(
+                    buttonText:
+                        'Repeat notification every other day at approximately 10:00:00 am',
+                    onPressed: () async {
+                      await _showCustomDayIntervalAtTime();
+                    },
+                  ),
+                  PaddedRaisedButton(
                     buttonText: 'Show notification with no sound',
                     onPressed: () async {
                       await _showNotificationWithNoSound();
@@ -592,6 +599,24 @@ class _HomePageState extends State<HomePage> {
         'show weekly title',
         'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
         Day.Monday,
+        time,
+        platformChannelSpecifics);
+  }
+
+  Future<void> _showCustomDayIntervalAtTime() async {
+    var time = Time(10, 0, 0);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'show custom day interval channel id',
+        'show custom day interval channel name',
+        'show custom day interval description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.showCustomDayIntervalAtTime(
+        0,
+        'show custom day interval title',
+        'Custom day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        2,
         time,
         platformChannelSpecifics);
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -131,7 +131,7 @@ class _HomePageState extends State<HomePage> {
                     buttonText:
                         'Repeat notification every other day at approximately 10:00:00 am',
                     onPressed: () async {
-                      await _showCustomDayIntervalAtTime();
+                      await _showEveryOtherDayAtTime();
                     },
                   ),
                   PaddedRaisedButton(
@@ -603,22 +603,23 @@ class _HomePageState extends State<HomePage> {
         platformChannelSpecifics);
   }
 
-  Future<void> _showCustomDayIntervalAtTime() async {
+  Future<void> _showEveryOtherDayAtTime() async {
     var time = Time(10, 0, 0);
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'show custom day interval channel id',
-        'show custom day interval channel name',
-        'show custom day interval description');
+        'repeatEveryOtherDayAtTime channel id',
+        'repeatEveryOtherDayAtTime channel name',
+        'repeatEveryOtherDayAtTime description');
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.showCustomDayIntervalAtTime(
-        0,
-        'show custom day interval title',
-        'Custom day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
-        2,
-        time,
-        platformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.showDailyAtTime(
+      0,
+      'show every other day title',
+      'Every other day interval notification shown every two days at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+      time,
+      platformChannelSpecifics,
+      dayInterval: 2,
+    );
   }
 
   Future<void> _showNotificationWithNoBadge() async {

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -24,7 +24,6 @@ NSString *const SCHEDULE_METHOD = @"schedule";
 NSString *const PERIODICALLY_SHOW_METHOD = @"periodicallyShow";
 NSString *const SHOW_DAILY_AT_TIME_METHOD = @"showDailyAtTime";
 NSString *const SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD = @"showWeeklyAtDayAndTime";
-NSString *const SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD = @"showCustomDayIntervalAtTime";
 NSString *const CANCEL_METHOD = @"cancel";
 NSString *const CANCEL_ALL_METHOD = @"cancelAll";
 NSString *const PENDING_NOTIFICATIONS_REQUESTS_METHOD = @"pendingNotificationRequests";
@@ -69,8 +68,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly,
-    CustomDayInterval
+    Weekly
 };
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -220,7 +218,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     }
     if([SCHEDULE_METHOD isEqualToString:call.method]) {
         notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] longLongValue] / 1000);
-    } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method] || [SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD isEqualToString:call.method]) {
+    } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
         if (call.arguments[REPEAT_TIME]) {
             NSDictionary *timeArguments = (NSDictionary *) call.arguments[REPEAT_TIME];
             notificationDetails.repeatTime = [[NotificationTime alloc] init];
@@ -286,7 +284,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if([INITIALIZE_METHOD isEqualToString:call.method]) {
         [self initialize:call result:result];
     } else if ([SHOW_METHOD isEqualToString:call.method] || [SCHEDULE_METHOD isEqualToString:call.method] || [PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method]
-               || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method] || [SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD isEqualToString:call.method]) {
+               || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
         [self showNotification:call result:result];
     } else if([CANCEL_METHOD isEqualToString:call.method]) {
         [self cancelNotification:call result:result];
@@ -341,13 +339,10 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     timeInterval = 60 * 60;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24;
+                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
                     break;
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
-                    break;
-                case CustomDayInterval:
-                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
                     break;
             }
             repeats = YES;
@@ -419,16 +414,12 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     notification.repeatInterval = NSCalendarUnitHour;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24;
+                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
                     notification.repeatInterval = NSCalendarUnitDay;
                     break;
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
                     notification.repeatInterval = NSCalendarUnitWeekOfYear;
-                    break;
-                case CustomDayInterval:
-                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
-                    notification.repeatInterval = NSCalendarUnitDay;
                     break;
             }
             if (notificationDetails.repeatTime != nil) {

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -330,6 +330,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if(notificationDetails.secondsSinceEpoch == nil) {
         NSTimeInterval timeInterval = 0.1;
         Boolean repeats = NO;
+        NSInteger dayInterval = notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue];
         if(notificationDetails.repeatInterval != nil) {
             switch([notificationDetails.repeatInterval integerValue]) {
                 case EveryMinute:
@@ -339,7 +340,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     timeInterval = 60 * 60;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
+                    timeInterval = 60 * 60 * 24 * dayInterval;
                     break;
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
@@ -403,7 +404,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if(notificationDetails.secondsSinceEpoch == nil) {
         if(notificationDetails.repeatInterval != nil) {
             NSTimeInterval timeInterval = 0;
-            
+            NSInteger dayInterval = notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue];
             switch([notificationDetails.repeatInterval integerValue]) {
                 case EveryMinute:
                     timeInterval = 60;
@@ -414,7 +415,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     notification.repeatInterval = NSCalendarUnitHour;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
+                    timeInterval = 60 * 60 * 24 * dayInterval;
                     notification.repeatInterval = NSCalendarUnitDay;
                     break;
                 case Weekly:

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -24,6 +24,7 @@ NSString *const SCHEDULE_METHOD = @"schedule";
 NSString *const PERIODICALLY_SHOW_METHOD = @"periodicallyShow";
 NSString *const SHOW_DAILY_AT_TIME_METHOD = @"showDailyAtTime";
 NSString *const SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD = @"showWeeklyAtDayAndTime";
+NSString *const SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD = @"showCustomDayIntervalAtTime";
 NSString *const CANCEL_METHOD = @"cancel";
 NSString *const CANCEL_ALL_METHOD = @"cancelAll";
 NSString *const PENDING_NOTIFICATIONS_REQUESTS_METHOD = @"pendingNotificationRequests";
@@ -57,6 +58,7 @@ NSString *const REPEAT_TIME = @"repeatTime";
 NSString *const HOUR = @"hour";
 NSString *const MINUTE = @"minute";
 NSString *const SECOND = @"second";
+NSString *const DAY_INTERVAL = @"dayInterval";
 
 NSString *const NOTIFICATION_ID = @"NotificationId";
 NSString *const PAYLOAD = @"payload";
@@ -67,7 +69,8 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly
+    Weekly,
+    CustomDayInterval
 };
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -217,7 +220,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     }
     if([SCHEDULE_METHOD isEqualToString:call.method]) {
         notificationDetails.secondsSinceEpoch = @([call.arguments[MILLISECONDS_SINCE_EPOCH] longLongValue] / 1000);
-    } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
+    } else if([PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method] || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method] || [SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD isEqualToString:call.method]) {
         if (call.arguments[REPEAT_TIME]) {
             NSDictionary *timeArguments = (NSDictionary *) call.arguments[REPEAT_TIME];
             notificationDetails.repeatTime = [[NotificationTime alloc] init];
@@ -233,6 +236,9 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         }
         if (call.arguments[DAY]) {
             notificationDetails.day = @([call.arguments[DAY] integerValue]);
+        }
+        if (call.arguments[DAY_INTERVAL]) {
+            notificationDetails.dayInterval = @([call.arguments[DAY_INTERVAL] integerValue]);
         }
         notificationDetails.repeatInterval = @([call.arguments[REPEAT_INTERVAL] integerValue]);
     }
@@ -280,7 +286,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if([INITIALIZE_METHOD isEqualToString:call.method]) {
         [self initialize:call result:result];
     } else if ([SHOW_METHOD isEqualToString:call.method] || [SCHEDULE_METHOD isEqualToString:call.method] || [PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method]
-               || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
+               || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method] || [SHOW_CUSTOM_DAY_INTERVAL_AT_TIME_METHOD isEqualToString:call.method]) {
         [self showNotification:call result:result];
     } else if([CANCEL_METHOD isEqualToString:call.method]) {
         [self cancelNotification:call result:result];
@@ -339,6 +345,9 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     break;
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
+                    break;
+                case CustomDayInterval:
+                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
                     break;
             }
             repeats = YES;
@@ -416,6 +425,10 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
                     notification.repeatInterval = NSCalendarUnitWeekOfYear;
+                    break;
+                case CustomDayInterval:
+                    timeInterval = 60 * 60 * 24 * [notificationDetails.dayInterval integerValue];
+                    notification.repeatInterval = NSCalendarUnitDay;
                     break;
             }
             if (notificationDetails.repeatTime != nil) {

--- a/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -330,7 +330,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if(notificationDetails.secondsSinceEpoch == nil) {
         NSTimeInterval timeInterval = 0.1;
         Boolean repeats = NO;
-        NSInteger dayInterval = notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue];
         if(notificationDetails.repeatInterval != nil) {
             switch([notificationDetails.repeatInterval integerValue]) {
                 case EveryMinute:
@@ -340,7 +339,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     timeInterval = 60 * 60;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24 * dayInterval;
+                    timeInterval = 60 * 60 * 24 * (notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue]);
                     break;
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
@@ -404,7 +403,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if(notificationDetails.secondsSinceEpoch == nil) {
         if(notificationDetails.repeatInterval != nil) {
             NSTimeInterval timeInterval = 0;
-            NSInteger dayInterval = notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue];
             switch([notificationDetails.repeatInterval integerValue]) {
                 case EveryMinute:
                     timeInterval = 60;
@@ -415,7 +413,7 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
                     notification.repeatInterval = NSCalendarUnitHour;
                     break;
                 case Daily:
-                    timeInterval = 60 * 60 * 24 * dayInterval;
+                    timeInterval = 60 * 60 * 24 * (notificationDetails.dayInterval == nil ? 1 : [notificationDetails.dayInterval integerValue]);
                     notification.repeatInterval = NSCalendarUnitDay;
                     break;
                 case Weekly:

--- a/ios/Classes/NotificationDetails.h
+++ b/ios/Classes/NotificationDetails.h
@@ -14,4 +14,5 @@
 @property(nonatomic, strong) NSNumber *repeatInterval;
 @property(nonatomic, strong) NotificationTime *repeatTime;
 @property(nonatomic, strong) NSNumber *day;
+@property(nonatomic, strong) NSNumber *dayInterval;
 @end

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -16,7 +16,13 @@ typedef DidReceiveLocalNotificationCallback = Future<dynamic> Function(
     int id, String title, String body, String payload);
 
 /// The available intervals for periodically showing notifications
-enum RepeatInterval { EveryMinute, Hourly, Daily, Weekly }
+enum RepeatInterval {
+  EveryMinute,
+  Hourly,
+  Daily,
+  Weekly,
+  CustomDayInterval,
+}
 
 /// The days of the week
 class Day {
@@ -212,6 +218,32 @@ class FlutterLocalNotificationsPlugin {
       'repeatInterval': RepeatInterval.Weekly.index,
       'repeatTime': notificationTime.toMap(),
       'day': day.value,
+      'platformSpecifics': serializedPlatformSpecifics,
+      'payload': payload ?? ''
+    });
+  }
+
+  /// Shows a notification on the given day interval at the specified time
+  Future<void> showCustomDayIntervalAtTime(
+    int id,
+    String title,
+    String body,
+    int dayInterval,
+    Time notificationTime,
+    NotificationDetails notificationDetails, {
+    String payload,
+  }) async {
+    final serializedPlatformSpecifics =
+        _retrievePlatformSpecificNotificationDetails(notificationDetails);
+    await _channel
+        .invokeMethod('showCustomDayIntervalAtTime', <String, dynamic>{
+      'id': id,
+      'title': title,
+      'body': body,
+      'calledAt': DateTime.now().millisecondsSinceEpoch,
+      'repeatInterval': RepeatInterval.CustomDayInterval.index,
+      'repeatTime': notificationTime.toMap(),
+      'dayInterval': dayInterval,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
     });

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -21,7 +21,6 @@ enum RepeatInterval {
   Hourly,
   Daily,
   Weekly,
-  CustomDayInterval,
 }
 
 /// The days of the week
@@ -187,7 +186,7 @@ class FlutterLocalNotificationsPlugin {
   /// Shows a notification on a daily interval at the specified time
   Future<void> showDailyAtTime(int id, String title, String body,
       Time notificationTime, NotificationDetails notificationDetails,
-      {String payload}) async {
+      {String payload, int dayInterval = 1}) async {
     _validateId(id);
     var serializedPlatformSpecifics =
         _retrievePlatformSpecificNotificationDetails(notificationDetails);
@@ -199,7 +198,8 @@ class FlutterLocalNotificationsPlugin {
       'repeatInterval': RepeatInterval.Daily.index,
       'repeatTime': notificationTime.toMap(),
       'platformSpecifics': serializedPlatformSpecifics,
-      'payload': payload ?? ''
+      'payload': payload ?? '',
+      'dayInterval': dayInterval,
     });
   }
 
@@ -218,32 +218,6 @@ class FlutterLocalNotificationsPlugin {
       'repeatInterval': RepeatInterval.Weekly.index,
       'repeatTime': notificationTime.toMap(),
       'day': day.value,
-      'platformSpecifics': serializedPlatformSpecifics,
-      'payload': payload ?? ''
-    });
-  }
-
-  /// Shows a notification on the given day interval at the specified time
-  Future<void> showCustomDayIntervalAtTime(
-    int id,
-    String title,
-    String body,
-    int dayInterval,
-    Time notificationTime,
-    NotificationDetails notificationDetails, {
-    String payload,
-  }) async {
-    final serializedPlatformSpecifics =
-        _retrievePlatformSpecificNotificationDetails(notificationDetails);
-    await _channel
-        .invokeMethod('showCustomDayIntervalAtTime', <String, dynamic>{
-      'id': id,
-      'title': title,
-      'body': body,
-      'calledAt': DateTime.now().millisecondsSinceEpoch,
-      'repeatInterval': RepeatInterval.CustomDayInterval.index,
-      'repeatTime': notificationTime.toMap(),
-      'dayInterval': dayInterval,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? ''
     });


### PR DESCRIPTION
This PR adds the ability to set a custom day interval when a notification should be shown at a specified time. This allows the user to set the day interval on a specific time of the notifications, f.e. every other day at 10:00, every 30 days, every 365 days...

The different periodically notifications current available are great, but lack support for this situation. It would be really helpful to have a more dynamic option available.