### PR TITLE
[flutter_local_notifications] Fix pub versioning error in Flutter 1.22

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.4.4+5]
+
+* [Android] Fix issue [782](https://github.com/MaikuB/flutter_local_notifications/issues/782) by removing unused dependency to the platform lib which fixes the pub versioning error in Flutter 1.22.
+
 # [1.4.4+4]
 
 * [Android] Fix issue [759](https://github.com/MaikuB/flutter_local_notifications/issues/759) by guarding code on getting the intent from the activity in case there isn't an activity that could cause `initialize()` and `getNotificationAppLaunchDetails()` to fail when called from the background

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -1,12 +1,11 @@
 name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local notifications for Flutter applications with the ability to customise for each platform.
-version: 1.4.4+4
+version: 1.4.4+5
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:
   flutter:
     sdk: flutter
-  platform: ^2.2.1
   flutter_local_notifications_platform_interface: ^1.0.1
 
 dev_dependencies:


### PR DESCRIPTION
This fixes the issue here: https://github.com/MaikuB/flutter_local_notifications/issues/782
