### PR TITLE
Add monthly & yearly notifications

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -771,6 +771,12 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Weekly) {
                 LocalDateTime localDateTime = LocalDateTime.parse(notificationDetails.scheduledDateTime).plusWeeks(1);
                 return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
+            } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Monthly) {
+                LocalDateTime localDateTime = LocalDateTime.parse(notificationDetails.scheduledDateTime).plusMonths(1);
+                return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
+            } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Yearly) {
+                LocalDateTime localDateTime = LocalDateTime.parse(notificationDetails.scheduledDateTime).plusYears(1);
+                return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
             }
         } else {
             if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Daily) {
@@ -778,6 +784,12 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
             } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Weekly) {
                 org.threeten.bp.LocalDateTime localDateTime = org.threeten.bp.LocalDateTime.parse(notificationDetails.scheduledDateTime).plusWeeks(1);
+                return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
+            } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Monthly) {
+                org.threeten.bp.LocalDateTime localDateTime = org.threeten.bp.LocalDateTime.parse(notificationDetails.scheduledDateTime).plusMonths(1);
+                return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
+            } else if(notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Yearly) {
+                org.threeten.bp.LocalDateTime localDateTime = org.threeten.bp.LocalDateTime.parse(notificationDetails.scheduledDateTime).plusYears(1);
                 return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
             }
         }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/ScheduledNotificationRepeatFrequency.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/ScheduledNotificationRepeatFrequency.java
@@ -2,5 +2,7 @@ package com.dexterous.flutterlocalnotifications.models;
 
 public enum ScheduledNotificationRepeatFrequency {
     Daily,
-    Weekly
+    Weekly,
+    Monthly,
+    Yearly
 }

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -294,6 +294,20 @@ class _HomePageState extends State<HomePage> {
                     },
                   ),
                   PaddedRaisedButton(
+                    buttonText:
+                        'Schedule monthly 10:00:00 am notification in your local time zone',
+                    onPressed: () async {
+                      await _scheduleMonthlyTenAMNotification();
+                    },
+                  ),
+                  PaddedRaisedButton(
+                    buttonText:
+                        'Schedule yearly 10:00:00 am notification in your local time zone',
+                    onPressed: () async {
+                      await _scheduleYearlyTenAMNotification();
+                    },
+                  ),
+                  PaddedRaisedButton(
                     buttonText: 'Show notification with no sound',
                     onPressed: () async {
                       await _showNotificationWithNoSound();
@@ -957,6 +971,44 @@ class _HomePageState extends State<HomePage> {
             UILocalNotificationDateInterpretation.absoluteTime,
         scheduledNotificationRepeatFrequency:
             ScheduledNotificationRepeatFrequency.weekly);
+  }
+
+  Future<void> _scheduleMonthlyTenAMNotification() async {
+    await flutterLocalNotificationsPlugin.zonedSchedule(
+        0,
+        'monthly scheduled notification title',
+        'monthly scheduled notification body',
+        _nextInstanceOfTenAM(),
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+              'monthly notification channel id',
+              'monthly notification channel name',
+              'monthly notificationdescription'),
+        ),
+        androidAllowWhileIdle: true,
+        uiLocalNotificationDateInterpretation:
+            UILocalNotificationDateInterpretation.absoluteTime,
+        scheduledNotificationRepeatFrequency:
+            ScheduledNotificationRepeatFrequency.monthly);
+  }
+
+  Future<void> _scheduleYearlyTenAMNotification() async {
+    await flutterLocalNotificationsPlugin.zonedSchedule(
+        0,
+        'yearly scheduled notification title',
+        'yearly scheduled notification body',
+        _nextInstanceOfTenAM(),
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+              'yearly notification channel id',
+              'yearly notification channel name',
+              'yearly notificationdescription'),
+        ),
+        androidAllowWhileIdle: true,
+        uiLocalNotificationDateInterpretation:
+            UILocalNotificationDateInterpretation.absoluteTime,
+        scheduledNotificationRepeatFrequency:
+            ScheduledNotificationRepeatFrequency.yearly);
   }
 
   tz.TZDateTime _nextInstanceOfTenAM() {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -81,7 +81,9 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
 
 typedef NS_ENUM(NSInteger, ScheduledNotificationRepeatFrequency) {
     DailyFrequency,
-    WeeklyFrequency
+    WeeklyFrequency,
+    MonthlyFrequency,
+    YearlyFrequency
 };
 
 typedef NS_ENUM(NSInteger, UILocalNotificationDateInterpretation) {
@@ -384,6 +386,10 @@ static FlutterError *getFlutterError(NSError *error) {
                 notification.repeatInterval = NSCalendarUnitDay;
             } else  if([scheduledNotificationRepeatFrequency integerValue] == WeeklyFrequency) {
                 notification.repeatInterval = NSCalendarUnitWeekOfYear;
+            } else  if([scheduledNotificationRepeatFrequency integerValue] == MonthlyFrequency) {
+                notification.repeatInterval = NSCalendarUnitMonth;
+            } else  if([scheduledNotificationRepeatFrequency integerValue] == YearlyFrequency) {
+                notification.repeatInterval = NSCalendarUnitYear;
             }
         }
         [[UIApplication sharedApplication] scheduleLocalNotification:notification];
@@ -610,7 +616,24 @@ static FlutterError *getFlutterError(NSError *error) {
             return [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:YES];
         }
         else if([scheduledNotificationRepeatFrequency integerValue] == WeeklyFrequency) {
-            NSDateComponents *dateComponents    = [calendar components:( NSCalendarUnitWeekday |
+            NSDateComponents *dateComponents    = [calendar components:(
+                                                                        NSCalendarUnitWeekday |
+                                                                        NSCalendarUnitHour  |
+                                                                        NSCalendarUnitMinute|
+                                                                        NSCalendarUnitSecond | NSCalendarUnitTimeZone) fromDate:date];
+            return [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:YES];
+        }
+        else if([scheduledNotificationRepeatFrequency integerValue] == MonthlyFrequency) {
+            NSDateComponents *dateComponents    = [calendar components:(
+                                                                        NSCalendarUnitDay |
+                                                                        NSCalendarUnitHour  |
+                                                                        NSCalendarUnitMinute|
+                                                                        NSCalendarUnitSecond | NSCalendarUnitTimeZone) fromDate:date];
+            return [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:YES];
+        }
+        else if([scheduledNotificationRepeatFrequency integerValue] == YearlyFrequency) {
+            NSDateComponents *dateComponents    = [calendar components:(
+                                                                        NSCalendarUnitMonth |
                                                                         NSCalendarUnitHour  |
                                                                         NSCalendarUnitMinute|
                                                                         NSCalendarUnitSecond | NSCalendarUnitTimeZone) fromDate:date];

--- a/flutter_local_notifications/lib/src/types.dart
+++ b/flutter_local_notifications/lib/src/types.dart
@@ -46,4 +46,6 @@ class Time {
 enum ScheduledNotificationRepeatFrequency {
   daily,
   weekly,
+  monthly,
+  yearly,
 }


### PR DESCRIPTION
Added support for monthly and yearly repeat notifications on both iOS and Android.

I tested the scheduled dates which are correct, however I could not confirm through tests that notifications are actually repeated every month/year.
Testing it on real device would take a long time (a month or a year), so if you have any guidance on how I could test and make sure this works, I will be happy to try it out.

