### PR TITLE
Added  MY_PACKAGE_REPLACED action handling in BootReceiver

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -115,12 +115,13 @@ If your application needs the ability to schedule notifications then you need to
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 ```
 
-The following is also needed to ensure scheduled notifications remain scheduled upon a reboot (this is handled by the plugin)
+The following is also needed to ensure scheduled notifications remain scheduled upon a reboot, and after the app was updated (this is handled by the plugin)
 
 ```xml
 <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
     <intent-filter>
-        <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+        <action android:name="android.intent.action.BOOT_COMPLETED"/>
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
     </intent-filter>
 </receiver>
 ```

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -115,7 +115,7 @@ If your application needs the ability to schedule notifications then you need to
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 ```
 
-The following is also needed to ensure scheduled notifications remain scheduled upon a reboot, and after the app was updated (this is handled by the plugin)
+The following is also needed to ensure notifications remain scheduled upon a reboot and after an application is updated
 
 ```xml
 <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
@@ -9,7 +9,6 @@ public class ScheduledNotificationBootReceiver extends BroadcastReceiver
     @Override
     public void onReceive(final Context context, Intent intent) {
         String action = intent.getAction();
-        System.out.println("ScheduledNotificationBootReceiver is running");
         if (action != null) {
             if (action.equals(android.content.Intent.ACTION_BOOT_COMPLETED)
                     || action.equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
@@ -9,9 +9,12 @@ public class ScheduledNotificationBootReceiver extends BroadcastReceiver
     @Override
     public void onReceive(final Context context, Intent intent) {
         String action = intent.getAction();
-        System.out.println("rebooted");
-        if (action != null && action.equals(android.content.Intent.ACTION_BOOT_COMPLETED)) {
-            FlutterLocalNotificationsPlugin.rescheduleNotifications(context);
+        System.out.println("ScheduledNotificationBootReceiver is running");
+        if (action != null) {
+            if (action.equals(android.content.Intent.ACTION_BOOT_COMPLETED)
+                    || action.equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
+                FlutterLocalNotificationsPlugin.rescheduleNotifications(context);
+            }
         }
     }
 }

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
I've added the action to the example's manifest and the README.

Changed the log message to something more generic

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications])

Fixes Issue #689 