### PR TITLE
changed FLAG_CANCEL_CURRENT to FLAG_UPDATE_CURRENT in cancelling alarms

### DIFF
--- a/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -784,7 +784,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     private void cancelNotification(Integer id) {
         Context context = registrar.context();
         Intent intent = new Intent(context, ScheduledNotificationReceiver.class);
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         AlarmManager alarmManager = getAlarmManager(context);
         alarmManager.cancel(pendingIntent);
         NotificationManagerCompat notificationManager = getNotificationManager(context);
@@ -805,7 +805,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         Intent intent = new Intent(context, ScheduledNotificationReceiver.class);
         for (NotificationDetails scheduledNotification :
                 scheduledNotifications) {
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, scheduledNotification.id, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, scheduledNotification.id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
             AlarmManager alarmManager = getAlarmManager(context);
             alarmManager.cancel(pendingIntent);
         }


### PR DESCRIPTION
Changed `FLAG_CANCEL_CURRENT` to `FLAG_UPDATE_CURRENT` when creating PendingIntents in cancelling functions.  `FLAG_CANCEL_CURRENT ` will cancel the existing one and create a new PendingIntent, causing failure when cancel previous alarms which are created with the previous PendingIntents.