### PR TITLE
[flutter_local_notifications] remove the need to specify certain enum properties for Android notifications

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -287,7 +287,6 @@ InboxStyleInformation inboxStyleInformation = InboxStyleInformation(
 AndroidNotificationDetails androidPlatformChannelSpecifics =
     AndroidNotificationDetails(
         groupChannelId, groupChannelName, groupChannelDescription,
-        style: NotificationStyleAndroid.Inbox,
         styleInformation: inboxStyleInformation,
         groupKey: groupKey,
         setAsGroupSummary: true);

--- a/flutter_local_notifications/example/analysis_options.yaml
+++ b/flutter_local_notifications/example/analysis_options.yaml
@@ -1,6 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-linter:
-  rules:
-    - camel_case_types
-    - unnecessary_new

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -456,9 +456,9 @@ class _HomePageState extends State<HomePage> {
         'your other channel name',
         'your other channel description',
         icon: 'secondary_icon',
-        sound: RawResourceAndroidNotificationSound('slow_spring_board'),
+        sound: AndroidRawResourceNotificationSound('slow_spring_board'),
         largeIcon: 'sample_large_icon',
-        largeIconBitmapSource: BitmapSource.Drawable,
+        largeIconBitmapSource: AndroidBitmapSource.Drawable,
         vibrationPattern: vibrationPattern,
         enableLights: true,
         color: const Color.fromARGB(255, 255, 0, 0),
@@ -496,7 +496,7 @@ class _HomePageState extends State<HomePage> {
     // this calls a method over a platform channel implemented within the example app to return the Uri for the default
     // alarm sound and uses as the notification sound
     String alarmUri = await platform.invokeMethod('getAlarmUri');
-    final x = UriAndroidNotificationSound(alarmUri);
+    final x = AndroidUriNotificationSound(alarmUri);
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'uri channel id', 'uri channel name', 'uri channel description',
         sound: x,
@@ -540,9 +540,8 @@ class _HomePageState extends State<HomePage> {
     var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
-        bigPicturePath, BitmapSource.FilePath,
-        largeIcon: largeIconPath,
-        largeIconBitmapSource: BitmapSource.FilePath,
+        AndroidFilePathBitmap(bigPicturePath),
+        largeIcon: AndroidFilePathBitmap(largeIconPath),
         contentTitle: 'overridden <b>big</b> content title',
         htmlFormatContentTitle: true,
         summaryText: 'summary <i>text</i>',
@@ -565,7 +564,7 @@ class _HomePageState extends State<HomePage> {
     var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
-        bigPicturePath, BitmapSource.FilePath,
+        AndroidFilePathBitmap(bigPicturePath),
         hideExpandedLargeIcon: true,
         contentTitle: 'overridden <b>big</b> content title',
         htmlFormatContentTitle: true,
@@ -576,7 +575,7 @@ class _HomePageState extends State<HomePage> {
         'big text channel name',
         'big text channel description',
         largeIcon: largeIconPath,
-        largeIconBitmapSource: BitmapSource.FilePath,
+        largeIconBitmapSource: AndroidBitmapSource.FilePath,
         style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureStyleInformation);
     var platformChannelSpecifics =
@@ -593,7 +592,7 @@ class _HomePageState extends State<HomePage> {
       'media channel name',
       'media channel description',
       largeIcon: largeIconPath,
-      largeIconBitmapSource: BitmapSource.FilePath,
+      largeIconBitmapSource: AndroidBitmapSource.FilePath,
       style: AndroidNotificationStyle.Media,
     );
     var platformChannelSpecifics =
@@ -971,7 +970,7 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails(
         attachments: [IOSNotificationAttachment(bigPicturePath)]);
     var bigPictureAndroidStyle =
-        BigPictureStyleInformation(bigPicturePath, BitmapSource.FilePath);
+        BigPictureStyleInformation(AndroidFilePathBitmap(bigPicturePath));
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'your channel id', 'your channel name', 'your channel description',
         importance: Importance.High,

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -457,8 +457,7 @@ class _HomePageState extends State<HomePage> {
         'your other channel description',
         icon: 'secondary_icon',
         sound: RawResourceAndroidNotificationSound('slow_spring_board'),
-        largeIcon: 'sample_large_icon',
-        largeIconBitmapSource: AndroidBitmapSource.Drawable,
+        largeIcon: DrawableResourceAndroidBitmap('sample_large_icon'),
         vibrationPattern: vibrationPattern,
         enableLights: true,
         color: const Color.fromARGB(255, 255, 0, 0),
@@ -574,8 +573,7 @@ class _HomePageState extends State<HomePage> {
         'big text channel id',
         'big text channel name',
         'big text channel description',
-        largeIcon: largeIconPath,
-        largeIconBitmapSource: AndroidBitmapSource.FilePath,
+        largeIcon: FilePathAndroidBitmap(largeIconPath),
         style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureStyleInformation);
     var platformChannelSpecifics =
@@ -591,8 +589,7 @@ class _HomePageState extends State<HomePage> {
       'media channel id',
       'media channel name',
       'media channel description',
-      largeIcon: largeIconPath,
-      largeIconBitmapSource: AndroidBitmapSource.FilePath,
+      largeIcon: FilePathAndroidBitmap(largeIconPath),
       style: AndroidNotificationStyle.Media,
     );
     var platformChannelSpecifics =

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -648,27 +648,27 @@ class _HomePageState extends State<HomePage> {
     var messages = List<Message>();
     // First two person objects will use icons that part of the Android app's drawable resources
     var me = Person(
-        name: 'Me',
-        key: '1',
-        uri: 'tel:1234567890',
-        icon: 'me',
-        iconSource: IconSource.Drawable);
+      name: 'Me',
+      key: '1',
+      uri: 'tel:1234567890',
+      icon: AndroidDrawableResourceIcon('me'),
+    );
     var coworker = Person(
-        name: 'Coworker',
-        key: '2',
-        uri: 'tel:9876543210',
-        icon: 'icons/coworker.png',
-        iconSource: IconSource.BitmapAsset);
+      name: 'Coworker',
+      key: '2',
+      uri: 'tel:9876543210',
+      icon: AndroidBitmapAssetIcon('icons/coworker.png'),
+    );
     // download the icon that would be use for the lunch bot person
     var largeIconPath = await _downloadAndSaveFile(
         'http://via.placeholder.com/48x48', 'largeIcon');
     // this person object will use an icon that was downloaded
     var lunchBot = Person(
-        name: 'Lunch bot',
-        key: 'bot',
-        bot: true,
-        icon: largeIconPath,
-        iconSource: IconSource.BitmapFilePath);
+      name: 'Lunch bot',
+      key: 'bot',
+      bot: true,
+      icon: AndroidBitmapFilePathIcon(largeIconPath),
+    );
     messages.add(Message('Hi', DateTime.now(), null));
     messages.add(Message(
         'What\'s up?', DateTime.now().add(Duration(minutes: 5)), coworker));

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -549,7 +549,6 @@ class _HomePageState extends State<HomePage> {
         'big text channel id',
         'big text channel name',
         'big text channel description',
-        style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureStyleInformation);
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -574,7 +573,6 @@ class _HomePageState extends State<HomePage> {
         'big text channel name',
         'big text channel description',
         largeIcon: FilePathAndroidBitmap(largeIconPath),
-        style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureStyleInformation);
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -590,7 +588,6 @@ class _HomePageState extends State<HomePage> {
       'media channel name',
       'media channel description',
       largeIcon: FilePathAndroidBitmap(largeIconPath),
-      style: AndroidNotificationStyle.Media,
     );
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -610,7 +607,6 @@ class _HomePageState extends State<HomePage> {
         'big text channel id',
         'big text channel name',
         'big text channel description',
-        style: AndroidNotificationStyle.BigText,
         styleInformation: bigTextStyleInformation);
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -630,7 +626,6 @@ class _HomePageState extends State<HomePage> {
         htmlFormatSummaryText: true);
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'inbox channel id', 'inboxchannel name', 'inbox channel description',
-        style: AndroidNotificationStyle.Inbox,
         styleInformation: inboxStyleInformation);
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -685,7 +680,6 @@ class _HomePageState extends State<HomePage> {
         'message channel name',
         'message channel description',
         category: 'msg',
-        style: AndroidNotificationStyle.Messaging,
         styleInformation: messagingStyle);
     var platformChannelSpecifics =
         NotificationDetails(androidPlatformChannelSpecifics, null);
@@ -738,7 +732,6 @@ class _HomePageState extends State<HomePage> {
         contentTitle: '2 messages', summaryText: 'janedoe@example.com');
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         groupChannelId, groupChannelName, groupChannelDescription,
-        style: AndroidNotificationStyle.Inbox,
         styleInformation: inboxStyleInformation,
         groupKey: groupKey,
         setAsGroupSummary: true);
@@ -972,7 +965,6 @@ class _HomePageState extends State<HomePage> {
         'your channel id', 'your channel name', 'your channel description',
         importance: Importance.High,
         priority: Priority.High,
-        style: AndroidNotificationStyle.BigPicture,
         styleInformation: bigPictureAndroidStyle);
     var notificationDetails = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -456,7 +456,7 @@ class _HomePageState extends State<HomePage> {
         'your other channel name',
         'your other channel description',
         icon: 'secondary_icon',
-        sound: AndroidRawResourceNotificationSound('slow_spring_board'),
+        sound: RawResourceAndroidNotificationSound('slow_spring_board'),
         largeIcon: 'sample_large_icon',
         largeIconBitmapSource: AndroidBitmapSource.Drawable,
         vibrationPattern: vibrationPattern,
@@ -496,7 +496,7 @@ class _HomePageState extends State<HomePage> {
     // this calls a method over a platform channel implemented within the example app to return the Uri for the default
     // alarm sound and uses as the notification sound
     String alarmUri = await platform.invokeMethod('getAlarmUri');
-    final x = AndroidUriNotificationSound(alarmUri);
+    final x = UriAndroidNotificationSound(alarmUri);
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'uri channel id', 'uri channel name', 'uri channel description',
         sound: x,
@@ -540,8 +540,8 @@ class _HomePageState extends State<HomePage> {
     var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
-        AndroidFilePathBitmap(bigPicturePath),
-        largeIcon: AndroidFilePathBitmap(largeIconPath),
+        FilePathAndroidBitmap(bigPicturePath),
+        largeIcon: FilePathAndroidBitmap(largeIconPath),
         contentTitle: 'overridden <b>big</b> content title',
         htmlFormatContentTitle: true,
         summaryText: 'summary <i>text</i>',
@@ -564,7 +564,7 @@ class _HomePageState extends State<HomePage> {
     var bigPicturePath = await _downloadAndSaveFile(
         'http://via.placeholder.com/400x800', 'bigPicture');
     var bigPictureStyleInformation = BigPictureStyleInformation(
-        AndroidFilePathBitmap(bigPicturePath),
+        FilePathAndroidBitmap(bigPicturePath),
         hideExpandedLargeIcon: true,
         contentTitle: 'overridden <b>big</b> content title',
         htmlFormatContentTitle: true,
@@ -651,13 +651,13 @@ class _HomePageState extends State<HomePage> {
       name: 'Me',
       key: '1',
       uri: 'tel:1234567890',
-      icon: AndroidDrawableResourceIcon('me'),
+      icon: DrawableResourceAndroidIcon('me'),
     );
     var coworker = Person(
       name: 'Coworker',
       key: '2',
       uri: 'tel:9876543210',
-      icon: AndroidBitmapAssetIcon('icons/coworker.png'),
+      icon: BitmapAssetAndroidIcon('icons/coworker.png'),
     );
     // download the icon that would be use for the lunch bot person
     var largeIconPath = await _downloadAndSaveFile(
@@ -667,7 +667,7 @@ class _HomePageState extends State<HomePage> {
       name: 'Lunch bot',
       key: 'bot',
       bot: true,
-      icon: AndroidBitmapFilePathIcon(largeIconPath),
+      icon: BitmapFilePathAndroidIcon(largeIconPath),
     );
     messages.add(Message('Hi', DateTime.now(), null));
     messages.add(Message(
@@ -970,7 +970,7 @@ class _HomePageState extends State<HomePage> {
     var iOSPlatformChannelSpecifics = IOSNotificationDetails(
         attachments: [IOSNotificationAttachment(bigPicturePath)]);
     var bigPictureAndroidStyle =
-        BigPictureStyleInformation(AndroidFilePathBitmap(bigPicturePath));
+        BigPictureStyleInformation(FilePathAndroidBitmap(bigPicturePath));
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'your channel id', 'your channel name', 'your channel description',
         importance: Importance.High,

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -12,7 +12,7 @@ export 'src/platform_specifics/android/styles/inbox_style_information.dart';
 export 'src/platform_specifics/android/styles/messaging_style_information.dart';
 export 'src/platform_specifics/android/bitmap.dart' hide AndroidBitmap;
 export 'src/platform_specifics/android/enums.dart'
-    hide AndroidNotificationSoundSource, AndroidIconSource;
+    hide AndroidBitmapSource, AndroidIconSource, AndroidNotificationSoundSource;
 export 'src/platform_specifics/android/icon.dart' hide AndroidIcon;
 export 'src/platform_specifics/android/initialization_settings.dart';
 export 'src/platform_specifics/android/notification_details.dart';

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -10,6 +10,7 @@ export 'src/platform_specifics/android/styles/big_text_style_information.dart';
 export 'src/platform_specifics/android/styles/big_picture_style_information.dart';
 export 'src/platform_specifics/android/styles/inbox_style_information.dart';
 export 'src/platform_specifics/android/styles/messaging_style_information.dart';
+export 'src/platform_specifics/android/bitmap.dart' hide AndroidBitmap;
 export 'src/platform_specifics/android/enums.dart'
     hide AndroidNotificationSoundSource;
 export 'src/platform_specifics/android/initialization_settings.dart';

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -12,7 +12,8 @@ export 'src/platform_specifics/android/styles/inbox_style_information.dart';
 export 'src/platform_specifics/android/styles/messaging_style_information.dart';
 export 'src/platform_specifics/android/bitmap.dart' hide AndroidBitmap;
 export 'src/platform_specifics/android/enums.dart'
-    hide AndroidNotificationSoundSource;
+    hide AndroidNotificationSoundSource, AndroidIconSource;
+export 'src/platform_specifics/android/icon.dart' hide AndroidIcon;
 export 'src/platform_specifics/android/initialization_settings.dart';
 export 'src/platform_specifics/android/notification_details.dart';
 export 'src/platform_specifics/android/message.dart';

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -10,7 +10,7 @@ export 'src/platform_specifics/android/styles/big_text_style_information.dart';
 export 'src/platform_specifics/android/styles/big_picture_style_information.dart';
 export 'src/platform_specifics/android/styles/inbox_style_information.dart';
 export 'src/platform_specifics/android/styles/messaging_style_information.dart';
-export 'src/platform_specifics/android/bitmap.dart' hide AndroidBitmap;
+export 'src/platform_specifics/android/bitmap.dart';
 export 'src/platform_specifics/android/enums.dart'
     hide AndroidBitmapSource, AndroidIconSource, AndroidNotificationSoundSource;
 export 'src/platform_specifics/android/icon.dart' hide AndroidIcon;
@@ -18,8 +18,7 @@ export 'src/platform_specifics/android/initialization_settings.dart';
 export 'src/platform_specifics/android/notification_details.dart';
 export 'src/platform_specifics/android/message.dart';
 export 'src/platform_specifics/android/person.dart';
-export 'src/platform_specifics/android/notification_sound.dart'
-    hide AndroidNotificationSound;
+export 'src/platform_specifics/android/notification_sound.dart';
 export 'src/platform_specifics/ios/initialization_settings.dart';
 export 'src/platform_specifics/ios/notification_details.dart';
 export 'src/platform_specifics/ios/notification_attachment.dart';

--- a/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
@@ -1,0 +1,29 @@
+/// Represents a bitmap on Android.
+abstract class AndroidBitmap {
+  /// The location of the bitmap.
+  String get bitmap;
+}
+
+/// Represents a bitmap on Android that is a drawable resource belonging to an Android application.
+class AndroidDrawableResourceBitmap extends AndroidBitmap {
+  AndroidDrawableResourceBitmap(this._bitmap);
+
+  final String _bitmap;
+
+  /// The name of the drawable resource.
+  ///
+  /// For example if the drawable resource is located at `res/drawable/app_icon.png`, the bitmap should be `app_icon`
+  @override
+  String get bitmap => _bitmap;
+}
+
+/// Used to represent a file path on the Android device that contains a bitmap
+class AndroidFilePathBitmap extends AndroidBitmap {
+  AndroidFilePathBitmap(this._bitmap);
+
+  final String _bitmap;
+
+  /// A file path on the Android device that refers to the location of the bitmap.
+  @override
+  String get bitmap => _bitmap;
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
@@ -4,9 +4,9 @@ abstract class AndroidBitmap {
   String get bitmap;
 }
 
-/// Represents a bitmap on Android that is a drawable resource belonging to an Android application.
-class AndroidDrawableResourceBitmap extends AndroidBitmap {
-  AndroidDrawableResourceBitmap(this._bitmap);
+/// Represents a drawable resource belonging to the Android application that should be used as a bitmap on Android.
+class DrawableResourceAndroidBitmap extends AndroidBitmap {
+  DrawableResourceAndroidBitmap(this._bitmap);
 
   final String _bitmap;
 
@@ -17,9 +17,9 @@ class AndroidDrawableResourceBitmap extends AndroidBitmap {
   String get bitmap => _bitmap;
 }
 
-/// Represents a bitmap on Android that can be referenced to using a file path.
-class AndroidFilePathBitmap extends AndroidBitmap {
-  AndroidFilePathBitmap(this._bitmap);
+/// Represents a file path that should be used for a bitmap on Android.
+class FilePathAndroidBitmap extends AndroidBitmap {
+  FilePathAndroidBitmap(this._bitmap);
 
   final String _bitmap;
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/bitmap.dart
@@ -17,7 +17,7 @@ class AndroidDrawableResourceBitmap extends AndroidBitmap {
   String get bitmap => _bitmap;
 }
 
-/// Used to represent a file path on the Android device that contains a bitmap
+/// Represents a bitmap on Android that can be referenced to using a file path.
 class AndroidFilePathBitmap extends AndroidBitmap {
   AndroidFilePathBitmap(this._bitmap);
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -2,7 +2,12 @@
 enum AndroidBitmapSource { Drawable, FilePath }
 
 /// Specifies the source for icons.
-enum IconSource { Drawable, BitmapFilePath, ContentUri, BitmapAsset }
+enum AndroidIconSource {
+  DrawableResource,
+  BitmapFilePath,
+  ContentUri,
+  BitmapAsset
+}
 
 /// The available notification styles on Android.
 enum AndroidNotificationStyle {

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -1,5 +1,5 @@
 /// Specifies the source for a bitmap used by Android notifications.
-enum BitmapSource { Drawable, FilePath }
+enum AndroidBitmapSource { Drawable, FilePath }
 
 /// Specifies the source for icons.
 enum IconSource { Drawable, BitmapFilePath, ContentUri, BitmapAsset }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
@@ -4,9 +4,9 @@ abstract class AndroidIcon {
   String get icon;
 }
 
-/// Represents an icon on Android that is a drawable resource belonging to an Android application.
-class AndroidDrawableResourceIcon extends AndroidIcon {
-  AndroidDrawableResourceIcon(this._icon);
+/// Represents a drawable resource belonging to the Android application that should be used as an icon on Android.
+class DrawableResourceAndroidIcon extends AndroidIcon {
+  DrawableResourceAndroidIcon(this._icon);
 
   final String _icon;
 
@@ -17,9 +17,9 @@ class AndroidDrawableResourceIcon extends AndroidIcon {
   String get icon => _icon;
 }
 
-/// Represents a bitmap icon on Android that can be referenced to using a file path.
-class AndroidBitmapFilePathIcon extends AndroidIcon {
-  AndroidBitmapFilePathIcon(this._icon);
+/// Represents a file path to a bitmap that should be used for as an icon on Android.
+class BitmapFilePathAndroidIcon extends AndroidIcon {
+  BitmapFilePathAndroidIcon(this._icon);
 
   final String _icon;
 
@@ -28,9 +28,9 @@ class AndroidBitmapFilePathIcon extends AndroidIcon {
   String get icon => _icon;
 }
 
-/// Represents an icon on Android that can be referenced to using a content URI.
-class AndroidContentUriIcon extends AndroidIcon {
-  AndroidContentUriIcon(this._icon);
+/// Represents a content URI that should be used for as an icon on Android.
+class ContentUriAndroidIcon extends AndroidIcon {
+  ContentUriAndroidIcon(this._icon);
 
   final String _icon;
 
@@ -39,9 +39,9 @@ class AndroidContentUriIcon extends AndroidIcon {
   String get icon => _icon;
 }
 
-/// Represents an bitmap icon on Android that can be referenced to using a path to a Flutter asset.
-class AndroidBitmapAssetIcon extends AndroidIcon {
-  AndroidBitmapAssetIcon(this._icon);
+/// Represents a bitmap asset belonging to the Flutter application that should be used for as an icon on Android.
+class BitmapAssetAndroidIcon extends AndroidIcon {
+  BitmapAssetAndroidIcon(this._icon);
 
   final String _icon;
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
@@ -1,0 +1,60 @@
+/// Represents an icon on Android.
+abstract class AndroidIcon {
+  /// The location to the icon;
+  String get icon;
+}
+
+/// Represents an icon on Android that is a drawable resource belonging to an Android application.
+class AndroidDrawableResourceIcon extends AndroidIcon {
+  AndroidDrawableResourceIcon(this._icon);
+
+  final String _icon;
+
+  /// The name of the drawable resource.
+  ///
+  /// For example if the drawable resource is located at `res/drawable/app_icon.png`, the icon should be `app_icon`
+  @override
+  String get icon => _icon;
+}
+
+/// Represents a bitmap icon on Android that can be referenced to using a file path.
+class AndroidBitmapFilePathIcon extends AndroidIcon {
+  AndroidBitmapFilePathIcon(this._icon);
+
+  final String _icon;
+
+  /// A file path on the Android device that refers to the location of the icon.
+  @override
+  String get icon => _icon;
+}
+
+/// Represents an icon on Android that can be referenced to using a content URI.
+class AndroidContentUriIcon extends AndroidIcon {
+  AndroidContentUriIcon(this._icon);
+
+  final String _icon;
+
+  /// A content URI that refers to the location of the icon.
+  @override
+  String get icon => _icon;
+}
+
+/// Represents an bitmap icon on Android that can be referenced to using a path to a Flutter asset.
+class AndroidBitmapAssetIcon extends AndroidIcon {
+  AndroidBitmapAssetIcon(this._icon);
+
+  final String _icon;
+
+  /// Path to the Flutter asset that refers to the location of the icon.
+  ///
+  /// For example, if the following asset is declared in the Flutter application's `pubspec.yaml` file
+  ///
+  /// ```
+  /// assets:
+  ///   - icons/coworker.png
+  /// ```
+  ///
+  /// then the path to the asset would be `icons/coworker.png`.
+  @override
+  String get icon => _icon;
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'bitmap.dart';
 import 'enums.dart';
 import 'notification_sound.dart';
 import 'styles/style_information.dart';
@@ -94,11 +95,8 @@ class AndroidNotificationDetails {
   /// Sets the color.
   Color color;
 
-  /// Specifics the large icon to use. This will be either the name of the drawable of an actual file path based on the value of [largeIconBitmapSource].
-  String largeIcon;
-
-  /// Specifies the source for the large icon.
-  AndroidBitmapSource largeIconBitmapSource;
+  /// Specifics the large icon to use.
+  AndroidBitmap largeIcon;
 
   /// Specifies if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.
   bool onlyAlertOnce;
@@ -172,7 +170,6 @@ class AndroidNotificationDetails {
     this.ongoing,
     this.color,
     this.largeIcon,
-    this.largeIconBitmapSource,
     this.onlyAlertOnce,
     this.showWhen = true,
     this.channelShowBadge = true,
@@ -220,8 +217,6 @@ class AndroidNotificationDetails {
       'colorRed': color?.red,
       'colorGreen': color?.green,
       'colorBlue': color?.blue,
-      'largeIcon': largeIcon,
-      'largeIconBitmapSource': largeIconBitmapSource?.index,
       'onlyAlertOnce': onlyAlertOnce,
       'showWhen': showWhen,
       'showProgress': showProgress,
@@ -239,7 +234,25 @@ class AndroidNotificationDetails {
       'visibility': visibility?.index,
       'timeoutAfter': timeoutAfter,
       'category': category
-    }..addAll(_convertSoundToMap());
+    }
+      ..addAll(_convertSoundToMap())
+      ..addAll(_convertLargeIconToMap());
+  }
+
+  Map<String, dynamic> _convertLargeIconToMap() {
+    if (largeIcon is DrawableResourceAndroidBitmap) {
+      return <String, dynamic>{
+        'largeIcon': largeIcon.bitmap,
+        'largeIconBitmapSource': AndroidBitmapSource.Drawable.index,
+      };
+    } else if (largeIcon is FilePathAndroidBitmap) {
+      return <String, dynamic>{
+        'largeIcon': largeIcon.bitmap,
+        'largeIconBitmapSource': AndroidBitmapSource.FilePath.index,
+      };
+    } else {
+      return <String, dynamic>{};
+    }
   }
 
   Map<String, dynamic> _convertSoundToMap() {

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -98,7 +98,7 @@ class AndroidNotificationDetails {
   String largeIcon;
 
   /// Specifies the source for the large icon.
-  BitmapSource largeIconBitmapSource;
+  AndroidBitmapSource largeIconBitmapSource;
 
   /// Specifies if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.
   bool onlyAlertOnce;
@@ -243,12 +243,12 @@ class AndroidNotificationDetails {
   }
 
   Map<String, dynamic> _convertSoundToMap() {
-    if (sound is RawResourceAndroidNotificationSound) {
+    if (sound is AndroidRawResourceNotificationSound) {
       return <String, dynamic>{
         'sound': sound.sound,
         'soundSource': AndroidNotificationSoundSource.RawResource.index,
       };
-    } else if (sound is UriAndroidNotificationSound) {
+    } else if (sound is AndroidUriNotificationSound) {
       return <String, dynamic>{
         'sound': sound.sound,
         'soundSource': AndroidNotificationSoundSource.Uri.index,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -243,12 +243,12 @@ class AndroidNotificationDetails {
   }
 
   Map<String, dynamic> _convertSoundToMap() {
-    if (sound is AndroidRawResourceNotificationSound) {
+    if (sound is RawResourceAndroidNotificationSound) {
       return <String, dynamic>{
         'sound': sound.sound,
         'soundSource': AndroidNotificationSoundSource.RawResource.index,
       };
-    } else if (sound is AndroidUriNotificationSound) {
+    } else if (sound is UriAndroidNotificationSound) {
       return <String, dynamic>{
         'sound': sound.sound,
         'soundSource': AndroidNotificationSoundSource.Uri.index,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -4,6 +4,11 @@ import 'dart:ui';
 import 'bitmap.dart';
 import 'enums.dart';
 import 'notification_sound.dart';
+import 'styles/big_picture_style_information.dart';
+import 'styles/big_text_style_information.dart';
+import 'styles/inbox_style_information.dart';
+import 'styles/media_style_information.dart';
+import 'styles/messaging_style_information.dart';
 import 'styles/style_information.dart';
 import 'styles/default_style_information.dart';
 
@@ -33,122 +38,119 @@ class AndroidNotificationDetails {
   final bool channelShowBadge;
 
   /// The importance of the notification.
-  Importance importance;
+  final Importance importance;
 
   /// The priority of the notification
-  Priority priority;
+  final Priority priority;
 
   /// Indicates if a sound should be played when the notification is displayed.
   ///
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  bool playSound;
+  final bool playSound;
 
   /// The sound to play for the notification.
   ///
   /// Requires setting [playSound] to true for it to work.
   /// If [playSound] is set to true but this is not specified then the default sound is played.
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  AndroidNotificationSound sound;
+  final AndroidNotificationSound sound;
 
   /// Indicates if vibration should be enabled when the notification is displayed.
   ///
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  bool enableVibration;
+  final bool enableVibration;
 
   /// Indicates if lights should be enabled when the notification is displayed.
   ///
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  bool enableLights;
+  final bool enableLights;
 
   /// Configures the vibration pattern.
   ///
   /// Requires setting [enableVibration] to true for it to work.
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  Int64List vibrationPattern;
+  final Int64List vibrationPattern;
 
-  /// Defines the notification style.
-  AndroidNotificationStyle style;
-
-  /// Contains extra information for the specified notification [style].
-  StyleInformation styleInformation;
+  /// Specifies the information of the rich notification style to apply to the notification.
+  final StyleInformation styleInformation;
 
   /// Specifies the group that this notification belongs to.
   ///
   /// For Android 7.0+ (API level 24)
-  String groupKey;
+  final String groupKey;
 
   /// Specifies if this notification will function as the summary for grouped notifications.
-  bool setAsGroupSummary;
+  final bool setAsGroupSummary;
 
   /// Sets the group alert behavior for this notification.
   ///
   /// Default is AlertAll.
   /// See https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder.html#setGroupAlertBehavior(int) for more details.
-  GroupAlertBehavior groupAlertBehavior;
+  final GroupAlertBehavior groupAlertBehavior;
 
   /// Specifies if the notification should automatically dismissed upon tapping on it.
-  bool autoCancel;
+  final bool autoCancel;
 
   /// Specifies if the notification will be "ongoing".
-  bool ongoing;
+  final bool ongoing;
 
   /// Sets the color.
-  Color color;
+  final Color color;
 
   /// Specifics the large icon to use.
-  AndroidBitmap largeIcon;
+  final AndroidBitmap largeIcon;
 
   /// Specifies if you would only like the sound, vibrate and ticker to be played if the notification is not already showing.
-  bool onlyAlertOnce;
+  final bool onlyAlertOnce;
 
   /// Specifies if the notification should display the timestamp of when it occurred.
-  bool showWhen;
+  final bool showWhen;
 
   /// Specifies if the notification will be used to show progress.
-  bool showProgress;
+  final bool showProgress;
 
   /// The maximum progress value.
-  int maxProgress;
+  final int maxProgress;
 
   /// The current progress value.
-  int progress;
+  final int progress;
 
   /// Specifies if an indeterminate progress bar will be shown.
-  bool indeterminate;
+  final bool indeterminate;
 
   /// Sets the light color of the notification.
   ///
   /// For Android 8.0+, this is tied to the specified channel cannot be changed afterward the channel has been created for the first time.
-  Color ledColor;
+  final Color ledColor;
 
   /// Sets how long the light colour will remain on.
   ///
   /// Not applicable for Android 8.0+
-  int ledOnMs;
+  final int ledOnMs;
 
   /// Sets how long the light colour will remain off.
   ///
   /// Not applicable for Android 8.0+
-  int ledOffMs;
+  final int ledOffMs;
 
   /// Set the "ticker" text which is sent to accessibility services.
-  String ticker;
+  final String ticker;
 
   /// The action to take for managing notification channels.
   ///
   /// Defaults to creating the notification channel using the provided details if it doesn't exist
-  AndroidNotificationChannelAction channelAction;
+  final AndroidNotificationChannelAction channelAction;
 
   /// Defines the notification visibility on the lockscreen
-  NotificationVisibility visibility;
+  final NotificationVisibility visibility;
 
   /// The duration in milliseconds after which the notification will be cancelled if it hasn't already
-  int timeoutAfter;
+  final int timeoutAfter;
 
   /// The notification category.
   ///
   /// Refer to Android notification API documentation at https://developer.android.com/reference/androidx/core/app/NotificationCompat.html#constants_2 for the available categories
-  String category;
+  final String category;
 
   AndroidNotificationDetails(
     this.channelId,
@@ -157,7 +159,6 @@ class AndroidNotificationDetails {
     this.icon,
     this.importance = Importance.Default,
     this.priority = Priority.Default,
-    this.style = AndroidNotificationStyle.Default,
     this.styleInformation,
     this.playSound = true,
     this.sound,
@@ -204,10 +205,6 @@ class AndroidNotificationDetails {
       'playSound': playSound,
       'enableVibration': enableVibration,
       'vibrationPattern': vibrationPattern,
-      'style': style.index,
-      'styleInformation': styleInformation == null
-          ? DefaultStyleInformation(false, false).toMap()
-          : styleInformation.toMap(),
       'groupKey': groupKey,
       'setAsGroupSummary': setAsGroupSummary,
       'groupAlertBehavior': groupAlertBehavior.index,
@@ -235,8 +232,48 @@ class AndroidNotificationDetails {
       'timeoutAfter': timeoutAfter,
       'category': category
     }
+      ..addAll(_convertStyleInformationToMap())
       ..addAll(_convertSoundToMap())
       ..addAll(_convertLargeIconToMap());
+  }
+
+  Map<String, dynamic> _convertStyleInformationToMap() {
+    if (styleInformation is BigPictureStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.BigPicture.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else if (styleInformation is BigTextStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.BigText.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else if (styleInformation is InboxStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.Inbox.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else if (styleInformation is MessagingStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.Messaging.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else if (styleInformation is MediaStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.Media.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else if (styleInformation is DefaultStyleInformation) {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.Default.index,
+        'styleInformation': styleInformation.toMap(),
+      };
+    } else {
+      return <String, dynamic>{
+        'style': AndroidNotificationStyle.Default.index,
+        'styleInformation': DefaultStyleInformation(false, false).toMap(),
+      };
+    }
   }
 
   Map<String, dynamic> _convertLargeIconToMap() {

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
@@ -1,14 +1,14 @@
 /// Represents an Android notification sound.
 abstract class AndroidNotificationSound {
-  /// The location of the sound
+  /// The location of the sound.
   String get sound;
 }
 
-/// Used when a notification sound is a raw resource belonging to the Android application.
+/// Represents a notification sound that is a raw resource belonging to the Android application.
 ///
 /// These resources would be found in the `res/raw` directory of the Android application
-class RawResourceAndroidNotificationSound implements AndroidNotificationSound {
-  RawResourceAndroidNotificationSound(this._sound);
+class AndroidRawResourceNotificationSound implements AndroidNotificationSound {
+  AndroidRawResourceNotificationSound(this._sound);
 
   final String _sound;
 
@@ -17,12 +17,12 @@ class RawResourceAndroidNotificationSound implements AndroidNotificationSound {
   String get sound => _sound;
 }
 
-/// Used when a notification sound that is on the Android device that is represented by a URI.
+/// Represents a notification sound that is on the Android device that is represented by a URI.
 ///
 /// One way of obtaining such URIs is to use the native Android RingtoneManager APIs,
 /// which may require developers to write their own to access the API.
-class UriAndroidNotificationSound implements AndroidNotificationSound {
-  UriAndroidNotificationSound(this._sound);
+class AndroidUriNotificationSound implements AndroidNotificationSound {
+  AndroidUriNotificationSound(this._sound);
 
   final String _sound;
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
@@ -4,11 +4,11 @@ abstract class AndroidNotificationSound {
   String get sound;
 }
 
-/// Represents a notification sound that is a raw resource belonging to the Android application.
+/// Represents a raw resource belonging to the Android application that should be used for the notification sound.
 ///
 /// These resources would be found in the `res/raw` directory of the Android application
-class AndroidRawResourceNotificationSound implements AndroidNotificationSound {
-  AndroidRawResourceNotificationSound(this._sound);
+class RawResourceAndroidNotificationSound implements AndroidNotificationSound {
+  RawResourceAndroidNotificationSound(this._sound);
 
   final String _sound;
 
@@ -17,12 +17,12 @@ class AndroidRawResourceNotificationSound implements AndroidNotificationSound {
   String get sound => _sound;
 }
 
-/// Represents a notification sound that is on the Android device that is represented by a URI.
+/// Represents a URI on the Android device that should be used for the notification sound.
 ///
 /// One way of obtaining such URIs is to use the native Android RingtoneManager APIs,
 /// which may require developers to write their own to access the API.
-class AndroidUriNotificationSound implements AndroidNotificationSound {
-  AndroidUriNotificationSound(this._sound);
+class UriAndroidNotificationSound implements AndroidNotificationSound {
+  UriAndroidNotificationSound(this._sound);
 
   final String _sound;
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
@@ -45,22 +45,22 @@ class Person {
   }
 
   Map<String, dynamic> _convertIconToMap() {
-    if (icon is AndroidDrawableResourceIcon) {
+    if (icon is DrawableResourceAndroidIcon) {
       return <String, dynamic>{
         'icon': icon.icon,
         'iconSource': AndroidIconSource.DrawableResource.index,
       };
-    } else if (icon is AndroidBitmapFilePathIcon) {
+    } else if (icon is BitmapFilePathAndroidIcon) {
       return <String, dynamic>{
         'icon': icon.icon,
         'iconSource': AndroidIconSource.BitmapFilePath.index,
       };
-    } else if (icon is AndroidContentUriIcon) {
+    } else if (icon is ContentUriAndroidIcon) {
       return <String, dynamic>{
         'icon': icon.icon,
         'iconSource': AndroidIconSource.ContentUri.index,
       };
-    } else if (icon is AndroidBitmapAssetIcon) {
+    } else if (icon is BitmapAssetAndroidIcon) {
       return <String, dynamic>{
         'icon': icon.icon,
         'iconSource': AndroidIconSource.BitmapAsset.index,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_local_notifications/src/platform_specifics/android/icon.dart';
+
 import 'enums.dart';
 
 /// Details of a person e.g. someone who sent a message.
@@ -6,10 +8,7 @@ class Person {
   final bool bot;
 
   /// Icon for this person.
-  final String icon;
-
-  /// Determines how the icon should be interpreted/resolved e.g. as a drawable.
-  final IconSource iconSource;
+  final AndroidIcon icon;
 
   /// Whether or not this is an important person.
   final bool important;
@@ -26,25 +25,48 @@ class Person {
   Person({
     this.bot,
     this.icon,
-    this.iconSource,
     this.important,
     this.key,
     this.name,
     this.uri,
   });
 
-  /// Create a [Map] object that describes the [Person] object.
+  /// Creates a [Map] object that describes the [Person] object.
   ///
   /// Mainly for internal use to send the data over a platform channel.
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
       'bot': bot,
-      'icon': icon,
-      'iconSource': iconSource?.index,
       'important': important,
       'key': key,
       'name': name,
       'uri': uri
-    };
+    }..addAll(_convertIconToMap());
+  }
+
+  Map<String, dynamic> _convertIconToMap() {
+    if (icon is AndroidDrawableResourceIcon) {
+      return <String, dynamic>{
+        'icon': icon.icon,
+        'iconSource': AndroidIconSource.DrawableResource.index,
+      };
+    } else if (icon is AndroidBitmapFilePathIcon) {
+      return <String, dynamic>{
+        'icon': icon.icon,
+        'iconSource': AndroidIconSource.BitmapFilePath.index,
+      };
+    } else if (icon is AndroidContentUriIcon) {
+      return <String, dynamic>{
+        'icon': icon.icon,
+        'iconSource': AndroidIconSource.ContentUri.index,
+      };
+    } else if (icon is AndroidBitmapAssetIcon) {
+      return <String, dynamic>{
+        'icon': icon.icon,
+        'iconSource': AndroidIconSource.BitmapAsset.index,
+      };
+    } else {
+      return <String, dynamic>{};
+    }
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
@@ -68,8 +68,9 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
         'bigPicture': bigPicture.bitmap,
         'bigPictureBitmapSource': AndroidBitmapSource.FilePath.index,
       };
+    } else {
+      return <String, dynamic>{};
     }
-    return <String, dynamic>{};
   }
 
   Map<String, dynamic> _convertLargeIconToMap() {
@@ -83,7 +84,8 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
         'largeIcon': largeIcon.bitmap,
         'largeIconBitmapSource': AndroidBitmapSource.FilePath.index,
       };
+    } else {
+      return <String, dynamic>{};
     }
-    return <String, dynamic>{};
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
@@ -58,12 +58,12 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
   }
 
   Map<String, dynamic> _convertBigPictureToMap() {
-    if (bigPicture is AndroidDrawableResourceBitmap) {
+    if (bigPicture is DrawableResourceAndroidBitmap) {
       return <String, dynamic>{
         'bigPicture': bigPicture.bitmap,
         'bigPictureBitmapSource': AndroidBitmapSource.Drawable.index,
       };
-    } else if (bigPicture is AndroidFilePathBitmap) {
+    } else if (bigPicture is FilePathAndroidBitmap) {
       return <String, dynamic>{
         'bigPicture': bigPicture.bitmap,
         'bigPictureBitmapSource': AndroidBitmapSource.FilePath.index,
@@ -74,12 +74,12 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
   }
 
   Map<String, dynamic> _convertLargeIconToMap() {
-    if (largeIcon is AndroidDrawableResourceBitmap) {
+    if (largeIcon is DrawableResourceAndroidBitmap) {
       return <String, dynamic>{
         'largeIcon': largeIcon.bitmap,
         'largeIconBitmapSource': AndroidBitmapSource.Drawable.index,
       };
-    } else if (largeIcon is AndroidFilePathBitmap) {
+    } else if (largeIcon is FilePathAndroidBitmap) {
       return <String, dynamic>{
         'largeIcon': largeIcon.bitmap,
         'largeIconBitmapSource': AndroidBitmapSource.FilePath.index,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
@@ -11,7 +11,7 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
   /// Set the first line of text after the detail section in the big form of the template.
   final String summaryText;
 
-  /// Specifies if the overridden ContentTitle should have formatting applies through HTML markup.
+  /// Specifies if the overridden ContentTitle should have formatting applied through HTML markup.
   final bool htmlFormatContentTitle;
 
   /// Specifies if formatting should be applied to the first line of text after the detail section in the big form of the template.

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_local_notifications/src/platform_specifics/android/bitmap.dart';
+
 import 'default_style_information.dart';
 import '../enums.dart';
 
@@ -15,60 +17,73 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
   /// Specifies if formatting should be applied to the first line of text after the detail section in the big form of the template.
   final bool htmlFormatSummaryText;
 
-  /// Path the bitmap that will override the large icon when the big notification is shown.
-  ///
-  /// This will be either the name of the drawable of an actual file path based on the value of [largeIconBitmapSource].
-  final String largeIcon;
+  /// The bitmap that will override the large icon when the big notification is shown.
+  final AndroidBitmap largeIcon;
 
-  /// Specifics the source for bitmap that will override the large icon specified in this style.
-  final BitmapSource largeIconBitmapSource;
-
-  /// Path to the bitmap to be used as the payload for the BigPicture notification.
-  ///
-  /// This will be either the name of the drawable of an actual file path based on the value of [bigPictureBitmapSource].
-  final String bigPicture;
-
-  /// Specifies the source for the bitmap to be used as the payload for the BigPicture notification.
-  final BitmapSource bigPictureBitmapSource;
+  /// The bitmap to be used as the payload for the BigPicture notification.
+  final AndroidBitmap bigPicture;
 
   /// Hides the large icon when showing the expanded notification.
   final bool hideExpandedLargeIcon;
 
-  BigPictureStyleInformation(this.bigPicture, this.bigPictureBitmapSource,
+  BigPictureStyleInformation(this.bigPicture,
       {this.contentTitle,
       this.summaryText,
       this.htmlFormatContentTitle = false,
       this.htmlFormatSummaryText = false,
       this.largeIcon,
-      this.largeIconBitmapSource,
       bool htmlFormatContent = false,
       bool htmlFormatTitle = false,
       this.hideExpandedLargeIcon = false})
       : super(htmlFormatContent, htmlFormatTitle);
 
-  /// Create a [Map] object that describes the [BigPictureStyleInformation] object.
+  /// Creates a [Map] object that describes the [BigPictureStyleInformation] object.
   ///
   /// Mainly for internal use to send the data over a platform channel.
   @override
   Map<String, dynamic> toMap() {
-    var styleJson = super.toMap();
+    var styleMap = super.toMap();
     var bigPictureStyleJson = <String, dynamic>{
       'contentTitle': contentTitle,
       'summaryText': summaryText,
       'htmlFormatContentTitle': htmlFormatContentTitle,
       'htmlFormatSummaryText': htmlFormatSummaryText,
-      'largeIcon': largeIcon,
-      'bigPicture': bigPicture,
-      'bigPictureBitmapSource': bigPictureBitmapSource?.index,
       'hideExpandedLargeIcon': hideExpandedLargeIcon
-    };
-
-    if (largeIconBitmapSource != null) {
-      bigPictureStyleJson['largeIconBitmapSource'] =
-          largeIconBitmapSource.index;
     }
+      ..addAll(_convertBigPictureToMap())
+      ..addAll(_convertLargeIconToMap());
 
-    styleJson.addAll(bigPictureStyleJson);
-    return styleJson;
+    styleMap.addAll(bigPictureStyleJson);
+    return styleMap;
+  }
+
+  Map<String, dynamic> _convertBigPictureToMap() {
+    if (bigPicture is AndroidDrawableResourceBitmap) {
+      return <String, dynamic>{
+        'bigPicture': bigPicture.bitmap,
+        'bigPictureBitmapSource': AndroidBitmapSource.Drawable.index,
+      };
+    } else if (bigPicture is AndroidFilePathBitmap) {
+      return <String, dynamic>{
+        'bigPicture': bigPicture.bitmap,
+        'bigPictureBitmapSource': AndroidBitmapSource.FilePath.index,
+      };
+    }
+    return <String, dynamic>{};
+  }
+
+  Map<String, dynamic> _convertLargeIconToMap() {
+    if (largeIcon is AndroidDrawableResourceBitmap) {
+      return <String, dynamic>{
+        'largeIcon': largeIcon.bitmap,
+        'largeIconBitmapSource': AndroidBitmapSource.Drawable.index,
+      };
+    } else if (largeIcon is AndroidFilePathBitmap) {
+      return <String, dynamic>{
+        'largeIcon': largeIcon.bitmap,
+        'largeIconBitmapSource': AndroidBitmapSource.FilePath.index,
+      };
+    }
+    return <String, dynamic>{};
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_picture_style_information.dart
@@ -42,19 +42,16 @@ class BigPictureStyleInformation extends DefaultStyleInformation {
   /// Mainly for internal use to send the data over a platform channel.
   @override
   Map<String, dynamic> toMap() {
-    var styleMap = super.toMap();
-    var bigPictureStyleJson = <String, dynamic>{
-      'contentTitle': contentTitle,
-      'summaryText': summaryText,
-      'htmlFormatContentTitle': htmlFormatContentTitle,
-      'htmlFormatSummaryText': htmlFormatSummaryText,
-      'hideExpandedLargeIcon': hideExpandedLargeIcon
-    }
+    return super.toMap()
       ..addAll(_convertBigPictureToMap())
-      ..addAll(_convertLargeIconToMap());
-
-    styleMap.addAll(bigPictureStyleJson);
-    return styleMap;
+      ..addAll(_convertLargeIconToMap())
+      ..addAll(<String, dynamic>{
+        'contentTitle': contentTitle,
+        'summaryText': summaryText,
+        'htmlFormatContentTitle': htmlFormatContentTitle,
+        'htmlFormatSummaryText': htmlFormatSummaryText,
+        'hideExpandedLargeIcon': hideExpandedLargeIcon
+      });
   }
 
   Map<String, dynamic> _convertBigPictureToMap() {

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_text_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/big_text_style_information.dart
@@ -35,17 +35,14 @@ class BigTextStyleInformation extends DefaultStyleInformation {
   /// Mainly for internal use to send the data over a platform channel.
   @override
   Map<String, dynamic> toMap() {
-    var styleJson = super.toMap();
-
-    var bigTextStyleJson = <String, dynamic>{
-      'bigText': bigText,
-      'htmlFormatBigText': htmlFormatBigText,
-      'contentTitle': contentTitle,
-      'htmlFormatContentTitle': htmlFormatContentTitle,
-      'summaryText': summaryText,
-      'htmlFormatSummaryText': htmlFormatSummaryText
-    };
-    styleJson.addAll(bigTextStyleJson);
-    return styleJson;
+    return super.toMap()
+      ..addAll(<String, dynamic>{
+        'bigText': bigText,
+        'htmlFormatBigText': htmlFormatBigText,
+        'contentTitle': contentTitle,
+        'htmlFormatContentTitle': htmlFormatContentTitle,
+        'summaryText': summaryText,
+        'htmlFormatSummaryText': htmlFormatSummaryText
+      });
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/default_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/default_style_information.dart
@@ -3,13 +3,12 @@ import 'style_information.dart';
 /// The default Android notification style.
 class DefaultStyleInformation extends StyleInformation {
   /// Specifies if formatting should be applied to the content through HTML markup.
-  bool htmlFormatContent;
+  final bool htmlFormatContent;
 
   /// Specifies if formatting should be applied to the title through HTML markup.
-  bool htmlFormatTitle;
+  final bool htmlFormatTitle;
 
-  DefaultStyleInformation(this.htmlFormatContent, this.htmlFormatTitle)
-      : super();
+  DefaultStyleInformation(this.htmlFormatContent, this.htmlFormatTitle);
 
   /// Create a [Map] object that describes the [DefaultStyleInformation] object.
   ///

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/inbox_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/inbox_style_information.dart
@@ -36,16 +36,14 @@ class InboxStyleInformation extends DefaultStyleInformation {
   /// Mainly for internal use to send the data over a platform channel.
   @override
   Map<String, dynamic> toMap() {
-    var styleJson = super.toMap();
-    var bigTextStyleJson = <String, dynamic>{
-      'contentTitle': contentTitle,
-      'htmlFormatContentTitle': htmlFormatContentTitle,
-      'summaryText': summaryText,
-      'htmlFormatSummaryText': htmlFormatSummaryText,
-      'lines': lines ?? List<String>(),
-      'htmlFormatLines': htmlFormatLines
-    };
-    styleJson.addAll(bigTextStyleJson);
-    return styleJson;
+    return super.toMap()
+      ..addAll(<String, dynamic>{
+        'contentTitle': contentTitle,
+        'htmlFormatContentTitle': htmlFormatContentTitle,
+        'summaryText': summaryText,
+        'htmlFormatSummaryText': htmlFormatSummaryText,
+        'lines': lines ?? List<String>(),
+        'htmlFormatLines': htmlFormatLines
+      });
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/inbox_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/inbox_style_information.dart
@@ -9,7 +9,7 @@ class InboxStyleInformation extends DefaultStyleInformation {
   final String summaryText;
 
   /// The lines that form part of the digest section for inbox-style notifications.
-  List<String> lines;
+  final List<String> lines;
 
   /// Specifies if the lines should have formatting applied through HTML markup.
   final bool htmlFormatLines;

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/media_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/media_style_information.dart
@@ -1,0 +1,13 @@
+import 'default_style_information.dart';
+
+/// Used to pass the content for an Android notification displayed using the media style.
+///
+/// When used, the bitmap specified [largeIcon](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/AndroidNotificationDetails/largeIcon.html)
+/// as part of the [AndroidNotificationDetails](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/AndroidNotificationDetails-class.html)
+/// class will be treated as album artwork.
+class MediaStyleInformation extends DefaultStyleInformation {
+  MediaStyleInformation({
+    bool htmlFormatContent = false,
+    bool htmlFormatTitle = false,
+  }) : super(htmlFormatContent, htmlFormatTitle);
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/messaging_style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/messaging_style_information.dart
@@ -32,11 +32,12 @@ class MessagingStyleInformation extends DefaultStyleInformation {
   /// Mainly for internal use to send the data over a platform channel.
   @override
   Map<String, dynamic> toMap() {
-    var styleJson = super.toMap();
-    styleJson['person'] = person.toMap();
-    styleJson['conversationTitle'] = conversationTitle;
-    styleJson['groupConversation'] = groupConversation;
-    styleJson['messages'] = messages?.map((m) => m.toMap())?.toList();
-    return styleJson;
+    return super.toMap()
+      ..addAll(<String, dynamic>{
+        'person': person.toMap(),
+        'conversationTitle': conversationTitle,
+        'groupConversation': groupConversation,
+        'messages': messages?.map((m) => m.toMap())?.toList()
+      });
   }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/styles/style_information.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/styles/style_information.dart
@@ -1,6 +1,4 @@
 /// Abstract class for defining an Android notification style
 abstract class StyleInformation {
-  StyleInformation();
-
   Map<String, dynamic> toMap();
 }


### PR DESCRIPTION
Relates to #552, #257, #393 