### PR TITLE
[flutter_local_notifications] add support for delayed notification permission request on iOS

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -109,7 +109,7 @@ By default this plugin will request notification permission when it is initializ
 1. `requestAlertPermission`
 that control this behaviour.
 
-If you want to delay permission request, set all of the above to false, then later call `requestPermissions` method with desired permissions.
+If you want to delay permission request, set all of the above to false.
 
 ```dart
 FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = new FlutterLocalNotificationsPlugin();
@@ -125,7 +125,11 @@ var initializationSettings = new InitializationSettings(
     initializationSettingsAndroid, initializationSettingsIOS);
 flutterLocalNotificationsPlugin.initialize(initializationSettings,
     onSelectNotification: onSelectNotification);
+```
 
+Then later call `requestPermissions` method with desired permissions.
+
+```dart
 var result = await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
         sound: true,
         badge: true,

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -39,6 +39,7 @@ A cross platform plugin for displaying local notifications.
 * [Android] Group notifications
 * [Android] Show progress notifications
 * [Android] Configure notification visibility on the lockscreen
+* [iOS] Delay requesting notification permission
 * [iOS] Customise the permissions to be requested around displaying notifications
 
 Note that this plugin aims to provide abstractions for all platforms as opposed to having methods that only work on specific platforms. However, each method allows passing in "platform-specifics" that contains data that is specific for customising notifications on each platform. This approach means that some scenarios may not be covered by the plugin. Developers can either fork or maintain their code for showing notifications in these situations. Note that the plugin still under development so expect the API surface to change over time.
@@ -99,6 +100,39 @@ Future onSelectNotification(String payload) async {
 In the real world, this payload could represent the id of the item you want to display the details of. Once the initialisation has been done, then you can manage the displaying of notifications.
 
 *Notes around initialisation*: if the app had been launched by tapping on a notification created by this plugin, calling `initialize` is what will trigger the `onSelectNotification` to trigger to handle the notification that the user tapped on. An alternative to handling the "launch notification" is to call the `getNotificationAppLaunchDetails` method that is available in the plugin. This could be used, for example, to change the home route of the app for deep-linking. Calling `initialize` will still cause the `onSelectNotification` callback to fire for the launch notification. It will be up to developers to ensure that they don't process the same notification twice (e.g. by storing and comparing the notification id).
+
+### [iOS only] Requesting notification permission
+
+By default this plugin will request notification permission when it is initialized. `IOSInitializationSettings` have three named parameters:
+1. `requestSoundPermission`,
+1. `requestBadgePermission`,
+1. `requestAlertPermission`
+that control this behaviour.
+
+If you want to delay permission request, set all of the above to false, then later call `requestPermissions` method with desired permissions.
+
+```dart
+FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = new FlutterLocalNotificationsPlugin();
+var initializationSettingsAndroid =
+    new AndroidInitializationSettings('app_icon');
+var initializationSettingsIOS = new IOSInitializationSettings(
+        requestSoundPermission: false,
+        requestBadgePermission: false,
+        requestAlertPermission: false,
+        onDidReceiveLocalNotification: onDidReceiveLocalNotification,
+    );
+var initializationSettings = new InitializationSettings(
+    initializationSettingsAndroid, initializationSettingsIOS);
+flutterLocalNotificationsPlugin.initialize(initializationSettings,
+    onSelectNotification: onSelectNotification);
+/* some logic */
+var result = await flutterLocalNotificationsPlugin.requestPermissions(
+        requestSoundPermission: false,
+        requestBadgePermission: false,
+        requestAlertPermission: false,
+    );
+print('notification permissions were ${result ? '' : 'not '}granted');
+```
 
 ### Displaying a notification
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -127,9 +127,9 @@ flutterLocalNotificationsPlugin.initialize(initializationSettings,
     onSelectNotification: onSelectNotification);
 
 var result = await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
-        requestSoundPermission: false,
-        requestBadgePermission: false,
-        requestAlertPermission: false,
+        sound: true,
+        badge: true,
+        alert: true,
     );
 ```
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -125,13 +125,12 @@ var initializationSettings = new InitializationSettings(
     initializationSettingsAndroid, initializationSettingsIOS);
 flutterLocalNotificationsPlugin.initialize(initializationSettings,
     onSelectNotification: onSelectNotification);
-/* some logic */
-var result = await flutterLocalNotificationsPlugin.requestPermissions(
+
+var result = await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
         requestSoundPermission: false,
         requestBadgePermission: false,
         requestAlertPermission: false,
     );
-print('notification permissions were ${result ? '' : 'not '}granted');
 ```
 
 ### Displaying a notification

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -862,9 +862,9 @@ class _HomePageState extends State<HomePage> {
     }
     final result =
         await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
-      requestAlertPermission: true,
-      requestBadgePermission: true,
-      requestSoundPermission: true,
+      alert: true,
+      badge: true,
+      sound: true,
     );
     return showDialog(
       context: context,

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -45,11 +46,14 @@ Future<void> main() async {
 
   var initializationSettingsAndroid = AndroidInitializationSettings('app_icon');
   var initializationSettingsIOS = IOSInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
       onDidReceiveLocalNotification:
           (int id, String title, String body, String payload) async {
-    didReceiveLocalNotificationSubject.add(ReceivedNotification(
-        id: id, title: title, body: body, payload: payload));
-  });
+        didReceiveLocalNotificationSubject.add(ReceivedNotification(
+            id: id, title: title, body: body, payload: payload));
+      });
   var initializationSettings = InitializationSettings(
       initializationSettingsAndroid, initializationSettingsIOS);
   await flutterLocalNotificationsPlugin.initialize(initializationSettings,
@@ -311,6 +315,12 @@ class _HomePageState extends State<HomePage> {
                     buttonText: 'Cancel all notifications',
                     onPressed: () async {
                       await _cancelAllNotifications();
+                    },
+                  ),
+                  PaddedRaisedButton(
+                    buttonText: 'Request permissions [iOS]',
+                    onPressed: () async {
+                      await _requestPermissions(context);
                     },
                   ),
                   PaddedRaisedButton(
@@ -837,6 +847,32 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(0, 'public notification title',
         'public notification body', platformChannelSpecifics,
         payload: 'item x');
+  }
+
+  Future<void> _requestPermissions(BuildContext context) async {
+    if (!Platform.isIOS) {
+      return showDialog(
+        context: context,
+        builder: (context) => SimpleDialog(
+          children: <Widget>[
+            Center(child: Text('Only supported on iOS.')),
+          ],
+        ),
+      );
+    }
+    final result = await flutterLocalNotificationsPlugin.requestPermissions(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+    return showDialog(
+      context: context,
+      builder: (context) => SimpleDialog(
+        children: <Widget>[
+          Center(child: Text('result: $result')),
+        ],
+      ),
+    );
   }
 
   Future<void> _showNotificationWithIconBadge() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -96,6 +96,22 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    _requestIOSPermissions();
+    _configureDidReceiveLocalNotificationSubject();
+    _configureSelectNotificationSubject();
+  }
+
+  void _requestIOSPermissions() {
+    if (Platform.isIOS) {
+      IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    }
+  }
+
+  void _configureDidReceiveLocalNotificationSubject() {
     didReceiveLocalNotificationSubject.stream
         .listen((ReceivedNotification receivedNotification) async {
       await showDialog(
@@ -126,6 +142,9 @@ class _HomePageState extends State<HomePage> {
         ),
       );
     });
+  }
+
+  void _configureSelectNotificationSubject() {
     selectNotificationSubject.stream.listen((String payload) async {
       await Navigator.push(
         context,
@@ -315,12 +334,6 @@ class _HomePageState extends State<HomePage> {
                     buttonText: 'Cancel all notifications',
                     onPressed: () async {
                       await _cancelAllNotifications();
-                    },
-                  ),
-                  PaddedRaisedButton(
-                    buttonText: 'Request permissions [iOS]',
-                    onPressed: () async {
-                      await _requestPermissions(context);
                     },
                   ),
                   PaddedRaisedButton(
@@ -847,33 +860,6 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(0, 'public notification title',
         'public notification body', platformChannelSpecifics,
         payload: 'item x');
-  }
-
-  Future<void> _requestPermissions(BuildContext context) async {
-    if (!Platform.isIOS) {
-      return showDialog(
-        context: context,
-        builder: (context) => SimpleDialog(
-          children: <Widget>[
-            Center(child: Text('Only supported on iOS.')),
-          ],
-        ),
-      );
-    }
-    final result =
-        await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
-      alert: true,
-      badge: true,
-      sound: true,
-    );
-    return showDialog(
-      context: context,
-      builder: (context) => SimpleDialog(
-        children: <Widget>[
-          Center(child: Text('result: $result')),
-        ],
-      ),
-    );
   }
 
   Future<void> _showNotificationWithIconBadge() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -860,7 +860,8 @@ class _HomePageState extends State<HomePage> {
         ),
       );
     }
-    final result = await flutterLocalNotificationsPlugin.requestPermissions(
+    final result =
+        await IOSFlutterLocalNotificationsPlugin.instance?.requestPermissions(
       requestAlertPermission: true,
       requestBadgePermission: true,
       requestSoundPermission: true,

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -38,6 +38,9 @@ NSString *const DAY = @"day";
 NSString *const REQUEST_SOUND_PERMISSION = @"requestSoundPermission";
 NSString *const REQUEST_ALERT_PERMISSION = @"requestAlertPermission";
 NSString *const REQUEST_BADGE_PERMISSION = @"requestBadgePermission";
+NSString *const SOUND_PERMISSION = @"sound";
+NSString *const ALERT_PERMISSION = @"alert";
+NSString *const BADGE_PERMISSION = @"badge";
 NSString *const DEFAULT_PRESENT_ALERT = @"defaultPresentAlert";
 NSString *const DEFAULT_PRESENT_SOUND = @"defaultPresentSound";
 NSString *const DEFAULT_PRESENT_BADGE = @"defaultPresentBadge";
@@ -155,14 +158,14 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     bool requestedSoundPermission = false;
     bool requestedAlertPermission = false;
     bool requestedBadgePermission = false;
-    if (arguments[REQUEST_SOUND_PERMISSION] != [NSNull null]) {
-        requestedSoundPermission = [arguments[REQUEST_SOUND_PERMISSION] boolValue];
+    if (arguments[SOUND_PERMISSION] != [NSNull null]) {
+        requestedSoundPermission = [arguments[SOUND_PERMISSION] boolValue];
     }
-    if (arguments[REQUEST_ALERT_PERMISSION] != [NSNull null]) {
-        requestedAlertPermission = [arguments[REQUEST_ALERT_PERMISSION] boolValue];
+    if (arguments[ALERT_PERMISSION] != [NSNull null]) {
+        requestedAlertPermission = [arguments[ALERT_PERMISSION] boolValue];
     }
-    if (arguments[REQUEST_BADGE_PERMISSION] != [NSNull null]) {
-        requestedBadgePermission = [arguments[REQUEST_BADGE_PERMISSION] boolValue];
+    if (arguments[BADGE_PERMISSION] != [NSNull null]) {
+        requestedBadgePermission = [arguments[BADGE_PERMISSION] boolValue];
     }
 
     if(@available(iOS 10.0, *)) {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -31,6 +31,7 @@ NSString *const CHANNEL = @"dexterous.com/flutter/local_notifications";
 NSString *const CALLBACK_CHANNEL = @"dexterous.com/flutter/local_notifications_background";
 NSString *const ON_NOTIFICATION_METHOD = @"onNotification";
 NSString *const DID_RECEIVE_LOCAL_NOTIFICATION = @"didReceiveLocalNotification";
+NSString *const REQUEST_PERMISSIONS_METHOD = @"requestPermissions";
 
 NSString *const DAY = @"day";
 
@@ -136,6 +137,11 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
 }
 
 - (void)initialize:(FlutterMethodCall * _Nonnull)call result:(FlutterResult _Nonnull)result {
+    [self requestPermissions:call result:result];
+    _initialized = true;
+}
+
+- (void)requestPermissions:(FlutterMethodCall * _Nonnull)call result:(FlutterResult _Nonnull)result {
     NSDictionary *arguments = [call arguments];
     if(arguments[DEFAULT_PRESENT_ALERT] != [NSNull null]) {
         _displayAlert = [[arguments objectForKey:DEFAULT_PRESENT_ALERT] boolValue];
@@ -158,10 +164,10 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     if (arguments[REQUEST_BADGE_PERMISSION] != [NSNull null]) {
         requestedBadgePermission = [arguments[REQUEST_BADGE_PERMISSION] boolValue];
     }
-    
+
     if(@available(iOS 10.0, *)) {
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        
+
         UNAuthorizationOptions authorizationOptions = 0;
         if (requestedSoundPermission) {
             authorizationOptions += UNAuthorizationOptionSound;
@@ -197,7 +203,6 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
         }
         result(@YES);
     }
-    _initialized = true;
 }
 
 - (void)showNotification:(FlutterMethodCall * _Nonnull)call result:(FlutterResult _Nonnull)result {
@@ -297,6 +302,8 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     } else if ([SHOW_METHOD isEqualToString:call.method] || [SCHEDULE_METHOD isEqualToString:call.method] || [PERIODICALLY_SHOW_METHOD isEqualToString:call.method] || [SHOW_DAILY_AT_TIME_METHOD isEqualToString:call.method]
                || [SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD isEqualToString:call.method]) {
         [self showNotification:call result:result];
+    } else if([REQUEST_PERMISSIONS_METHOD isEqualToString:call.method]) {
+            [self requestPermissions:call result:result];
     } else if([CANCEL_METHOD isEqualToString:call.method]) {
         [self cancelNotification:call result:result];
     } else if([CANCEL_ALL_METHOD isEqualToString:call.method]) {

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -1,8 +1,10 @@
-import 'dart:io';
 import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
 import 'package:platform/platform.dart';
+
 import 'initialization_settings.dart';
 import 'notification_details.dart';
 import 'platform_flutter_local_notifications.dart';
@@ -60,6 +62,23 @@ class FlutterLocalNotificationsPlugin {
               onSelectNotification: onSelectNotification);
     }
     return true;
+  }
+
+  Future<bool> requestPermissions({
+    bool requestSoundPermission,
+    bool requestAlertPermission,
+    bool requestBadgePermission,
+  }) {
+    if (_platform.isAndroid) {
+      return Future.value(true);
+    }
+    return (FlutterLocalNotificationsPlatform.instance
+            as IOSFlutterLocalNotificationsPlugin)
+        ?.requestPermissions(
+      requestSoundPermission: requestSoundPermission,
+      requestAlertPermission: requestAlertPermission,
+      requestBadgePermission: requestBadgePermission,
+    );
   }
 
   /// Returns info on if a notification had been used to launch the application.

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -64,23 +64,6 @@ class FlutterLocalNotificationsPlugin {
     return true;
   }
 
-  Future<bool> requestPermissions({
-    bool requestSoundPermission,
-    bool requestAlertPermission,
-    bool requestBadgePermission,
-  }) {
-    if (_platform.isAndroid) {
-      return Future.value(true);
-    }
-    return (FlutterLocalNotificationsPlatform.instance
-            as IOSFlutterLocalNotificationsPlugin)
-        ?.requestPermissions(
-      requestSoundPermission: requestSoundPermission,
-      requestAlertPermission: requestAlertPermission,
-      requestBadgePermission: requestBadgePermission,
-    );
-  }
-
   /// Returns info on if a notification had been used to launch the application.
   /// An example of how this could be used is to change the initial route of your application when it starts up.
   ///

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -55,13 +55,9 @@ class MethodChannelFlutterLocalNotificationsPlugin
 class AndroidFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
   /// Android specific plugin instance or null when not running in Android environment
-  static AndroidFlutterLocalNotificationsPlugin get instance {
-    if (FlutterLocalNotificationsPlatform.instance
-        is AndroidFlutterLocalNotificationsPlugin) {
-      return FlutterLocalNotificationsPlatform.instance;
-    }
-    return null;
-  }
+  static AndroidFlutterLocalNotificationsPlugin get instance =>
+      FlutterLocalNotificationsPlatform.instance
+          as AndroidFlutterLocalNotificationsPlugin;
 
   SelectNotificationCallback _onSelectNotification;
 
@@ -183,13 +179,9 @@ class AndroidFlutterLocalNotificationsPlugin
 class IOSFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
   /// IOS specific instance of plugin or null when not running in iOS environment
-  static IOSFlutterLocalNotificationsPlugin get instance {
-    if (FlutterLocalNotificationsPlatform.instance
-        is IOSFlutterLocalNotificationsPlugin) {
-      return FlutterLocalNotificationsPlatform.instance;
-    }
-    return null;
-  }
+  static IOSFlutterLocalNotificationsPlugin get instance =>
+      FlutterLocalNotificationsPlatform.instance
+          as IOSFlutterLocalNotificationsPlugin;
 
   SelectNotificationCallback _onSelectNotification;
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -54,6 +54,15 @@ class MethodChannelFlutterLocalNotificationsPlugin
 /// Android implementation of the local notifications plugin
 class AndroidFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
+  /// Android specific plugin instance or null when not running in Android environment
+  static AndroidFlutterLocalNotificationsPlugin get instance {
+    if (FlutterLocalNotificationsPlatform.instance
+        is AndroidFlutterLocalNotificationsPlugin) {
+      return FlutterLocalNotificationsPlatform.instance;
+    }
+    return null;
+  }
+
   SelectNotificationCallback _onSelectNotification;
 
   /// Initializes the plugin. Call this method on application before using the plugin further.
@@ -173,6 +182,15 @@ class AndroidFlutterLocalNotificationsPlugin
 /// iOS implementation of the local notifications plugin
 class IOSFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
+  /// IOS specific instance of plugin or null when not running in iOS environment
+  static IOSFlutterLocalNotificationsPlugin get instance {
+    if (FlutterLocalNotificationsPlatform.instance
+        is IOSFlutterLocalNotificationsPlugin) {
+      return FlutterLocalNotificationsPlatform.instance;
+    }
+    return null;
+  }
+
   SelectNotificationCallback _onSelectNotification;
 
   DidReceiveLocalNotificationCallback _onDidReceiveLocalNotification;

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -201,15 +201,11 @@ class IOSFlutterLocalNotificationsPlugin
   }
 
   /// Requests the specified permission(s) from user and returns current permission status.
-  Future<bool> requestPermissions({
-    bool requestSoundPermission,
-    bool requestAlertPermission,
-    bool requestBadgePermission,
-  }) {
+  Future<bool> requestPermissions({bool sound, bool alert, bool badge}) {
     return _channel.invokeMethod('requestPermissions', {
-      'requestSoundPermission': requestSoundPermission,
-      'requestAlertPermission': requestAlertPermission,
-      'requestBadgePermission': requestBadgePermission,
+      'sound': sound,
+      'alert': alert,
+      'badge': badge,
     });
   }
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -200,7 +200,7 @@ class IOSFlutterLocalNotificationsPlugin
         'initialize', initializationSettings.toMap());
   }
 
-  /// Requests given permission from user and returns current permission status.
+  /// Requests the specified permission(s) from user and returns current permission status.
   Future<bool> requestPermissions({
     bool requestSoundPermission,
     bool requestAlertPermission,

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -55,9 +55,13 @@ class MethodChannelFlutterLocalNotificationsPlugin
 class AndroidFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
   /// Android specific plugin instance or null when not running in Android environment
-  static AndroidFlutterLocalNotificationsPlugin get instance =>
-      FlutterLocalNotificationsPlatform.instance
-          as AndroidFlutterLocalNotificationsPlugin;
+  static AndroidFlutterLocalNotificationsPlugin get instance {
+    if (FlutterLocalNotificationsPlatform.instance
+        is AndroidFlutterLocalNotificationsPlugin) {
+      return FlutterLocalNotificationsPlatform.instance;
+    }
+    return null;
+  }
 
   SelectNotificationCallback _onSelectNotification;
 
@@ -179,9 +183,13 @@ class AndroidFlutterLocalNotificationsPlugin
 class IOSFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
   /// IOS specific instance of plugin or null when not running in iOS environment
-  static IOSFlutterLocalNotificationsPlugin get instance =>
-      FlutterLocalNotificationsPlatform.instance
-          as IOSFlutterLocalNotificationsPlugin;
+  static IOSFlutterLocalNotificationsPlugin get instance {
+    if (FlutterLocalNotificationsPlatform.instance
+        is IOSFlutterLocalNotificationsPlugin) {
+      return FlutterLocalNotificationsPlatform.instance;
+    }
+    return null;
+  }
 
   SelectNotificationCallback _onSelectNotification;
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -4,11 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
 
+import 'helpers.dart';
 import 'platform_specifics/android/initialization_settings.dart';
 import 'platform_specifics/android/notification_details.dart';
 import 'platform_specifics/ios/initialization_settings.dart';
 import 'platform_specifics/ios/notification_details.dart';
-import 'helpers.dart';
 import 'typedefs.dart';
 import 'types.dart';
 
@@ -188,6 +188,18 @@ class IOSFlutterLocalNotificationsPlugin
     _channel.setMethodCallHandler(_handleMethod);
     return await _channel.invokeMethod(
         'initialize', initializationSettings.toMap());
+  }
+
+  Future<bool> requestPermissions({
+    bool requestSoundPermission,
+    bool requestAlertPermission,
+    bool requestBadgePermission,
+  }) {
+    return _channel.invokeMethod('requestPermissions', {
+      'requestSoundPermission': requestSoundPermission,
+      'requestAlertPermission': requestAlertPermission,
+      'requestBadgePermission': requestBadgePermission,
+    });
   }
 
   /// Schedules a notification to be shown at the specified time with an optional payload that is passed through when a notification is tapped

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -208,6 +208,7 @@ class IOSFlutterLocalNotificationsPlugin
         'initialize', initializationSettings.toMap());
   }
 
+  /// Requests given permission from user and returns current permission status.
   Future<bool> requestPermissions({
     bool requestSoundPermission,
     bool requestAlertPermission,


### PR DESCRIPTION
Currently notification permissions can only be requested when plugin is
initialized. In some cases this may result in suboptimal user
experience, when user will be asked for the notification permission
before he would event decide if he want to be notified by application.

This patch adds 'requestPermissions' method that may be used later on
for asking user to grant application notification permission. This way
all the notification handlers can be initialized immediately after app
startup. Then later on, when user actually decide to use local
notifications 'requestPermissions' method will be used to as him for
required permissions.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications])
