### PR TITLE
[flutter_local_notifications] Added callback for dismissing a notification

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -21,6 +21,9 @@ final BehaviorSubject<ReceivedNotification> didReceiveLocalNotificationSubject =
 final BehaviorSubject<String> selectNotificationSubject =
     BehaviorSubject<String>();
 
+final BehaviorSubject<String> dismissNotificationSubject =
+    BehaviorSubject<String>();
+
 NotificationAppLaunchDetails notificationAppLaunchDetails;
 
 class ReceivedNotification {
@@ -66,6 +69,11 @@ Future<void> main() async {
       debugPrint('notification payload: ' + payload);
     }
     selectNotificationSubject.add(payload);
+  }, onDismissNotification: (String payload) async {
+    if (payload != null) {
+      debugPrint('dismiss notification payload: ' + payload);
+    }
+    dismissNotificationSubject.add(payload);
   });
   runApp(
     MaterialApp(

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -90,12 +90,14 @@ class FlutterLocalNotificationsPlugin {
   /// [IOSInitializationSettings.requestBadgePermission] and [IOSInitializationSettings.requestSoundPermission] values to false.
   /// [requestPermissions] can then be called to request permissions when needed.
   Future<bool> initialize(InitializationSettings initializationSettings,
-      {SelectNotificationCallback onSelectNotification}) async {
+      {SelectNotificationCallback onSelectNotification,
+        DismissNotificationCallback onDismissNotification}) async {
     if (_platform.isAndroid) {
       return await resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()
           ?.initialize(initializationSettings?.android,
-              onSelectNotification: onSelectNotification);
+              onSelectNotification: onSelectNotification,
+          onDismissNotification: onDismissNotification);
     } else if (_platform.isIOS) {
       return await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -56,13 +56,16 @@ class MethodChannelFlutterLocalNotificationsPlugin
 class AndroidFlutterLocalNotificationsPlugin
     extends MethodChannelFlutterLocalNotificationsPlugin {
   SelectNotificationCallback _onSelectNotification;
+  DismissNotificationCallback _onDismissNotification;
 
   /// Initializes the plugin. Call this method on application before using the plugin further.
   /// This should only be done once. When a notification created by this plugin was used to launch the app,
   /// calling `initialize` is what will trigger to the `onSelectNotification` callback to be fire.
   Future<bool> initialize(AndroidInitializationSettings initializationSettings,
-      {SelectNotificationCallback onSelectNotification}) async {
+      {SelectNotificationCallback onSelectNotification,
+        DismissNotificationCallback onDismissNotification}) async {
     _onSelectNotification = onSelectNotification;
+    _onDismissNotification = onDismissNotification;
     _channel.setMethodCallHandler(_handleMethod);
     return await _channel.invokeMethod(
         'initialize', initializationSettings.toMap());
@@ -179,6 +182,8 @@ class AndroidFlutterLocalNotificationsPlugin
     switch (call.method) {
       case 'selectNotification':
         return _onSelectNotification(call.arguments);
+      case 'dismissNotification':
+        return _onDismissNotification?.call(call.arguments);
       default:
         return Future.error('method not defined');
     }

--- a/flutter_local_notifications/lib/src/typedefs.dart
+++ b/flutter_local_notifications/lib/src/typedefs.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 /// Signature of callback passed to [initialize] that is triggered when user taps on a notification.
 typedef SelectNotificationCallback = Future<dynamic> Function(String payload);
 
+/// Signature of callback passed to [initialize] that is trigger when user dismiss a notification
+typedef DismissNotificationCallback = Future<void> Function(String id);
+
 /// Signature of the callback that is triggered when a notification is shown whilst the app is in the foreground.
 ///
 /// Applicable to iOS versions below 10.


### PR DESCRIPTION
Notes:
- I don't have a Mac so this is an Android only version. I hope the iOS version will be not be complex either
- I couldn't think of a way to show the dismiss in the UI, so right now you can just see it in the console
  - I thought about using a Snackbar but there isn't a scaffold, and I wasn't sure it's worth adding