### PR TITLE
Add support for delayed notification permission request on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,42 @@ await flutterLocalNotificationsPlugin.show(
     3, 'Attention', 'Two new messages', platformChannelSpecifics);
 ```
 
+### [iOS only] Requesting notification permission
+
+By default this plugin will request notification permission when it is initialized. `IOSInitializationSettings` have three named parameters:
+1. `requestSoundPermission`,
+1. `requestBadgePermission`,
+1. `requestAlertPermission`
+that control this behaviour.
+
+If you want to delay permission request, set all of the above to false, then later call `requestPermissions` method.
+
+```dart
+FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = new FlutterLocalNotificationsPlugin();
+var initializationSettingsAndroid =
+    new AndroidInitializationSettings('app_icon');
+var initializationSettingsIOS = new IOSInitializationSettings(
+        requestSoundPermission: false,
+        requestBadgePermission: false,
+        requestAlertPermission: false,
+        onDidReceiveLocalNotification: onDidReceiveLocalNotification,
+    );
+var initializationSettings = new InitializationSettings(
+    initializationSettingsAndroid, initializationSettingsIOS);
+flutterLocalNotificationsPlugin.initialize(initializationSettings,
+    onSelectNotification: onSelectNotification);
+
+/* some logic */
+
+var result = await flutterLocalNotificationsPlugin.requestPermissions(
+        requestSoundPermission: false,
+        requestBadgePermission: false,
+        requestAlertPermission: false,
+    );
+
+print('notification permissions were ${result ? '' : 'not '}granted');
+```
+
 ### Cancelling/deleting a notification
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -207,6 +208,12 @@ class _HomePageState extends State<HomePage> {
                     buttonText: 'Cancel all notifications',
                     onPressed: () async {
                       await _cancelAllNotifications();
+                    },
+                  ),
+                  PaddedRaisedButton(
+                    buttonText: 'Request permissions [iOS]',
+                    onPressed: () async {
+                      await _requestPermissions(context);
                     },
                   ),
                 ],
@@ -522,6 +529,22 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _cancelAllNotifications() async {
     await flutterLocalNotificationsPlugin.cancelAll();
+  }
+
+  Future<void> _requestPermissions(BuildContext context) async {
+    final result = await flutterLocalNotificationsPlugin.requestPermissions(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+    await showDialog(
+      context: context,
+      builder: (context) => SimpleDialog(
+        children: <Widget>[
+          Center(child: Text('result: $result')),
+        ],
+      ),
+    );
   }
 
   Future<void> onSelectNotification(String payload) async {

--- a/lib/src/flutter_local_notifications.dart
+++ b/lib/src/flutter_local_notifications.dart
@@ -1,8 +1,10 @@
-import 'dart:io';
 import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
+
 import 'initialization_settings.dart';
 import 'notification_app_launch_details.dart';
 import 'notification_details.dart';
@@ -102,6 +104,21 @@ class FlutterLocalNotificationsPlugin {
     var result =
         await _channel.invokeMethod('initialize', serializedPlatformSpecifics);
     return result;
+  }
+
+  Future<bool> requestPermissions({
+    bool requestSoundPermission,
+    bool requestAlertPermission,
+    bool requestBadgePermission,
+  }) {
+    if (_platform.isAndroid) {
+      return Future.value(true);
+    }
+    return _channel.invokeMethod('requestPermissions', {
+      'requestSoundPermission': requestSoundPermission,
+      'requestAlertPermission': requestAlertPermission,
+      'requestBadgePermission': requestBadgePermission,
+    });
   }
 
   Future<NotificationAppLaunchDetails> getNotificationAppLaunchDetails() async {


### PR DESCRIPTION
Currently notification permissions can only be requested when plugin is
initialized. In some cases this may result in suboptimal user
experience, when user will be asked for the notification permission
before he would event decide if he want to be notified by application.

This patch adds 'requestPermissions' method that may be used later on
for asking user to grant application notification permission. This way
all the notificaiton handlers can be initialized immediately after app
startup. Then later on, when user actually decide to use local
notifications 'requestPermissions' method will be used to as him for
required permissions.