### PR TITLE
[flutter_local_notifications] add ability to associate iOS user notifications with attachments

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -500,7 +500,7 @@ class _HomePageState extends State<HomePage> {
         'Times out after 3 seconds', platformChannelSpecifics);
   }
 
-  Future<String> _downloadAndSaveImage(String url, String fileName) async {
+  Future<String> _downloadAndSaveFile(String url, String fileName) async {
     var directory = await getApplicationDocumentsDirectory();
     var filePath = '${directory.path}/$fileName';
     var response = await http.get(url);
@@ -510,9 +510,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _showBigPictureNotification() async {
-    var largeIconPath = await _downloadAndSaveImage(
+    var largeIconPath = await _downloadAndSaveFile(
         'http://via.placeholder.com/48x48', 'largeIcon');
-    var bigPicturePath = await _downloadAndSaveImage(
+    var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
         bigPicturePath, BitmapSource.FilePath,
@@ -535,9 +535,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _showBigPictureNotificationHideExpandedLargeIcon() async {
-    var largeIconPath = await _downloadAndSaveImage(
+    var largeIconPath = await _downloadAndSaveFile(
         'http://via.placeholder.com/48x48', 'largeIcon');
-    var bigPicturePath = await _downloadAndSaveImage(
+    var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
         bigPicturePath, BitmapSource.FilePath,
@@ -561,7 +561,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _showNotificationMediaStyle() async {
-    var largeIconPath = await _downloadAndSaveImage(
+    var largeIconPath = await _downloadAndSaveFile(
         'http://via.placeholder.com/128x128/00FF00/000000', 'largeIcon');
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
       'media channel id',
@@ -636,7 +636,7 @@ class _HomePageState extends State<HomePage> {
         icon: 'coworker',
         iconSource: IconSource.Drawable);
     // download the icon that would be use for the lunch bot person
-    var largeIconPath = await _downloadAndSaveImage(
+    var largeIconPath = await _downloadAndSaveFile(
         'http://via.placeholder.com/48x48', 'largeIcon');
     // this person object will use an icon that was downloaded
     var lunchBot = Person(
@@ -941,27 +941,25 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _showNotificationWithAttachment() async {
-    var bigPicturePath = await _downloadAndSaveImage(
+    var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/600x200', 'bigPicture.jpg');
     var iOSPlatformChannelSpecifics = IOSNotificationDetails(
-        presentAlert: true,
-        presentSound: false,
-        presentBadge: false,
-        attachments: [IOSNotificationAttachment('id', bigPicturePath)]);
-    var bigPictureAndroidStyle = BigPictureStyleInformation(
-        bigPicturePath, BitmapSource.FilePath,
-        contentTitle: "Test Title", summaryText: "Test Subtitle");
+        attachments: [IOSNotificationAttachment(bigPicturePath)]);
+    var bigPictureAndroidStyle =
+        BigPictureStyleInformation(bigPicturePath, BitmapSource.FilePath);
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'andr_id', 'andr channel', 'andr channel for local pushes',
+        'your channel id', 'your channel name', 'your channel description',
         importance: Importance.High,
         priority: Priority.High,
-        ticker: 'ticker',
         style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureAndroidStyle);
     var notificationDetails = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
-        0, 'Simple title', 'Simple body', notificationDetails);
+        0,
+        'notification with attachment title',
+        'notification with attachment body',
+        notificationDetails);
   }
 
   String _toTwoDigitString(int value) {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -391,6 +391,12 @@ class _HomePageState extends State<HomePage> {
                       await _showNotificationWithoutTimestamp();
                     },
                   ),
+                  PaddedRaisedButton(
+                    buttonText: 'Show notification with attachment [iOS]',
+                    onPressed: () async {
+                      await _showNotificationWithAttachment();
+                    },
+                  ),
                 ],
               ),
             ),
@@ -932,6 +938,30 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(
         0, 'plain title', 'plain body', platformChannelSpecifics,
         payload: 'item x');
+  }
+
+  Future<void> _showNotificationWithAttachment() async {
+    var bigPicturePath = await _downloadAndSaveImage(
+        'http://via.placeholder.com/600x200', 'bigPicture.jpg');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails(
+        presentAlert: true,
+        presentSound: false,
+        presentBadge: false,
+        attachments: [IOSNotificationAttachment('id', bigPicturePath)]);
+    var bigPictureAndroidStyle = BigPictureStyleInformation(
+        bigPicturePath, BitmapSource.FilePath,
+        contentTitle: "Test Title", summaryText: "Test Subtitle");
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'fltr_id', 'flt channel', 'flr channel for local pushes',
+        importance: Importance.High,
+        priority: Priority.High,
+        ticker: 'ticker',
+        style: AndroidNotificationStyle.BigPicture,
+        styleInformation: bigPictureAndroidStyle);
+    var notificationDetails = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'Simple title', 'Simple body', notificationDetails);
   }
 
   String _toTwoDigitString(int value) {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -952,7 +952,7 @@ class _HomePageState extends State<HomePage> {
         bigPicturePath, BitmapSource.FilePath,
         contentTitle: "Test Title", summaryText: "Test Subtitle");
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'fltr_id', 'flt channel', 'flr channel for local pushes',
+        'andr_id', 'andr channel', 'andr channel for local pushes',
         importance: Importance.High,
         priority: Priority.High,
         ticker: 'ticker',

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -27,4 +27,3 @@ flutter:
 environment:
   sdk: ">=2.3.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"
-

--- a/flutter_local_notifications/ios/Classes/NotificationAttachment.h
+++ b/flutter_local_notifications/ios/Classes/NotificationAttachment.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NotificationAttachment : NSObject
+    @property(nonatomic, strong) NSString *identifier;
+    @property(nonatomic, strong) NSString *filePath;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/flutter_local_notifications/ios/Classes/NotificationAttachment.m
+++ b/flutter_local_notifications/ios/Classes/NotificationAttachment.m
@@ -1,10 +1,3 @@
-//
-//  NotificationAttachment.m
-//  flutter_local_notifications
-//
-//  Created by Pavel Sipaylo on 3/20/20.
-//
-
 #import "NotificationAttachment.h"
 
 @implementation NotificationAttachment

--- a/flutter_local_notifications/ios/Classes/NotificationAttachment.m
+++ b/flutter_local_notifications/ios/Classes/NotificationAttachment.m
@@ -1,0 +1,12 @@
+//
+//  NotificationAttachment.m
+//  flutter_local_notifications
+//
+//  Created by Pavel Sipaylo on 3/20/20.
+//
+
+#import "NotificationAttachment.h"
+
+@implementation NotificationAttachment
+
+@end

--- a/flutter_local_notifications/ios/Classes/NotificationDetails.h
+++ b/flutter_local_notifications/ios/Classes/NotificationDetails.h
@@ -1,10 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "NotificationTime.h"
+#import "NotificationAttachment.h"
 
 @interface NotificationDetails : NSObject
     @property(nonatomic, strong) NSNumber *id;
     @property(nonatomic, strong) NSString *title;
     @property(nonatomic, strong) NSString *body;
+    @property(nonatomic, strong) NSArray<NotificationAttachment *> *attachments;
     @property(nonatomic, strong) NSString *payload;
     @property(nonatomic) bool presentAlert;
     @property(nonatomic) bool presentSound;

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -17,6 +17,7 @@ export 'src/platform_specifics/android/message.dart';
 export 'src/platform_specifics/android/person.dart';
 export 'src/platform_specifics/ios/initialization_settings.dart';
 export 'src/platform_specifics/ios/notification_details.dart';
+export 'src/platform_specifics/ios/notification_attachment.dart';
 export 'src/notification_details.dart';
 export 'src/initialization_settings.dart';
 export 'src/flutter_local_notifications_plugin.dart';

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_attachment.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_attachment.dart
@@ -1,21 +1,28 @@
-
-/// Represents notification attachment for iOS
+/// Represents an attachment for an iOS notification.
 class IOSNotificationAttachment {
-  /// Identifier for the attachment.
-  final String identifier;
-
-  /// Local file path to the attachment.
+  /// The local file path to the attachment.
+  ///
+  /// See the documentation at https://developer.apple.com/documentation/usernotifications/unnotificationattachment?language=objc
+  /// for details on the supported file types and the file size restrictions.
   final String filePath;
 
-  IOSNotificationAttachment(this.identifier, this.filePath);
+  /// The unique identifier for the attachment.
+  ///
+  /// When left empty, the iOS APIs will generate a unique identifier
+  final String identifier;
+
+  const IOSNotificationAttachment(
+    this.filePath, {
+    this.identifier,
+  }) : assert(filePath != null);
 
   /// Create a [Map] object that describes the [IOSNotificationAttachment] object.
   ///
   /// Mainly for internal use to send the data over a platform channel.
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
-      'identifier': identifier,
-      'filePath': filePath
+      'identifier': identifier ?? '',
+      'filePath': filePath,
     };
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_attachment.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_attachment.dart
@@ -1,0 +1,21 @@
+
+/// Represents notification attachment for iOS
+class IOSNotificationAttachment {
+  /// Identifier for the attachment.
+  final String identifier;
+
+  /// Local file path to the attachment.
+  final String filePath;
+
+  IOSNotificationAttachment(this.identifier, this.filePath);
+
+  /// Create a [Map] object that describes the [IOSNotificationAttachment] object.
+  ///
+  /// Mainly for internal use to send the data over a platform channel.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'identifier': identifier,
+      'filePath': filePath
+    };
+  }
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
@@ -1,3 +1,5 @@
+import 'notification_attachment.dart';
+
 /// Configures the notification details on iOS.
 class IOSNotificationDetails {
   /// Display an alert when the notification is triggered while app is in the foreground.
@@ -26,13 +28,18 @@ class IOSNotificationDetails {
   /// Specify null to leave the current badge unchanged.
   final int badgeNumber;
 
-  IOSNotificationDetails({
-    this.presentAlert,
-    this.presentBadge,
-    this.presentSound,
-    this.sound,
-    this.badgeNumber,
-  });
+  /// Specifies the list of attachments that have to be included with the notification.
+  ///
+  /// Specify empty list or null to keep the notification without attachments
+  final List<IOSNotificationAttachment> attachments;
+
+  IOSNotificationDetails(
+      {this.presentAlert,
+      this.presentBadge,
+      this.presentSound,
+      this.sound,
+      this.badgeNumber,
+      this.attachments});
 
   /// Create a [Map] object that describes the [IOSNotificationDetails] object.
   ///
@@ -44,6 +51,9 @@ class IOSNotificationDetails {
       'presentBadge': presentBadge,
       'sound': sound,
       'badgeNumber': badgeNumber,
+      'attachments': attachments != null
+          ? attachments.map((a) => a.toMap()).toList()
+          : null
     };
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
@@ -28,18 +28,19 @@ class IOSNotificationDetails {
   /// Specify null to leave the current badge unchanged.
   final int badgeNumber;
 
-  /// Specifies the list of attachments that have to be included with the notification.
+  /// Specifies the list of attachments included with the notification.
   ///
-  /// Specify empty list or null to keep the notification without attachments
+  /// Applicable to iOS 10 and above.
   final List<IOSNotificationAttachment> attachments;
 
-  IOSNotificationDetails(
-      {this.presentAlert,
-      this.presentBadge,
-      this.presentSound,
-      this.sound,
-      this.badgeNumber,
-      this.attachments});
+  IOSNotificationDetails({
+    this.presentAlert,
+    this.presentBadge,
+    this.presentSound,
+    this.sound,
+    this.badgeNumber,
+    this.attachments,
+  });
 
   /// Create a [Map] object that describes the [IOSNotificationDetails] object.
   ///
@@ -51,9 +52,7 @@ class IOSNotificationDetails {
       'presentBadge': presentBadge,
       'sound': sound,
       'badgeNumber': badgeNumber,
-      'attachments': attachments != null
-          ? attachments.map((a) => a.toMap()).toList()
-          : null
+      'attachments': attachments?.map((a) => a.toMap())?.toList()
     };
   }
 }

--- a/flutter_local_notifications/test/flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/flutter_local_notifications_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -36,6 +37,16 @@ void main() {
   test('getNotificationAppLaunchDetails', () async {
     await mock.getNotificationAppLaunchDetails();
     verify(mock.getNotificationAppLaunchDetails());
+  });
+
+  test(
+      'Throws assertion error when creating an IOSNotificationAttachment with no file path',
+      () {
+    expect(() => IOSNotificationAttachment(null), throwsAssertionError);
+  });
+
+  test('Creates IOSNotificationAttachment when file path is specified', () {
+    expect(IOSNotificationAttachment(''), isA<IOSNotificationAttachment>());
   });
 }
 


### PR DESCRIPTION
This PR adds ability to pass attachments from Dart to the native iOS code and set them into UNNotificationContent of a new notification. 