### PR TITLE
Add support of intervals quantity for periodic notifications

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -301,7 +301,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             default:
                 break;
         }
-
+        repeatInterval = repeatInterval * notificationDetails.repeatIntervalQuantity;
         long startTimeMilliseconds = notificationDetails.calledAt;
         if (notificationDetails.repeatTime != null) {
             Calendar calendar = Calendar.getInstance();

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -26,6 +26,7 @@ public class NotificationDetails {
     private static final String MILLISECONDS_SINCE_EPOCH = "millisecondsSinceEpoch";
     private static final String CALLED_AT = "calledAt";
     private static final String REPEAT_INTERVAL = "repeatInterval";
+    private static final String REPEAT_INTERVAL_QUANTITY = "repeatIntervalQuantity";
     private static final String REPEAT_TIME = "repeatTime";
     private static final String PLATFORM_SPECIFICS = "platformSpecifics";
     private static final String AUTO_CANCEL = "autoCancel";
@@ -124,6 +125,7 @@ public class NotificationDetails {
     public NotificationStyle style;
     public StyleInformation styleInformation;
     public RepeatInterval repeatInterval;
+    public Integer repeatIntervalQuantity;
     public Time repeatTime;
     public Long millisecondsSinceEpoch;
     public Long calledAt;
@@ -175,6 +177,11 @@ public class NotificationDetails {
         }
         if (arguments.containsKey(REPEAT_INTERVAL)) {
             notificationDetails.repeatInterval = RepeatInterval.values()[(Integer) arguments.get(REPEAT_INTERVAL)];
+        }
+        if (arguments.containsKey(REPEAT_INTERVAL_QUANTITY)) {
+            notificationDetails.repeatIntervalQuantity = (Integer) arguments.get(REPEAT_INTERVAL_QUANTITY);
+        } else {
+            notificationDetails.repeatIntervalQuantity = (Integer) 1;
         }
         if (arguments.containsKey(REPEAT_TIME)) {
             @SuppressWarnings("unchecked")

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -60,6 +60,7 @@ NSString *const PRESENT_BADGE = @"presentBadge";
 NSString *const BADGE_NUMBER = @"badgeNumber";
 NSString *const MILLISECONDS_SINCE_EPOCH = @"millisecondsSinceEpoch";
 NSString *const REPEAT_INTERVAL = @"repeatInterval";
+NSString *const REPEAT_INTERVAL_QUANTITY = @"repeatIntervalQuantity";
 NSString *const REPEAT_TIME = @"repeatTime";
 NSString *const HOUR = @"hour";
 NSString *const MINUTE = @"minute";
@@ -302,6 +303,11 @@ static FlutterError *getFlutterError(NSError *error) {
             notificationDetails.day = @([call.arguments[DAY] integerValue]);
         }
         notificationDetails.repeatInterval = @([call.arguments[REPEAT_INTERVAL] integerValue]);
+        if (call.arguments[REPEAT_INTERVAL_QUANTITY]) {
+            notificationDetails.repeatIntervalQuantity = @([call.arguments[REPEAT_INTERVAL_QUANTITY] integerValue]);
+        } else {
+            notificationDetails.repeatIntervalQuantity = @1;
+        }
     }
     if(@available(iOS 10.0, *)) {
         [self showUserNotification:notificationDetails result:result];
@@ -428,6 +434,7 @@ static FlutterError *getFlutterError(NSError *error) {
                     timeInterval = 60 * 60 * 24 * 7;
                     break;
             }
+            timeInterval *= notificationDetails.repeatIntervalQuantity.integerValue;
             repeats = YES;
         }
         if (notificationDetails.repeatTime != nil) {

--- a/flutter_local_notifications/ios/Classes/NotificationDetails.h
+++ b/flutter_local_notifications/ios/Classes/NotificationDetails.h
@@ -14,6 +14,7 @@
     @property(nonatomic, strong) NSString *sound;
     @property(nonatomic, strong) NSNumber *secondsSinceEpoch;
     @property(nonatomic, strong) NSNumber *repeatInterval;
+    @property(nonatomic, strong) NSNumber *repeatIntervalQuantity;
     @property(nonatomic, strong) NotificationTime *repeatTime;
     @property(nonatomic, strong) NSNumber *day;
     @property(nonatomic, strong) NSNumber *badgeNumber;

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -186,21 +186,27 @@ class FlutterLocalNotificationsPlugin {
   /// For example, specifying a hourly interval means the first time the notification will be an hour after the method has been called and then every hour after that.
   Future<void> periodicallyShow(int id, String title, String body,
       RepeatInterval repeatInterval, NotificationDetails notificationDetails,
-      {String payload}) async {
+      {String payload, int intervalQuantity}) async {
+    var internalIntervalQuantity = intervalQuantity ?? 1;
     if (_platform.isAndroid) {
       await resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>()
+          AndroidFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
-              notificationDetails: notificationDetails?.android,
-              payload: payload);
+          notificationDetails: notificationDetails?.android,
+          payload: payload, intervalQuantity: internalIntervalQuantity
+      );
     } else if (_platform.isIOS) {
       await resolvePlatformSpecificImplementation<
-              IOSFlutterLocalNotificationsPlugin>()
+          IOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
-              notificationDetails: notificationDetails?.iOS, payload: payload);
+          notificationDetails: notificationDetails?.iOS,
+          payload: payload,
+          intervalQuantity: internalIntervalQuantity
+      );
     } else {
       await FlutterLocalNotificationsPlatform.instance
-          ?.periodicallyShow(id, title, body, repeatInterval);
+          ?.periodicallyShow(id, title, body, repeatInterval
+      );
     }
   }
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -149,7 +149,7 @@ class AndroidFlutterLocalNotificationsPlugin
   @override
   Future<void> periodicallyShow(
       int id, String title, String body, RepeatInterval repeatInterval,
-      {AndroidNotificationDetails notificationDetails, String payload}) async {
+      {AndroidNotificationDetails notificationDetails, String payload, int intervalQuantity}) async {
     validateId(id);
     await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
       'id': id,
@@ -157,6 +157,7 @@ class AndroidFlutterLocalNotificationsPlugin
       'body': body,
       'calledAt': DateTime.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
+      'repeatIntervalQuantity': intervalQuantity,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
     });
@@ -297,7 +298,7 @@ class IOSFlutterLocalNotificationsPlugin
   @override
   Future<void> periodicallyShow(
       int id, String title, String body, RepeatInterval repeatInterval,
-      {IOSNotificationDetails notificationDetails, String payload}) async {
+      {IOSNotificationDetails notificationDetails, String payload, int intervalQuantity}) async {
     validateId(id);
     await _channel.invokeMethod('periodicallyShow', <String, dynamic>{
       'id': id,
@@ -305,6 +306,7 @@ class IOSFlutterLocalNotificationsPlugin
       'body': body,
       'calledAt': DateTime.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
+      'repeatIntervalQuantity': intervalQuantity,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
     });


### PR DESCRIPTION
Added number of intervals for repeating notifications. For ios lower than ios 10 works as before. 

Works as: if you set `repeatInterval` as EveryMinute and set `repeatIntervalQuantity` to 5, that means "Repeat every 5 minutes". Same for other `repeatInterval`