### PR TITLE
Adds support for broadcasting an intent with the notification in Android

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -23,6 +23,7 @@ public class NotificationDetails {
     private static final String TITLE = "title";
     private static final String BODY = "body";
     private static final String PAYLOAD = "payload";
+    private static final String BROADCAST_TARGET = "broadcastTarget";
     private static final String MILLISECONDS_SINCE_EPOCH = "millisecondsSinceEpoch";
     private static final String CALLED_AT = "calledAt";
     private static final String REPEAT_INTERVAL = "repeatInterval";
@@ -128,6 +129,7 @@ public class NotificationDetails {
     public Long millisecondsSinceEpoch;
     public Long calledAt;
     public String payload;
+    public String broadcastTarget;
     public String groupKey;
     public Boolean setAsGroupSummary;
     public Integer groupAlertBehavior;
@@ -164,6 +166,7 @@ public class NotificationDetails {
     public static NotificationDetails from(Map<String, Object> arguments) {
         NotificationDetails notificationDetails = new NotificationDetails();
         notificationDetails.payload = (String) arguments.get(PAYLOAD);
+        notificationDetails.broadcastTarget = (String) arguments.get(BROADCAST_TARGET);
         notificationDetails.id = (Integer) arguments.get(ID);
         notificationDetails.title = (String) arguments.get(TITLE);
         notificationDetails.body = (String) arguments.get(BODY);

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <receiver android:name="com.dexterous.flutterlocalnotificationsexample.ForegroundServiceBroadcastReceiver" />
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
             <intent-filter>

--- a/flutter_local_notifications/example/android/app/src/main/java/com/dexterous/flutterlocalnotificationsexample/ForegroundService.java
+++ b/flutter_local_notifications/example/android/app/src/main/java/com/dexterous/flutterlocalnotificationsexample/ForegroundService.java
@@ -1,0 +1,25 @@
+package com.dexterous.flutterlocalnotificationsexample;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import androidx.annotation.Nullable;
+
+public class ForegroundService extends Service {
+
+
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+    return null;
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    int notificationId = intent.getIntExtra("notificationId", 1);
+    Notification notification = intent.getExtras().getParcelable("notification");
+    startForeground(notificationId, notification);
+    return START_NOT_STICKY;
+  }
+}

--- a/flutter_local_notifications/example/android/app/src/main/java/com/dexterous/flutterlocalnotificationsexample/ForegroundServiceBroadcastReceiver.java
+++ b/flutter_local_notifications/example/android/app/src/main/java/com/dexterous/flutterlocalnotificationsexample/ForegroundServiceBroadcastReceiver.java
@@ -1,0 +1,20 @@
+package com.dexterous.flutterlocalnotificationsexample;
+
+import android.app.Notification;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import androidx.core.content.ContextCompat;
+
+public class ForegroundServiceBroadcastReceiver extends BroadcastReceiver {
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    Intent foregroundIntent = new Intent(context, ForegroundService.class);
+    int notificationId = intent.getIntExtra("notificationId", 1);
+    Notification intentNotification = intent.getExtras().getParcelable("notification");
+    foregroundIntent.putExtra("notificationId", notificationId);
+    foregroundIntent.putExtra("notification", intentNotification);
+    ContextCompat.startForegroundService(context, foregroundIntent);
+  }
+}

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -230,6 +230,13 @@ class _HomePageState extends State<HomePage> {
                   ),
                   PaddedRaisedButton(
                     buttonText:
+                        'Show plain notification in Foreground Service [Android]',
+                    onPressed: () async {
+                      await _showNotificationInForegroundService();
+                    },
+                  ),
+                  PaddedRaisedButton(
+                    buttonText:
                         'Show plain notification that has no body with payload',
                     onPressed: () async {
                       await _showNotificationWithNoBody();
@@ -442,6 +449,25 @@ class _HomePageState extends State<HomePage> {
     var androidPlatformChannelSpecifics = AndroidNotificationDetails(
         'your channel id', 'your channel name', 'your channel description',
         importance: Importance.Max, priority: Priority.High, ticker: 'ticker');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> _showNotificationInForegroundService() async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+      'your channel id',
+      'your channel name',
+      'your channel description',
+      importance: Importance.Max,
+      priority: Priority.High,
+      ticker: 'ticker',
+      broadcastTarget:
+          'com.dexterous.flutterlocalnotificationsexample.ForegroundServiceBroadcastReceiver',
+    );
     var iOSPlatformChannelSpecifics = IOSNotificationDetails();
     var platformChannelSpecifics = NotificationDetails(
         androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -6,11 +6,11 @@ import 'enums.dart';
 import 'notification_sound.dart';
 import 'styles/big_picture_style_information.dart';
 import 'styles/big_text_style_information.dart';
+import 'styles/default_style_information.dart';
 import 'styles/inbox_style_information.dart';
 import 'styles/media_style_information.dart';
 import 'styles/messaging_style_information.dart';
 import 'styles/style_information.dart';
-import 'styles/default_style_information.dart';
 
 /// Configures the notification on Android.
 class AndroidNotificationDetails {
@@ -51,6 +51,7 @@ class AndroidNotificationDetails {
     this.timeoutAfter,
     this.category,
     this.additionalFlags,
+    this.broadcastTarget,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -210,6 +211,11 @@ class AndroidNotificationDetails {
   /// For example, use a value of 4 to allow the audio to repeat as documented at https://developer.android.com/reference/android/app/Notification.html#FLAG_INSISTEN
   final Int32List additionalFlags;
 
+  /// The broadcast target className.
+  ///
+  /// Lookup will be done via `Class.forName` in Android
+  final String broadcastTarget;
+
   /// Creates a [Map] object that describes the [AndroidNotificationDetails] object.
   ///
   /// Mainly for internal use to send the data over a platform channel.
@@ -253,7 +259,8 @@ class AndroidNotificationDetails {
       'visibility': visibility?.index,
       'timeoutAfter': timeoutAfter,
       'category': category,
-      'additionalFlags': additionalFlags
+      'additionalFlags': additionalFlags,
+      'broadcastTarget': broadcastTarget
     }
       ..addAll(_convertStyleInformationToMap())
       ..addAll(_convertSoundToMap())

--- a/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
@@ -127,6 +127,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -201,6 +202,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': [4, 32],
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -277,6 +279,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -358,6 +361,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -438,6 +442,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -516,6 +521,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Default.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': true,
@@ -596,6 +602,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.BigPicture.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -691,6 +698,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.BigPicture.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': true,
@@ -780,6 +788,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.BigPicture.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -875,6 +884,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.BigPicture.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': true,
@@ -962,6 +972,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Inbox.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -1053,6 +1064,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Inbox.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': true,
@@ -1135,6 +1147,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Media.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -1214,6 +1227,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Media.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': true,
@@ -1300,6 +1314,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Messaging.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,
@@ -1415,6 +1430,7 @@ void main() {
               'timeoutAfter': null,
               'category': null,
               'additionalFlags': null,
+              'broadcastTarget': null,
               'style': AndroidNotificationStyle.Messaging.index,
               'styleInformation': <String, Object>{
                 'htmlFormatContent': false,


### PR DESCRIPTION
This adds support for broadcasting an [`Intent`](https://developer.android.com/reference/android/content/Intent) containing a notification in Android.

The current implementation is the one I am using in my own application and it has proven very useful, so I'm opening this PR here in the hope that it can benefit others too.

### Use case
It enables using the notification in other ways than via `notify`, such as in:
- [Foreground services](https://developer.android.com/guide/components/services#Foreground)
- [WorkManager](https://developer.android.com/reference/androidx/work/WorkManager)
- and maybe other Android APIs I'm unaware of

This can be very helpful for advanced Android Flutter applications, especially those who need to keep executing in the background. The PR includes an example of using it in a "dumb" foreground service which does nothing but start. 

The existing `notify` method can then be used against a `notificationId` previously used via an `Intent`, so it possible to keep using only this plugin to update a notification displaying in a foreground service or WorkManager.

It opens the door to other plugins using this one, in order to benefit from its good maintenance and good feature coverage, while focusing of their core functionality.

### Implementation
The proposed API is to:
- add a `broadcastTarget` String argument to the `AndroidNotificationDetails` constructor, which will be parsed by `Class.forName` in Android.
- let plugin authors or end users implement their own [`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver), whose `onReceive` method will be responsible for handling the notification.

I have tried to follow the existing architecture, but would happily change the implementation if needed.