### PR TITLE
[flutter_local_notifications] null checking mainActivity before .getIntent()

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -795,7 +795,9 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
 
     private void setActivity(Activity flutterActivity) {
         this.mainActivity = flutterActivity;
-        launchIntent = mainActivity.getIntent();
+        if (mainActivity != null) {
+            launchIntent = mainActivity.getIntent();
+        }
     }
 
     private void onAttachedToEngine(Context context, BinaryMessenger binaryMessenger) {


### PR DESCRIPTION
Calling 
```java 
 FlutterLocalNotificationsPlugin.registerWith(...
```
from background throws null pointer at
```java
launchIntent = mainActivity.getIntent();
```

Demo app repo here where we FirebaseMessaging will try to initialize  flutter_local_notifications from background (just run app):
https://github.com/bornold/firebase_messaging_local_notifications_npe_example
and example of using this fix:
https://github.com/bornold/firebase_messaging_local_notifications_npe_example/tree/using-fix