### PR TITLE
Fixed missing emulator-headless

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,7 @@ task:
   create_device_script:
     echo no | avdmanager create avd --force -n test -k "system-images;android-$EMULATOR_API_LEVEL;$ANDROID_ABI"
   start_emulator_background_script:
-    $ANDROID_HOME/emulator/emulator-headless -verbose -avd test -no-audio -no-window
+    $ANDROID_HOME/emulator/emulator -no-window -verbose -avd test -no-audio -no-window
   wait_for_emulator_script:
     android-wait-for-emulator
   test_script:


### PR DESCRIPTION
Apparently there is no more `emulator-headless`: https://stackoverflow.com/a/59250326

