### PR TITLE
[flutter_local_notifications] add ability to toggle showing notification timestamp on Android

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -134,8 +134,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 .setContentIntent(pendingIntent)
                 .setPriority(notificationDetails.priority)
                 .setOngoing(BooleanUtils.getValue(notificationDetails.ongoing))
-                .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce))
-                .setShowWhen(BooleanUtils.getValue(notificationDetails.setShowWhen));
+                .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce));
 
         setSmallIcon(context, notificationDetails, builder);
         if (!StringUtils.isNullOrEmpty(notificationDetails.largeIcon)) {
@@ -144,6 +143,11 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         if (notificationDetails.color != null) {
             builder.setColor(notificationDetails.color.intValue());
         }
+
+        if (notificationDetails.showWhen != null){
+            builder.setShowWhen(BooleanUtils.getValue(notificationDetails.showWhen));
+        }
+
 
         setVisibility(notificationDetails, builder);
         applyGrouping(notificationDetails, builder);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -134,7 +134,8 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 .setContentIntent(pendingIntent)
                 .setPriority(notificationDetails.priority)
                 .setOngoing(BooleanUtils.getValue(notificationDetails.ongoing))
-                .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce));
+                .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce))
+                .setShowWhen(BooleanUtils.getValue(notificationDetails.setShowWhen));
 
         setSmallIcon(context, notificationDetails, builder);
         if (!StringUtils.isNullOrEmpty(notificationDetails.largeIcon)) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -99,6 +99,8 @@ public class NotificationDetails {
     private static final String ALLOW_WHILE_IDLE = "allowWhileIdle";
     private static final String CATEGORY = "category";
     private static final String TIMEOUT_AFTER = "timeoutAfter";
+    private static final String SET_SHOW_WHEN = "setShowWhen";
+
 
     public Integer id;
     public String title;
@@ -145,6 +147,8 @@ public class NotificationDetails {
     public Boolean allowWhileIdle;
     public Long timeoutAfter;
     public String category;
+    public Boolean setShowWhen;
+
 
 
     // Note: this is set on the Android to save details about the icon that should be used when re-hydrating scheduled notifications when a device has been restarted.
@@ -190,6 +194,7 @@ public class NotificationDetails {
             notificationDetails.setAsGroupSummary = (Boolean) platformChannelSpecifics.get(SET_AS_GROUP_SUMMARY);
             notificationDetails.groupAlertBehavior = (Integer) platformChannelSpecifics.get(GROUP_ALERT_BEHAVIOR);
             notificationDetails.onlyAlertOnce = (Boolean) platformChannelSpecifics.get(ONLY_ALERT_ONCE);
+            notificationDetails.setShowWhen = (Boolean) platformChannelSpecifics.get(SET_SHOW_WHEN);
             notificationDetails.showProgress = (Boolean) platformChannelSpecifics.get(SHOW_PROGRESS);
             if (platformChannelSpecifics.containsKey(MAX_PROGRESS)) {
                 notificationDetails.maxProgress = (Integer) platformChannelSpecifics.get(MAX_PROGRESS);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -194,7 +194,7 @@ public class NotificationDetails {
             notificationDetails.setAsGroupSummary = (Boolean) platformChannelSpecifics.get(SET_AS_GROUP_SUMMARY);
             notificationDetails.groupAlertBehavior = (Integer) platformChannelSpecifics.get(GROUP_ALERT_BEHAVIOR);
             notificationDetails.onlyAlertOnce = (Boolean) platformChannelSpecifics.get(ONLY_ALERT_ONCE);
-            notificationDetails.setShowWhen = (Boolean) platformChannelSpecifics.get(SET_SHOW_WHEN);
+            notificationDetails.showWhen = (Boolean) platformChannelSpecifics.get(SHOW_WHEN);
             notificationDetails.showProgress = (Boolean) platformChannelSpecifics.get(SHOW_PROGRESS);
             if (platformChannelSpecifics.containsKey(MAX_PROGRESS)) {
                 notificationDetails.maxProgress = (Integer) platformChannelSpecifics.get(MAX_PROGRESS);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -99,7 +99,7 @@ public class NotificationDetails {
     private static final String ALLOW_WHILE_IDLE = "allowWhileIdle";
     private static final String CATEGORY = "category";
     private static final String TIMEOUT_AFTER = "timeoutAfter";
-    private static final String SET_SHOW_WHEN = "setShowWhen";
+    private static final String SHOW_WHEN = "showWhen";
 
 
     public Integer id;
@@ -147,7 +147,7 @@ public class NotificationDetails {
     public Boolean allowWhileIdle;
     public Long timeoutAfter;
     public String category;
-    public Boolean setShowWhen;
+    public Boolean showWhen;
 
 
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -382,9 +382,9 @@ class _HomePageState extends State<HomePage> {
                     },
                   ),
                   PaddedRaisedButton(
-                    buttonText: 'Show notification without displaying occurred time [Android]',
+                    buttonText: 'Show notification without timestamp [Android]',
                     onPressed: () async {
-                      await _showNotificationWithoutOccurredTime();
+                      await _showNotificationWithoutTimestamp();
                     },
                   ),
                 ],
@@ -918,10 +918,10 @@ class _HomePageState extends State<HomePage> {
         payload: 'item x');
   }
 
-  Future<void> _showNotificationWithoutOccurredTime() async {
+  Future<void> _showNotificationWithoutTimestamp() async {
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max, priority: Priority.High, ticker: 'ticker' , showWhen : false);
+        importance: Importance.Max, priority: Priority.High, showWhen: false);
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
@@ -929,7 +929,6 @@ class _HomePageState extends State<HomePage> {
         0, 'plain title', 'plain body', platformChannelSpecifics,
         payload: 'item x');
   }
-
 
   String _toTwoDigitString(int value) {
     return value.toString().padLeft(2, '0');

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -381,6 +381,12 @@ class _HomePageState extends State<HomePage> {
                       await _showNotificationWithIconBadge();
                     },
                   ),
+                  PaddedRaisedButton(
+                    buttonText: 'Show notification without displaying occurred time [Android]',
+                    onPressed: () async {
+                      await _showNotificationWithoutOccurredTime();
+                    },
+                  ),
                 ],
               ),
             ),
@@ -911,6 +917,19 @@ class _HomePageState extends State<HomePage> {
         0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
         payload: 'item x');
   }
+
+  Future<void> _showNotificationWithoutOccurredTime() async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max, priority: Priority.High, ticker: 'ticker' , showWhen : false);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
 
   String _toTwoDigitString(int value) {
     return value.toString().padLeft(2, '0');

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -102,7 +102,7 @@ class AndroidNotificationDetails {
   /// Specifies if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.
   bool onlyAlertOnce;
 
-  /// Specifies if you would like showing notification update time
+  /// Specifies if the notification should display the timestamp of when it occurred.
   bool showWhen;
 
   /// Specifies if the notification will be used to show progress.
@@ -171,7 +171,7 @@ class AndroidNotificationDetails {
       this.largeIcon,
       this.largeIconBitmapSource,
       this.onlyAlertOnce,
-      this.showWhen,
+      this.showWhen = true,
       this.channelShowBadge = true,
       this.showProgress = false,
       this.maxProgress = 0,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -102,6 +102,9 @@ class AndroidNotificationDetails {
   /// Specifies if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.
   bool onlyAlertOnce;
 
+  /// Specifies if you would like showing notification update time
+  bool showWhen;
+
   /// Specifies if the notification will be used to show progress.
   bool showProgress;
 
@@ -168,6 +171,7 @@ class AndroidNotificationDetails {
       this.largeIcon,
       this.largeIconBitmapSource,
       this.onlyAlertOnce,
+      this.showWhen,
       this.channelShowBadge = true,
       this.showProgress = false,
       this.maxProgress = 0,
@@ -216,6 +220,7 @@ class AndroidNotificationDetails {
       'largeIcon': largeIcon,
       'largeIconBitmapSource': largeIconBitmapSource?.index,
       'onlyAlertOnce': onlyAlertOnce,
+      'showWhen': showWhen,
       'showProgress': showProgress,
       'maxProgress': maxProgress,
       'progress': progress,


### PR DESCRIPTION
now the developer can configure displaying the notification create or update time. default is true in android. just use **showWhen** attribute in AndroidNotificationDetails.

`  var androidPlatformChannelSpecifics = AndroidNotificationDetails(
      'your channel id', 'your channel name', 'your channel description',
      showWhen : false , enableVibration : false , autoCancel : false ,onlyAlertOnce: true, ongoing: true , playSound: false , icon: 'app_icon' );`
