### PR TITLE
[flutter_local_notifications] Added an option for Person to display a circle icon.

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -84,6 +84,7 @@ public class NotificationDetails {
     private static final String KEY = "key";
     private static final String NAME = "name";
     private static final String URI = "uri";
+    private static final String CIRCLE_ICON = "circleIcon";
     private static final String DATA_MIME_TYPE = "dataMimeType";
     private static final String DATA_URI = "dataUri";
     private static final String CHANNEL_ACTION = "channelAction";
@@ -343,7 +344,8 @@ public class NotificationDetails {
         String key = (String) person.get(KEY);
         String name = (String) person.get(NAME);
         String uri = (String) person.get(URI);
-        return new PersonDetails(bot, icon, iconSource, important, key, name, uri);
+        boolean circleIcon = (boolean) person.get(CIRCLE_ICON);
+        return new PersonDetails(bot, icon, iconSource, important, key, name, uri, circleIcon);
     }
 
     @SuppressWarnings("unchecked")

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/PersonDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/PersonDetails.java
@@ -8,8 +8,9 @@ public class PersonDetails {
     public String key;
     public String name;
     public String uri;
+    public boolean circleIcon;
 
-    public PersonDetails(Boolean bot, String icon, IconSource iconSource, Boolean important, String key, String name, String uri) {
+    public PersonDetails(Boolean bot, String icon, IconSource iconSource, Boolean important, String key, String name, String uri, boolean circleIcon) {
         this.bot = bot;
         this.icon = icon;
         this.iconBitmapSource = iconSource;
@@ -17,5 +18,6 @@ public class PersonDetails {
         this.key = key;
         this.name = name;
         this.uri = uri;
+        this.circleIcon = circleIcon;
     }
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/person.dart
@@ -11,6 +11,7 @@ class Person {
     this.key,
     this.name,
     this.uri,
+    this.circleIcon = false
   });
 
   /// Whether or not this person represents a machine rather than a human.
@@ -30,6 +31,12 @@ class Person {
 
   /// Uri for this person.
   final String uri;
+  
+  /// Whether or not to show icon as a rounded circle.
+  ///
+  /// Always false when icon is not a [FlutterBitmapAssetAndroidIcon] or
+  /// a [BitmapFilePathAndroidIcon]. Defaults to false.
+  final bool circleIcon;
 
   /// Creates a [Map] object that describes the [Person] object.
   ///
@@ -40,7 +47,8 @@ class Person {
       'important': important,
       'key': key,
       'name': name,
-      'uri': uri
+      'uri': uri,
+      'circleIcon': (icon is FlutterBitmapAssetAndroidIcon || icon is BitmapFilePathAndroidIcon) ? circleIcon : false
     }..addAll(_convertIconToMap());
   }
 


### PR DESCRIPTION
I added a simple `Bitmap` implementation of converting the original image to its rounded circle version, on the `Android` side. The change is in the `Person` class'. The new `circleIcon` parameter will decide whether show `Person.icon` as a circle or not when `icon` is a `FlutterBitmapAssetAndroidIcon` or `BitmapFilePathAndroidIcon`, for all other types of `AndroidIcon` class, the `circleIcon` parameter will be ignored. (e.g always assigned false).

I should state that I'm not an Android expert on these topic, I needed to show the Person icon as a circle and I took the opportunity to implement this, it might not be the best solution but it works for me. I hope it can be useful for others as well.

Also, notice that I haven't added an sample usage of this new `circleIcon` on the `main.dart` in the example project because I didn't want to change the existing example code as it could have been produced some merge conflicts after the changes. So the best thing is to let contributors decide how to properly change the example app.

I tested it on a real device running the example application. Here is the result, Lunch bot's avatar changed into a circle avatar: 

<a href="https://ibb.co/ynLMB7b"><img src="https://i.ibb.co/svLDJzM/example-sceenshot.jpg" alt="example-sceenshot" border="0"></a>