### PR TITLE
[flutter_local_notifications] Support notification reschedule for android during restart / quickboot

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [2.0.1]
 
-* [Android] updated plugin and steps in the readme to handle rescheduling the notifications after a HTC reboots. Thanks to the PR from [Le Liam](https://github.com/nghenglim)
+* [Android] updated plugin and steps in the readme to ensure notifications remain scheduled after a HTC device restarts. Thanks to the PR from [Le Liam](https://github.com/nghenglim)
 
 # [2.0.0+1]
 

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [2.0.1]
+
+* [Android] updated plugin and steps in the readme to handle rescheduling the notifications after a HTC reboots. Thanks to the PR from [Le Liam](https://github.com/nghenglim)
+
 # [2.0.0+1]
 
 * Fixed code snippet in readme around initialisation and configuring the `onDidReceiveLocalNotification` callback specific to iOS. Thanks to the PR from [Mike Truso](https://github.com/mftruso)

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -154,6 +154,8 @@ The following is also needed to ensure notifications remain scheduled upon a reb
     <intent-filter>
         <action android:name="android.intent.action.BOOT_COMPLETED"/>
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+        <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+        <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
     </intent-filter>
 </receiver>
 ```

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
@@ -12,8 +12,8 @@ public class ScheduledNotificationBootReceiver extends BroadcastReceiver
         if (action != null) {
             if (action.equals(android.content.Intent.ACTION_BOOT_COMPLETED)
                     || action.equals(Intent.ACTION_MY_PACKAGE_REPLACED)
-                    || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
-                    || intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
+                    || action.equals("android.intent.action.QUICKBOOT_POWERON")
+                    || action.equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
                 FlutterLocalNotificationsPlugin.rescheduleNotifications(context);
             }
         }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationBootReceiver.java
@@ -11,7 +11,9 @@ public class ScheduledNotificationBootReceiver extends BroadcastReceiver
         String action = intent.getAction();
         if (action != null) {
             if (action.equals(android.content.Intent.ACTION_BOOT_COMPLETED)
-                    || action.equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
+                    || action.equals(Intent.ACTION_MY_PACKAGE_REPLACED)
+                    || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
+                    || intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
                 FlutterLocalNotificationsPlugin.rescheduleNotifications(context);
             }
         }

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
             </intent-filter>
         </receiver>
         <!-- Don't delete the meta-data below.

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local notifications for Flutter applications with the ability to customise for each platform.
-version: 2.0.0+1
+version: 2.0.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
So I am testing the reschedule functionality on my Huawei device, the local notification is not being rescheduled when I restart my device.

The following enhancement (plus making sure the startup manager don't disable launch on startup) fixes the issue.