### PR TITLE
[flutter_local_notifications] Create notification helper

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1,41 +1,17 @@
 import 'dart:async';
-import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:http/http.dart' as http;
-import 'package:path_provider/path_provider.dart';
-import 'package:rxdart/subjects.dart';
+import 'package:flutter_local_notifications_example/notification_helper.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
 
-// Streams are created so that app can respond to notification-related events since the plugin is initialised in the `main` function
-final BehaviorSubject<ReceivedNotification> didReceiveLocalNotificationSubject =
-    BehaviorSubject<ReceivedNotification>();
-
-final BehaviorSubject<String> selectNotificationSubject =
-    BehaviorSubject<String>();
-
 NotificationAppLaunchDetails notificationAppLaunchDetails;
 
-class ReceivedNotification {
-  final int id;
-  final String title;
-  final String body;
-  final String payload;
-
-  ReceivedNotification({
-    @required this.id,
-    @required this.title,
-    @required this.body,
-    @required this.payload,
-  });
-}
+final NotificationHelper notificationHelper = NotificationHelper();
 
 /// IMPORTANT: running the following code on its own won't work as there is setup required for each platform head project.
 /// Please download the complete example app from the GitHub repository where all the setup has been done
@@ -46,27 +22,9 @@ Future<void> main() async {
   notificationAppLaunchDetails =
       await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
 
-  var initializationSettingsAndroid = AndroidInitializationSettings('app_icon');
-  // Note: permissions aren't requested here just to demonstrate that can be done later using the `requestPermissions()` method
-  // of the `IOSFlutterLocalNotificationsPlugin` class
-  var initializationSettingsIOS = IOSInitializationSettings(
-      requestAlertPermission: false,
-      requestBadgePermission: false,
-      requestSoundPermission: false,
-      onDidReceiveLocalNotification:
-          (int id, String title, String body, String payload) async {
-        didReceiveLocalNotificationSubject.add(ReceivedNotification(
-            id: id, title: title, body: body, payload: payload));
-      });
-  var initializationSettings = InitializationSettings(
-      initializationSettingsAndroid, initializationSettingsIOS);
-  await flutterLocalNotificationsPlugin.initialize(initializationSettings,
-      onSelectNotification: (String payload) async {
-    if (payload != null) {
-      debugPrint('notification payload: ' + payload);
-    }
-    selectNotificationSubject.add(payload);
-  });
+  await notificationHelper
+      .initializeNotification(flutterLocalNotificationsPlugin);
+
   runApp(
     MaterialApp(
       home: HomePage(),
@@ -98,67 +56,14 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  final MethodChannel platform =
-      MethodChannel('crossingthestreams.io/resourceResolver');
   @override
   void initState() {
     super.initState();
-    _requestIOSPermissions();
-    _configureDidReceiveLocalNotificationSubject();
-    _configureSelectNotificationSubject();
-  }
-
-  void _requestIOSPermissions() {
-    flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            IOSFlutterLocalNotificationsPlugin>()
-        ?.requestPermissions(
-          alert: true,
-          badge: true,
-          sound: true,
-        );
-  }
-
-  void _configureDidReceiveLocalNotificationSubject() {
-    didReceiveLocalNotificationSubject.stream
-        .listen((ReceivedNotification receivedNotification) async {
-      await showDialog(
-        context: context,
-        builder: (BuildContext context) => CupertinoAlertDialog(
-          title: receivedNotification.title != null
-              ? Text(receivedNotification.title)
-              : null,
-          content: receivedNotification.body != null
-              ? Text(receivedNotification.body)
-              : null,
-          actions: [
-            CupertinoDialogAction(
-              isDefaultAction: true,
-              child: Text('Ok'),
-              onPressed: () async {
-                Navigator.of(context, rootNavigator: true).pop();
-                await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) =>
-                        SecondScreen(receivedNotification.payload),
-                  ),
-                );
-              },
-            )
-          ],
-        ),
-      );
-    });
-  }
-
-  void _configureSelectNotificationSubject() {
-    selectNotificationSubject.stream.listen((String payload) async {
-      await Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => SecondScreen(payload)),
-      );
-    });
+    notificationHelper.requestIOSPermissions(flutterLocalNotificationsPlugin);
+    notificationHelper.configureDidReceiveLocalNotificationSubject(
+        flutterLocalNotificationsPlugin, context);
+    notificationHelper.configureSelectNotificationSubject(
+        flutterLocalNotificationsPlugin, context);
   }
 
   @override
@@ -225,41 +130,48 @@ class _HomePageState extends State<HomePage> {
                   PaddedRaisedButton(
                     buttonText: 'Show plain notification with payload',
                     onPressed: () async {
-                      await _showNotification();
+                      await notificationHelper
+                          .showNotification(flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show plain notification that has no body with payload',
                     onPressed: () async {
-                      await _showNotificationWithNoBody();
+                      await notificationHelper.showNotificationWithNoBody(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show plain notification with payload and update channel description [Android]',
                     onPressed: () async {
-                      await _showNotificationWithUpdatedChannelDescription();
+                      await notificationHelper
+                          .showNotificationWithUpdatedChannelDescription(
+                              flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show plain notification as public on every lockscreen [Android]',
                     onPressed: () async {
-                      await _showPublicNotification();
+                      await notificationHelper.showPublicNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Cancel notification',
                     onPressed: () async {
-                      await _cancelNotification();
+                      await notificationHelper
+                          .cancelNotification(flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Schedule notification to appear in 5 seconds, custom sound, red colour, large icon, red LED',
                     onPressed: () async {
-                      await _scheduleNotification();
+                      await notificationHelper.scheduleNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   Text(
@@ -267,166 +179,195 @@ class _HomePageState extends State<HomePage> {
                   PaddedRaisedButton(
                     buttonText: 'Repeat notification every minute',
                     onPressed: () async {
-                      await _repeatNotification();
+                      await notificationHelper
+                          .repeatNotification(flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Repeat notification every day at approximately 10:00:00 am',
                     onPressed: () async {
-                      await _showDailyAtTime();
+                      await notificationHelper
+                          .showDailyAtTime(flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Repeat notification weekly on Monday at approximately 10:00:00 am',
                     onPressed: () async {
-                      await _showWeeklyAtDayAndTime();
+                      await notificationHelper.showWeeklyAtDayAndTime(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show notification with no sound',
                     onPressed: () async {
-                      await _showNotificationWithNoSound();
+                      await notificationHelper.showNotificationWithNoSound(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show notification using Android Uri sound [Android]',
                     onPressed: () async {
-                      await _showSoundUriNotification();
+                      await notificationHelper.showSoundUriNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show notification that times out after 3 seconds [Android]',
                     onPressed: () async {
-                      await _showTimeoutNotification();
+                      await notificationHelper.showTimeoutNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show insistent notification [Android]',
                     onPressed: () async {
-                      await _showInsistentNotification();
+                      await notificationHelper.showInsistentNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show big picture notification [Android]',
                     onPressed: () async {
-                      await _showBigPictureNotification();
+                      await notificationHelper.showBigPictureNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show big picture notification, hide large icon on expand [Android]',
                     onPressed: () async {
-                      await _showBigPictureNotificationHideExpandedLargeIcon();
+                      await notificationHelper
+                          .showBigPictureNotificationHideExpandedLargeIcon(
+                              flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show media notification [Android]',
                     onPressed: () async {
-                      await _showNotificationMediaStyle();
+                      await notificationHelper.showNotificationMediaStyle(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show big text notification [Android]',
                     onPressed: () async {
-                      await _showBigTextNotification();
+                      await notificationHelper.showBigTextNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show inbox notification [Android]',
                     onPressed: () async {
-                      await _showInboxNotification();
+                      await notificationHelper.showInboxNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show messaging notification [Android]',
                     onPressed: () async {
-                      await _showMessagingNotification();
+                      await notificationHelper.showMessagingNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show grouped notifications [Android]',
                     onPressed: () async {
-                      await _showGroupedNotifications();
+                      await notificationHelper.showGroupedNotifications(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show ongoing notification [Android]',
                     onPressed: () async {
-                      await _showOngoingNotification();
+                      await notificationHelper.showOngoingNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show notification with no badge, alert only once [Android]',
                     onPressed: () async {
-                      await _showNotificationWithNoBadge();
+                      await notificationHelper.showNotificationWithNoBadge(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show progress notification - updates every second [Android]',
                     onPressed: () async {
-                      await _showProgressNotification();
+                      await notificationHelper.showProgressNotification(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show indeterminate progress notification [Android]',
                     onPressed: () async {
-                      await _showIndeterminateProgressNotification();
+                      await notificationHelper
+                          .showIndeterminateProgressNotification(
+                              flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Check pending notifications',
                     onPressed: () async {
-                      await _checkPendingNotificationRequests();
+                      await notificationHelper.checkPendingNotificationRequests(
+                          flutterLocalNotificationsPlugin, context);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Cancel all notifications',
                     onPressed: () async {
-                      await _cancelAllNotifications();
+                      await notificationHelper.cancelAllNotifications(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show notification with icon badge [iOS]',
                     onPressed: () async {
-                      await _showNotificationWithIconBadge();
+                      await notificationHelper.showNotificationWithIconBadge(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show notification without timestamp [Android]',
                     onPressed: () async {
-                      await _showNotificationWithoutTimestamp();
+                      await notificationHelper.showNotificationWithoutTimestamp(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText:
                         'Show notification with custom timestamp [Android]',
                     onPressed: () async {
-                      await _showNotificationWithCustomTimestamp();
+                      await notificationHelper
+                          .showNotificationWithCustomTimestamp(
+                              flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Show notification with attachment [iOS]',
                     onPressed: () async {
-                      await _showNotificationWithAttachment();
+                      await notificationHelper.showNotificationWithAttachment(
+                          flutterLocalNotificationsPlugin);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Create notification channel [Android]',
                     onPressed: () async {
-                      await _createNotificationChannel();
+                      await notificationHelper.createNotificationChannel(
+                          flutterLocalNotificationsPlugin, context);
                     },
                   ),
                   PaddedRaisedButton(
                     buttonText: 'Delete notification channel [Android]',
                     onPressed: () async {
-                      await _deleteNotificationChannel();
+                      await notificationHelper.deleteNotificationChannel(
+                          flutterLocalNotificationsPlugin, context);
                     },
                   ),
                 ],
@@ -436,657 +377,6 @@ class _HomePageState extends State<HomePage> {
         ),
       ),
     );
-  }
-
-  Future<void> _showNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max, priority: Priority.High, ticker: 'ticker');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', 'plain body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithNoBody() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max, priority: Priority.High, ticker: 'ticker');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', null, platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _cancelNotification() async {
-    await flutterLocalNotificationsPlugin.cancel(0);
-  }
-
-  /// Schedules a notification that specifies a different icon, sound and vibration pattern
-  Future<void> _scheduleNotification() async {
-    var scheduledNotificationDateTime =
-        DateTime.now().add(Duration(seconds: 5));
-    var vibrationPattern = Int64List(4);
-    vibrationPattern[0] = 0;
-    vibrationPattern[1] = 1000;
-    vibrationPattern[2] = 5000;
-    vibrationPattern[3] = 2000;
-
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your other channel id',
-        'your other channel name',
-        'your other channel description',
-        icon: 'secondary_icon',
-        sound: RawResourceAndroidNotificationSound('slow_spring_board'),
-        largeIcon: DrawableResourceAndroidBitmap('sample_large_icon'),
-        vibrationPattern: vibrationPattern,
-        enableLights: true,
-        color: const Color.fromARGB(255, 255, 0, 0),
-        ledColor: const Color.fromARGB(255, 255, 0, 0),
-        ledOnMs: 1000,
-        ledOffMs: 500);
-    var iOSPlatformChannelSpecifics =
-        IOSNotificationDetails(sound: 'slow_spring_board.aiff');
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.schedule(
-        0,
-        'scheduled title',
-        'scheduled body',
-        scheduledNotificationDateTime,
-        platformChannelSpecifics);
-  }
-
-  Future<void> _showNotificationWithNoSound() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'silent channel id',
-        'silent channel name',
-        'silent channel description',
-        playSound: false,
-        styleInformation: DefaultStyleInformation(true, true));
-    var iOSPlatformChannelSpecifics =
-        IOSNotificationDetails(presentSound: false);
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, '<b>silent</b> title',
-        '<b>silent</b> body', platformChannelSpecifics);
-  }
-
-  Future<void> _showSoundUriNotification() async {
-    // this calls a method over a platform channel implemented within the example app to return the Uri for the default
-    // alarm sound and uses as the notification sound
-    String alarmUri = await platform.invokeMethod('getAlarmUri');
-    final x = UriAndroidNotificationSound(alarmUri);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'uri channel id', 'uri channel name', 'uri channel description',
-        sound: x,
-        playSound: true,
-        styleInformation: DefaultStyleInformation(true, true));
-    var iOSPlatformChannelSpecifics =
-        IOSNotificationDetails(presentSound: false);
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'uri sound title', 'uri sound body', platformChannelSpecifics);
-  }
-
-  Future<void> _showTimeoutNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'silent channel id',
-        'silent channel name',
-        'silent channel description',
-        timeoutAfter: 3000,
-        styleInformation: DefaultStyleInformation(true, true));
-    var iOSPlatformChannelSpecifics =
-        IOSNotificationDetails(presentSound: false);
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, 'timeout notification',
-        'Times out after 3 seconds', platformChannelSpecifics);
-  }
-
-  Future<void> _showInsistentNotification() async {
-    // This value is from: https://developer.android.com/reference/android/app/Notification.html#FLAG_INSISTENT
-    var insistentFlag = 4;
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max,
-        priority: Priority.High,
-        ticker: 'ticker',
-        additionalFlags: Int32List.fromList([insistentFlag]));
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'insistent title', 'insistent body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<String> _downloadAndSaveFile(String url, String fileName) async {
-    var directory = await getApplicationDocumentsDirectory();
-    var filePath = '${directory.path}/$fileName';
-    var response = await http.get(url);
-    var file = File(filePath);
-    await file.writeAsBytes(response.bodyBytes);
-    return filePath;
-  }
-
-  Future<void> _showBigPictureNotification() async {
-    var largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
-    var bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/400x800', 'bigPicture');
-    var bigPictureStyleInformation = BigPictureStyleInformation(
-        FilePathAndroidBitmap(bigPicturePath),
-        largeIcon: FilePathAndroidBitmap(largeIconPath),
-        contentTitle: 'overridden <b>big</b> content title',
-        htmlFormatContentTitle: true,
-        summaryText: 'summary <i>text</i>',
-        htmlFormatSummaryText: true);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'big text channel id',
-        'big text channel name',
-        'big text channel description',
-        styleInformation: bigPictureStyleInformation);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
-  }
-
-  Future<void> _showBigPictureNotificationHideExpandedLargeIcon() async {
-    var largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
-    var bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/400x800', 'bigPicture');
-    var bigPictureStyleInformation = BigPictureStyleInformation(
-        FilePathAndroidBitmap(bigPicturePath),
-        hideExpandedLargeIcon: true,
-        contentTitle: 'overridden <b>big</b> content title',
-        htmlFormatContentTitle: true,
-        summaryText: 'summary <i>text</i>',
-        htmlFormatSummaryText: true);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'big text channel id',
-        'big text channel name',
-        'big text channel description',
-        largeIcon: FilePathAndroidBitmap(largeIconPath),
-        styleInformation: bigPictureStyleInformation);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
-  }
-
-  Future<void> _showNotificationMediaStyle() async {
-    var largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/128x128/00FF00/000000', 'largeIcon');
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-      'media channel id',
-      'media channel name',
-      'media channel description',
-      largeIcon: FilePathAndroidBitmap(largeIconPath),
-      styleInformation: MediaStyleInformation(),
-    );
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'notification title', 'notification body', platformChannelSpecifics);
-  }
-
-  Future<void> _showBigTextNotification() async {
-    var bigTextStyleInformation = BigTextStyleInformation(
-        'Lorem <i>ipsum dolor sit</i> amet, consectetur <b>adipiscing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-        htmlFormatBigText: true,
-        contentTitle: 'overridden <b>big</b> content title',
-        htmlFormatContentTitle: true,
-        summaryText: 'summary <i>text</i>',
-        htmlFormatSummaryText: true);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'big text channel id',
-        'big text channel name',
-        'big text channel description',
-        styleInformation: bigTextStyleInformation);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'big text title', 'silent body', platformChannelSpecifics);
-  }
-
-  Future<void> _showInboxNotification() async {
-    var lines = List<String>();
-    lines.add('line <b>1</b>');
-    lines.add('line <i>2</i>');
-    var inboxStyleInformation = InboxStyleInformation(lines,
-        htmlFormatLines: true,
-        contentTitle: 'overridden <b>inbox</b> context title',
-        htmlFormatContentTitle: true,
-        summaryText: 'summary <i>text</i>',
-        htmlFormatSummaryText: true);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'inbox channel id', 'inboxchannel name', 'inbox channel description',
-        styleInformation: inboxStyleInformation);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'inbox title', 'inbox body', platformChannelSpecifics);
-  }
-
-  Future<void> _showMessagingNotification() async {
-    // use a platform channel to resolve an Android drawable resource to a URI.
-    // This is NOT part of the notifications plugin. Calls made over this channel is handled by the app
-    String imageUri = await platform.invokeMethod('drawableToUri', 'food');
-    var messages = List<Message>();
-    // First two person objects will use icons that part of the Android app's drawable resources
-    var me = Person(
-      name: 'Me',
-      key: '1',
-      uri: 'tel:1234567890',
-      icon: DrawableResourceAndroidIcon('me'),
-    );
-    var coworker = Person(
-      name: 'Coworker',
-      key: '2',
-      uri: 'tel:9876543210',
-      icon: FlutterBitmapAssetAndroidIcon('icons/coworker.png'),
-    );
-    // download the icon that would be use for the lunch bot person
-    var largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
-    // this person object will use an icon that was downloaded
-    var lunchBot = Person(
-      name: 'Lunch bot',
-      key: 'bot',
-      bot: true,
-      icon: BitmapFilePathAndroidIcon(largeIconPath),
-    );
-    messages.add(Message('Hi', DateTime.now(), null));
-    messages.add(Message(
-        'What\'s up?', DateTime.now().add(Duration(minutes: 5)), coworker));
-    messages.add(Message(
-        'Lunch?', DateTime.now().add(Duration(minutes: 10)), null,
-        dataMimeType: 'image/png', dataUri: imageUri));
-    messages.add(Message('What kind of food would you prefer?',
-        DateTime.now().add(Duration(minutes: 10)), lunchBot));
-    var messagingStyle = MessagingStyleInformation(me,
-        groupConversation: true,
-        conversationTitle: 'Team lunch',
-        htmlFormatContent: true,
-        htmlFormatTitle: true,
-        messages: messages);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'message channel id',
-        'message channel name',
-        'message channel description',
-        category: 'msg',
-        styleInformation: messagingStyle);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'message title', 'message body', platformChannelSpecifics);
-
-    // wait 10 seconds and add another message to simulate another response
-    await Future.delayed(Duration(seconds: 10), () async {
-      messages.add(
-          Message('Thai', DateTime.now().add(Duration(minutes: 11)), null));
-      await flutterLocalNotificationsPlugin.show(
-          0, 'message title', 'message body', platformChannelSpecifics);
-    });
-  }
-
-  Future<void> _showGroupedNotifications() async {
-    var groupKey = 'com.android.example.WORK_EMAIL';
-    var groupChannelId = 'grouped channel id';
-    var groupChannelName = 'grouped channel name';
-    var groupChannelDescription = 'grouped channel description';
-    // example based on https://developer.android.com/training/notify-user/group.html
-    var firstNotificationAndroidSpecifics = AndroidNotificationDetails(
-        groupChannelId, groupChannelName, groupChannelDescription,
-        importance: Importance.Max,
-        priority: Priority.High,
-        groupKey: groupKey);
-    var firstNotificationPlatformSpecifics =
-        NotificationDetails(firstNotificationAndroidSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(1, 'Alex Faarborg',
-        'You will not believe...', firstNotificationPlatformSpecifics);
-    var secondNotificationAndroidSpecifics = AndroidNotificationDetails(
-        groupChannelId, groupChannelName, groupChannelDescription,
-        importance: Importance.Max,
-        priority: Priority.High,
-        groupKey: groupKey);
-    var secondNotificationPlatformSpecifics =
-        NotificationDetails(secondNotificationAndroidSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        2,
-        'Jeff Chang',
-        'Please join us to celebrate the...',
-        secondNotificationPlatformSpecifics);
-
-    // create the summary notification to support older devices that pre-date Android 7.0 (API level 24).
-    // this is required is regardless of which versions of Android your application is going to support
-    var lines = List<String>();
-    lines.add('Alex Faarborg  Check this out');
-    lines.add('Jeff Chang    Launch Party');
-    var inboxStyleInformation = InboxStyleInformation(lines,
-        contentTitle: '2 messages', summaryText: 'janedoe@example.com');
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        groupChannelId, groupChannelName, groupChannelDescription,
-        styleInformation: inboxStyleInformation,
-        groupKey: groupKey,
-        setAsGroupSummary: true);
-    var platformChannelSpecifics =
-        NotificationDetails(androidPlatformChannelSpecifics, null);
-    await flutterLocalNotificationsPlugin.show(
-        3, 'Attention', 'Two messages', platformChannelSpecifics);
-  }
-
-  Future<void> _checkPendingNotificationRequests() async {
-    var pendingNotificationRequests =
-        await flutterLocalNotificationsPlugin.pendingNotificationRequests();
-    return showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          content: Text(
-              '${pendingNotificationRequests.length} pending notification requests'),
-          actions: [
-            FlatButton(
-              child: Text('OK'),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  Future<void> _cancelAllNotifications() async {
-    await flutterLocalNotificationsPlugin.cancelAll();
-  }
-
-  Future<void> _showOngoingNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max,
-        priority: Priority.High,
-        ongoing: true,
-        autoCancel: false);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, 'ongoing notification title',
-        'ongoing notification body', platformChannelSpecifics);
-  }
-
-  Future<void> _repeatNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'repeating channel id',
-        'repeating channel name',
-        'repeating description');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating title',
-        'repeating body', RepeatInterval.EveryMinute, platformChannelSpecifics);
-  }
-
-  Future<void> _showDailyAtTime() async {
-    var time = Time(10, 0, 0);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'repeatDailyAtTime channel id',
-        'repeatDailyAtTime channel name',
-        'repeatDailyAtTime description');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.showDailyAtTime(
-        0,
-        'show daily title',
-        'Daily notification shown at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
-        time,
-        platformChannelSpecifics);
-  }
-
-  Future<void> _showWeeklyAtDayAndTime() async {
-    var time = Time(10, 0, 0);
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'show weekly channel id',
-        'show weekly channel name',
-        'show weekly description');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
-        0,
-        'show weekly title',
-        'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
-        Day.Monday,
-        time,
-        platformChannelSpecifics);
-  }
-
-  Future<void> _showNotificationWithNoBadge() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'no badge channel', 'no badge name', 'no badge description',
-        channelShowBadge: false,
-        importance: Importance.Max,
-        priority: Priority.High,
-        onlyAlertOnce: true);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'no badge title', 'no badge body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showProgressNotification() async {
-    var maxProgress = 5;
-    for (var i = 0; i <= maxProgress; i++) {
-      await Future.delayed(Duration(seconds: 1), () async {
-        var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-            'progress channel',
-            'progress channel',
-            'progress channel description',
-            channelShowBadge: false,
-            importance: Importance.Max,
-            priority: Priority.High,
-            onlyAlertOnce: true,
-            showProgress: true,
-            maxProgress: maxProgress,
-            progress: i);
-        var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-        var platformChannelSpecifics = NotificationDetails(
-            androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-        await flutterLocalNotificationsPlugin.show(
-            0,
-            'progress notification title',
-            'progress notification body',
-            platformChannelSpecifics,
-            payload: 'item x');
-      });
-    }
-  }
-
-  Future<void> _showIndeterminateProgressNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'indeterminate progress channel',
-        'indeterminate progress channel',
-        'indeterminate progress channel description',
-        channelShowBadge: false,
-        importance: Importance.Max,
-        priority: Priority.High,
-        onlyAlertOnce: true,
-        showProgress: true,
-        indeterminate: true);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0,
-        'indeterminate progress notification title',
-        'indeterminate progress notification body',
-        platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithUpdatedChannelDescription() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id',
-        'your channel name',
-        'your updated channel description',
-        importance: Importance.Max,
-        priority: Priority.High,
-        channelAction: AndroidNotificationChannelAction.Update);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0,
-        'updated notification channel',
-        'check settings to see updated channel description',
-        platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showPublicNotification() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max,
-        priority: Priority.High,
-        ticker: 'ticker',
-        visibility: NotificationVisibility.Public);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(0, 'public notification title',
-        'public notification body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithIconBadge() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'icon badge channel', 'icon badge name', 'icon badge description');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails(badgeNumber: 1);
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithoutTimestamp() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.Max, priority: Priority.High, showWhen: false);
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', 'plain body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithCustomTimestamp() async {
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-      'your channel id',
-      'your channel name',
-      'your channel description',
-      importance: Importance.Max,
-      priority: Priority.High,
-      showWhen: true,
-      when: DateTime.now().millisecondsSinceEpoch - 120 * 1000,
-    );
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
-    var platformChannelSpecifics = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0, 'plain title', 'plain body', platformChannelSpecifics,
-        payload: 'item x');
-  }
-
-  Future<void> _showNotificationWithAttachment() async {
-    var bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/600x200', 'bigPicture.jpg');
-    var iOSPlatformChannelSpecifics = IOSNotificationDetails(
-        attachments: [IOSNotificationAttachment(bigPicturePath)]);
-    var bigPictureAndroidStyle =
-        BigPictureStyleInformation(FilePathAndroidBitmap(bigPicturePath));
-    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
-        'your channel id', 'your channel name', 'your channel description',
-        importance: Importance.High,
-        priority: Priority.High,
-        styleInformation: bigPictureAndroidStyle);
-    var notificationDetails = NotificationDetails(
-        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(
-        0,
-        'notification with attachment title',
-        'notification with attachment body',
-        notificationDetails);
-  }
-
-  Future<void> _createNotificationChannel() async {
-    var androidNotificationChannel = AndroidNotificationChannel(
-      'your channel id 2',
-      'your channel name 2',
-      'your channel description 2',
-    );
-    await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
-        ?.createNotificationChannel(androidNotificationChannel);
-
-    await showDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            content: Text(
-                'Channel with name \"${androidNotificationChannel.name}\" created'),
-            actions: [
-              FlatButton(
-                child: Text('OK'),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-          );
-        });
-  }
-
-  Future<void> _deleteNotificationChannel() async {
-    const channelId = 'your channel id 2';
-    await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
-        ?.deleteNotificationChannel(channelId);
-
-    await showDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            content: Text('Channel with id \"$channelId\" deleted'),
-            actions: [
-              FlatButton(
-                child: Text('OK'),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-          );
-        });
-  }
-
-  String _toTwoDigitString(int value) {
-    return value.toString().padLeft(2, '0');
   }
 }
 
@@ -1101,6 +391,7 @@ class SecondScreen extends StatefulWidget {
 
 class SecondScreenState extends State<SecondScreen> {
   String _payload;
+
   @override
   void initState() {
     super.initState();

--- a/flutter_local_notifications/example/lib/notification_helper.dart
+++ b/flutter_local_notifications/example/lib/notification_helper.dart
@@ -1,0 +1,815 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:rxdart/subjects.dart';
+import 'package:http/http.dart' as http;
+
+import 'main.dart';
+
+// Streams are created so that app can respond to notification-related events since the plugin is initialised in the `main` function
+final BehaviorSubject<ReceivedNotification> didReceiveLocalNotificationSubject =
+    BehaviorSubject<ReceivedNotification>();
+
+final BehaviorSubject<String> selectNotificationSubject =
+    BehaviorSubject<String>();
+
+class ReceivedNotification {
+  final int id;
+  final String title;
+  final String body;
+  final String payload;
+
+  ReceivedNotification({
+    @required this.id,
+    @required this.title,
+    @required this.body,
+    @required this.payload,
+  });
+}
+
+class NotificationHelper {
+  static NotificationHelper _instance;
+  final MethodChannel _platform =
+      MethodChannel('crossingthestreams.io/resourceResolver');
+
+  NotificationHelper._internal() {
+    _instance = this;
+  }
+
+  factory NotificationHelper() => _instance ?? NotificationHelper._internal();
+
+  Future<void> initializeNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var initializationSettingsAndroid =
+        AndroidInitializationSettings('app_icon');
+    // Note: permissions aren't requested here just to demonstrate that can be done later using the `requestPermissions()` method
+    // of the `IOSFlutterLocalNotificationsPlugin` class
+    var initializationSettingsIOS = IOSInitializationSettings(
+        requestAlertPermission: false,
+        requestBadgePermission: false,
+        requestSoundPermission: false,
+        onDidReceiveLocalNotification:
+            (int id, String title, String body, String payload) async {
+          didReceiveLocalNotificationSubject.add(ReceivedNotification(
+              id: id, title: title, body: body, payload: payload));
+        });
+    var initializationSettings = InitializationSettings(
+        initializationSettingsAndroid, initializationSettingsIOS);
+    await flutterLocalNotificationsPlugin.initialize(initializationSettings,
+        onSelectNotification: (String payload) async {
+      if (payload != null) {
+        debugPrint('notification payload: ' + payload);
+      }
+      selectNotificationSubject.add(payload);
+    });
+  }
+
+  void requestIOSPermissions(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) {
+    flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+  }
+
+  Future<void> showNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max, priority: Priority.High, ticker: 'ticker');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithNoBody(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max, priority: Priority.High, ticker: 'ticker');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', null, platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> cancelNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    await flutterLocalNotificationsPlugin.cancel(0);
+  }
+
+  /// Schedules a notification that specifies a different icon, sound and vibration pattern
+  Future<void> scheduleNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var scheduledNotificationDateTime =
+        DateTime.now().add(Duration(seconds: 5));
+    var vibrationPattern = Int64List(4);
+    vibrationPattern[0] = 0;
+    vibrationPattern[1] = 1000;
+    vibrationPattern[2] = 5000;
+    vibrationPattern[3] = 2000;
+
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your other channel id',
+        'your other channel name',
+        'your other channel description',
+        icon: 'secondary_icon',
+        sound: RawResourceAndroidNotificationSound('slow_spring_board'),
+        largeIcon: DrawableResourceAndroidBitmap('sample_large_icon'),
+        vibrationPattern: vibrationPattern,
+        enableLights: true,
+        color: const Color.fromARGB(255, 255, 0, 0),
+        ledColor: const Color.fromARGB(255, 255, 0, 0),
+        ledOnMs: 1000,
+        ledOffMs: 500);
+    var iOSPlatformChannelSpecifics =
+        IOSNotificationDetails(sound: 'slow_spring_board.aiff');
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.schedule(
+        0,
+        'scheduled title',
+        'scheduled body',
+        scheduledNotificationDateTime,
+        platformChannelSpecifics);
+  }
+
+  Future<void> showNotificationWithNoSound(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'silent channel id',
+        'silent channel name',
+        'silent channel description',
+        playSound: false,
+        styleInformation: DefaultStyleInformation(true, true));
+    var iOSPlatformChannelSpecifics =
+        IOSNotificationDetails(presentSound: false);
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, '<b>silent</b> title',
+        '<b>silent</b> body', platformChannelSpecifics);
+  }
+
+  Future<void> showSoundUriNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    // this calls a method over a platform channel implemented within the example app to return the Uri for the default
+    // alarm sound and uses as the notification sound
+    var alarmUri = await _platform.invokeMethod('getAlarmUri');
+    final x = UriAndroidNotificationSound(alarmUri);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'uri channel id', 'uri channel name', 'uri channel description',
+        sound: x,
+        playSound: true,
+        styleInformation: DefaultStyleInformation(true, true));
+    var iOSPlatformChannelSpecifics =
+        IOSNotificationDetails(presentSound: false);
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'uri sound title', 'uri sound body', platformChannelSpecifics);
+  }
+
+  Future<void> showTimeoutNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'silent channel id',
+        'silent channel name',
+        'silent channel description',
+        timeoutAfter: 3000,
+        styleInformation: DefaultStyleInformation(true, true));
+    var iOSPlatformChannelSpecifics =
+        IOSNotificationDetails(presentSound: false);
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, 'timeout notification',
+        'Times out after 3 seconds', platformChannelSpecifics);
+  }
+
+  Future<void> showInsistentNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    // This value is from: https://developer.android.com/reference/android/app/Notification.html#FLAG_INSISTENT
+    var insistentFlag = 4;
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max,
+        priority: Priority.High,
+        ticker: 'ticker',
+        additionalFlags: Int32List.fromList([insistentFlag]));
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'insistent title', 'insistent body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<String> _downloadAndSaveFile(String url, String fileName) async {
+    var directory = await getApplicationDocumentsDirectory();
+    var filePath = '${directory.path}/$fileName';
+    var response = await http.get(url);
+    var file = File(filePath);
+    await file.writeAsBytes(response.bodyBytes);
+    return filePath;
+  }
+
+  Future<void> showBigPictureNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var largeIconPath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/48x48', 'largeIcon');
+    var bigPicturePath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/400x800', 'bigPicture');
+    var bigPictureStyleInformation = BigPictureStyleInformation(
+        FilePathAndroidBitmap(bigPicturePath),
+        largeIcon: FilePathAndroidBitmap(largeIconPath),
+        contentTitle: 'overridden <b>big</b> content title',
+        htmlFormatContentTitle: true,
+        summaryText: 'summary <i>text</i>',
+        htmlFormatSummaryText: true);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'big text channel id',
+        'big text channel name',
+        'big text channel description',
+        styleInformation: bigPictureStyleInformation);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'big text title', 'silent body', platformChannelSpecifics);
+  }
+
+  Future<void> showBigPictureNotificationHideExpandedLargeIcon(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var largeIconPath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/48x48', 'largeIcon');
+    var bigPicturePath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/400x800', 'bigPicture');
+    var bigPictureStyleInformation = BigPictureStyleInformation(
+        FilePathAndroidBitmap(bigPicturePath),
+        hideExpandedLargeIcon: true,
+        contentTitle: 'overridden <b>big</b> content title',
+        htmlFormatContentTitle: true,
+        summaryText: 'summary <i>text</i>',
+        htmlFormatSummaryText: true);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'big text channel id',
+        'big text channel name',
+        'big text channel description',
+        largeIcon: FilePathAndroidBitmap(largeIconPath),
+        styleInformation: bigPictureStyleInformation);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'big text title', 'silent body', platformChannelSpecifics);
+  }
+
+  Future<void> showNotificationMediaStyle(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var largeIconPath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/128x128/00FF00/000000', 'largeIcon');
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+      'media channel id',
+      'media channel name',
+      'media channel description',
+      largeIcon: FilePathAndroidBitmap(largeIconPath),
+      styleInformation: MediaStyleInformation(),
+    );
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'notification title', 'notification body', platformChannelSpecifics);
+  }
+
+  Future<void> showBigTextNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var bigTextStyleInformation = BigTextStyleInformation(
+        'Lorem <i>ipsum dolor sit</i> amet, consectetur <b>adipiscing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+        htmlFormatBigText: true,
+        contentTitle: 'overridden <b>big</b> content title',
+        htmlFormatContentTitle: true,
+        summaryText: 'summary <i>text</i>',
+        htmlFormatSummaryText: true);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'big text channel id',
+        'big text channel name',
+        'big text channel description',
+        styleInformation: bigTextStyleInformation);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'big text title', 'silent body', platformChannelSpecifics);
+  }
+
+  Future<void> showInboxNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var lines = <String>[];
+    lines.add('line <b>1</b>');
+    lines.add('line <i>2</i>');
+    var inboxStyleInformation = InboxStyleInformation(lines,
+        htmlFormatLines: true,
+        contentTitle: 'overridden <b>inbox</b> context title',
+        htmlFormatContentTitle: true,
+        summaryText: 'summary <i>text</i>',
+        htmlFormatSummaryText: true);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'inbox channel id', 'inboxchannel name', 'inbox channel description',
+        styleInformation: inboxStyleInformation);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'inbox title', 'inbox body', platformChannelSpecifics);
+  }
+
+  Future<void> showMessagingNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    // use a platform channel to resolve an Android drawable resource to a URI.
+    // This is NOT part of the notifications plugin. Calls made over this channel is handled by the app
+    var imageUri = await _platform.invokeMethod('drawableToUri', 'food');
+    var messages = <Message>[];
+    // First two person objects will use icons that part of the Android app's drawable resources
+    var me = Person(
+      name: 'Me',
+      key: '1',
+      uri: 'tel:1234567890',
+      icon: DrawableResourceAndroidIcon('me'),
+    );
+    var coworker = Person(
+      name: 'Coworker',
+      key: '2',
+      uri: 'tel:9876543210',
+      icon: FlutterBitmapAssetAndroidIcon('icons/coworker.png'),
+    );
+    // download the icon that would be use for the lunch bot person
+    var largeIconPath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/48x48', 'largeIcon');
+    // this person object will use an icon that was downloaded
+    var lunchBot = Person(
+      name: 'Lunch bot',
+      key: 'bot',
+      bot: true,
+      icon: BitmapFilePathAndroidIcon(largeIconPath),
+    );
+    messages.add(Message('Hi', DateTime.now(), null));
+    messages.add(Message(
+        'What\'s up?', DateTime.now().add(Duration(minutes: 5)), coworker));
+    messages.add(Message(
+        'Lunch?', DateTime.now().add(Duration(minutes: 10)), null,
+        dataMimeType: 'image/png', dataUri: imageUri));
+    messages.add(Message('What kind of food would you prefer?',
+        DateTime.now().add(Duration(minutes: 10)), lunchBot));
+    var messagingStyle = MessagingStyleInformation(me,
+        groupConversation: true,
+        conversationTitle: 'Team lunch',
+        htmlFormatContent: true,
+        htmlFormatTitle: true,
+        messages: messages);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'message channel id',
+        'message channel name',
+        'message channel description',
+        category: 'msg',
+        styleInformation: messagingStyle);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'message title', 'message body', platformChannelSpecifics);
+
+    // wait 10 seconds and add another message to simulate another response
+    await Future.delayed(Duration(seconds: 10), () async {
+      messages.add(
+          Message('Thai', DateTime.now().add(Duration(minutes: 11)), null));
+      await flutterLocalNotificationsPlugin.show(
+          0, 'message title', 'message body', platformChannelSpecifics);
+    });
+  }
+
+  Future<void> showGroupedNotifications(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var groupKey = 'com.android.example.WORK_EMAIL';
+    var groupChannelId = 'grouped channel id';
+    var groupChannelName = 'grouped channel name';
+    var groupChannelDescription = 'grouped channel description';
+    // example based on https://developer.android.com/training/notify-user/group.html
+    var firstNotificationAndroidSpecifics = AndroidNotificationDetails(
+        groupChannelId, groupChannelName, groupChannelDescription,
+        importance: Importance.Max,
+        priority: Priority.High,
+        groupKey: groupKey);
+    var firstNotificationPlatformSpecifics =
+        NotificationDetails(firstNotificationAndroidSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(1, 'Alex Faarborg',
+        'You will not believe...', firstNotificationPlatformSpecifics);
+    var secondNotificationAndroidSpecifics = AndroidNotificationDetails(
+        groupChannelId, groupChannelName, groupChannelDescription,
+        importance: Importance.Max,
+        priority: Priority.High,
+        groupKey: groupKey);
+    var secondNotificationPlatformSpecifics =
+        NotificationDetails(secondNotificationAndroidSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        2,
+        'Jeff Chang',
+        'Please join us to celebrate the...',
+        secondNotificationPlatformSpecifics);
+
+    // create the summary notification to support older devices that pre-date Android 7.0 (API level 24).
+    // this is required is regardless of which versions of Android your application is going to support
+    var lines = <String>[];
+    lines.add('Alex Faarborg  Check this out');
+    lines.add('Jeff Chang    Launch Party');
+    var inboxStyleInformation = InboxStyleInformation(lines,
+        contentTitle: '2 messages', summaryText: 'janedoe@example.com');
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        groupChannelId, groupChannelName, groupChannelDescription,
+        styleInformation: inboxStyleInformation,
+        groupKey: groupKey,
+        setAsGroupSummary: true);
+    var platformChannelSpecifics =
+        NotificationDetails(androidPlatformChannelSpecifics, null);
+    await flutterLocalNotificationsPlugin.show(
+        3, 'Attention', 'Two messages', platformChannelSpecifics);
+  }
+
+  Future<void> checkPendingNotificationRequests(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
+      BuildContext context) async {
+    var pendingNotificationRequests =
+        await flutterLocalNotificationsPlugin.pendingNotificationRequests();
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          content: Text(
+              '${pendingNotificationRequests.length} pending notification requests'),
+          actions: [
+            FlatButton(
+              child: Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> cancelAllNotifications(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    await flutterLocalNotificationsPlugin.cancelAll();
+  }
+
+  Future<void> showOngoingNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max,
+        priority: Priority.High,
+        ongoing: true,
+        autoCancel: false);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, 'ongoing notification title',
+        'ongoing notification body', platformChannelSpecifics);
+  }
+
+  Future<void> repeatNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'repeating channel id',
+        'repeating channel name',
+        'repeating description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating title',
+        'repeating body', RepeatInterval.EveryMinute, platformChannelSpecifics);
+  }
+
+  Future<void> showDailyAtTime(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var time = Time(10, 0, 0);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'repeatDailyAtTime channel id',
+        'repeatDailyAtTime channel name',
+        'repeatDailyAtTime description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.showDailyAtTime(
+        0,
+        'show daily title',
+        'Daily notification shown at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        time,
+        platformChannelSpecifics);
+  }
+
+  Future<void> showWeeklyAtDayAndTime(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var time = Time(10, 0, 0);
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'show weekly channel id',
+        'show weekly channel name',
+        'show weekly description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.showWeeklyAtDayAndTime(
+        0,
+        'show weekly title',
+        'Weekly notification shown on Monday at approximately ${_toTwoDigitString(time.hour)}:${_toTwoDigitString(time.minute)}:${_toTwoDigitString(time.second)}',
+        Day.Monday,
+        time,
+        platformChannelSpecifics);
+  }
+
+  Future<void> showNotificationWithNoBadge(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'no badge channel', 'no badge name', 'no badge description',
+        channelShowBadge: false,
+        importance: Importance.Max,
+        priority: Priority.High,
+        onlyAlertOnce: true);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'no badge title', 'no badge body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showProgressNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var maxProgress = 5;
+    for (var i = 0; i <= maxProgress; i++) {
+      await Future.delayed(Duration(seconds: 1), () async {
+        var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+            'progress channel',
+            'progress channel',
+            'progress channel description',
+            channelShowBadge: false,
+            importance: Importance.Max,
+            priority: Priority.High,
+            onlyAlertOnce: true,
+            showProgress: true,
+            maxProgress: maxProgress,
+            progress: i);
+        var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+        var platformChannelSpecifics = NotificationDetails(
+            androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+        await flutterLocalNotificationsPlugin.show(
+            0,
+            'progress notification title',
+            'progress notification body',
+            platformChannelSpecifics,
+            payload: 'item x');
+      });
+    }
+  }
+
+  Future<void> showIndeterminateProgressNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'indeterminate progress channel',
+        'indeterminate progress channel',
+        'indeterminate progress channel description',
+        channelShowBadge: false,
+        importance: Importance.Max,
+        priority: Priority.High,
+        onlyAlertOnce: true,
+        showProgress: true,
+        indeterminate: true);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0,
+        'indeterminate progress notification title',
+        'indeterminate progress notification body',
+        platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithUpdatedChannelDescription(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id',
+        'your channel name',
+        'your updated channel description',
+        importance: Importance.Max,
+        priority: Priority.High,
+        channelAction: AndroidNotificationChannelAction.Update);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0,
+        'updated notification channel',
+        'check settings to see updated channel description',
+        platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showPublicNotification(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max,
+        priority: Priority.High,
+        ticker: 'ticker',
+        visibility: NotificationVisibility.Public);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(0, 'public notification title',
+        'public notification body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithIconBadge(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'icon badge channel', 'icon badge name', 'icon badge description');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails(badgeNumber: 1);
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithoutTimestamp(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.Max, priority: Priority.High, showWhen: false);
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithCustomTimestamp(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+      'your channel id',
+      'your channel name',
+      'your channel description',
+      importance: Importance.Max,
+      priority: Priority.High,
+      showWhen: true,
+      when: DateTime.now().millisecondsSinceEpoch - 120 * 1000,
+    );
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails();
+    var platformChannelSpecifics = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> showNotificationWithAttachment(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin) async {
+    var bigPicturePath = await _downloadAndSaveFile(
+        'http://via.placeholder.com/600x200', 'bigPicture.jpg');
+    var iOSPlatformChannelSpecifics = IOSNotificationDetails(
+        attachments: [IOSNotificationAttachment(bigPicturePath)]);
+    var bigPictureAndroidStyle =
+        BigPictureStyleInformation(FilePathAndroidBitmap(bigPicturePath));
+    var androidPlatformChannelSpecifics = AndroidNotificationDetails(
+        'your channel id', 'your channel name', 'your channel description',
+        importance: Importance.High,
+        priority: Priority.High,
+        styleInformation: bigPictureAndroidStyle);
+    var notificationDetails = NotificationDetails(
+        androidPlatformChannelSpecifics, iOSPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0,
+        'notification with attachment title',
+        'notification with attachment body',
+        notificationDetails);
+  }
+
+  Future<void> createNotificationChannel(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
+      BuildContext context) async {
+    var androidNotificationChannel = AndroidNotificationChannel(
+      'your channel id 2',
+      'your channel name 2',
+      'your channel description 2',
+    );
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(androidNotificationChannel);
+
+    await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            content: Text(
+                'Channel with name \"${androidNotificationChannel.name}\" created'),
+            actions: [
+              FlatButton(
+                child: Text('OK'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        });
+  }
+
+  Future<void> deleteNotificationChannel(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
+      BuildContext context) async {
+    const channelId = 'your channel id 2';
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.deleteNotificationChannel(channelId);
+
+    await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            content: Text('Channel with id \"$channelId\" deleted'),
+            actions: [
+              FlatButton(
+                child: Text('OK'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        });
+  }
+
+  String _toTwoDigitString(int value) {
+    return value.toString().padLeft(2, '0');
+  }
+
+  void configureDidReceiveLocalNotificationSubject(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
+      BuildContext context) {
+    didReceiveLocalNotificationSubject.stream
+        .listen((ReceivedNotification receivedNotification) async {
+      await showDialog(
+        context: context,
+        builder: (BuildContext context) => CupertinoAlertDialog(
+          title: receivedNotification.title != null
+              ? Text(receivedNotification.title)
+              : null,
+          content: receivedNotification.body != null
+              ? Text(receivedNotification.body)
+              : null,
+          actions: [
+            CupertinoDialogAction(
+              isDefaultAction: true,
+              child: Text('Ok'),
+              onPressed: () async {
+                Navigator.of(context, rootNavigator: true).pop();
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) =>
+                        SecondScreen(receivedNotification.payload),
+                  ),
+                );
+              },
+            )
+          ],
+        ),
+      );
+    });
+  }
+
+  void configureSelectNotificationSubject(
+      FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
+      BuildContext context) {
+    selectNotificationSubject.stream.listen((String payload) async {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => SecondScreen(payload)),
+      );
+    });
+  }
+}


### PR DESCRIPTION
Create `notification helper` with implementation `singleton pattern` to grouping all notification types including permission and initialize.
With this class, we separated the `UI` (main.dart) and the `logic of notification` (notification_helper.dart). And our code on main.dart is not too many lines of code.