### PR TITLE
[flutter_local_notifications] setSmallIcon NullPointerException

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -183,12 +183,15 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         } else {
             SharedPreferences sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
             String defaultIcon = sharedPreferences.getString(DEFAULT_ICON, null);
-            if (StringUtils.isNullOrEmpty(defaultIcon)) {
+            
+            if (!StringUtils.isNullOrEmpty(defaultIcon)) {
+                builder.setSmallIcon(getDrawableResourceId(context, defaultIcon));
+            } else if (notificationDetails.iconResourceId != null) {
                 // for backwards compatibility: this is for handling the old way references to the icon used to be kept but should be removed in future
                 builder.setSmallIcon(notificationDetails.iconResourceId);
-
             } else {
-                builder.setSmallIcon(getDrawableResourceId(context, defaultIcon));
+                // for errors where small icon is null
+                builder.setSmallIcon(context.getApplicationInfo().icon);
             }
         }
     }


### PR DESCRIPTION
This is a proposed fix for 'Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference' in setSmallIcon method, described here https://github.com/MaikuB/flutter_local_notifications/issues/298

My thought is that, even if the small icon is indicated when a notification is being scheduled, some devices are clearing the data stored in SharedPreferences. This means that when a scheduled notification is going to be shown, it cannot find the small icon, so it crashes.

I think using the app icon in those cases is not the most elegant solution, but it has helped our team to reduce crash rate (this bug was number 1 in our list). I hope it helps.