### PR TITLE
Added monthly option

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -290,6 +290,9 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             case Weekly:
                 repeatInterval = 60000 * 60 * 24 * 7;
                 break;
+            case Monthly:
+                repeatInterval = 60000 * 60 * 24 * 7 * 30;
+                break;
             default:
                 break;
         }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/RepeatInterval.java
@@ -4,5 +4,6 @@ public enum RepeatInterval {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly
+    Weekly,
+    Monthly
 }

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -74,7 +74,8 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
     EveryMinute,
     Hourly,
     Daily,
-    Weekly
+    Weekly,
+    Monthly
 };
 
 static FlutterError *getFlutterError(NSError *error) {
@@ -427,6 +428,9 @@ static FlutterError *getFlutterError(NSError *error) {
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
                     break;
+                case Monthly:
+                    timeInterval = 60 * 60 * 24 * 7 * 30;
+                    break;
             }
             repeats = YES;
         }
@@ -506,6 +510,10 @@ static FlutterError *getFlutterError(NSError *error) {
                 case Weekly:
                     timeInterval = 60 * 60 * 24 * 7;
                     notification.repeatInterval = NSCalendarUnitWeekOfYear;
+                    break;
+                case Monthly:
+                    timeInterval = 60 * 60 * 24 * 30;
+                    notification.repeatInterval = NSCalendarUnitMonth;
                     break;
             }
             if (notificationDetails.repeatTime != nil) {

--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -1,5 +1,5 @@
 /// The available intervals for periodically showing notifications
-enum RepeatInterval { EveryMinute, Hourly, Daily, Weekly }
+enum RepeatInterval { EveryMinute, Hourly, Daily, Weekly, Monthly }
 
 /// Details of a pending notification that has not been delivered
 class PendingNotificationRequest {


### PR DESCRIPTION
Hi,
Currently, We have an option to set the repetition of flutter notifications in every minute, daily and weekly, it will be good if we have an option to send the notification monthly say 5ht of every month.
@MaikuB: please consider this requirement, and I have created a rough PR for the same, I am not sure it is correct changes for that, please discard if it is not good, But it will be good if we have this option, as well. If this option is already  achieved please update otherwise
