### PR TITLE
[flutter_local_notifications] Fix for issue #860

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [2.0.2]
+
+* [iOS][macOS] fixed issue [860](https://github.com/MaikuB/flutter_local_notifications/issues/860) where notifications may fail to be scheduled to an error parsing the specified date that could occur for some users depending on their locale and if they had turned on/off the setting for showing 24 hour time on their device. Thanks to the PR from [Eugene Alitz](https://github.com/psycura)
+
 # [2.0.1+1]
 
 * Updated example application to demonstrate how to use the schedule notifications to occur on particular weekday using `zonedSchedule` method

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [2.0.2]
 
-* [iOS][macOS] fixed issue [860](https://github.com/MaikuB/flutter_local_notifications/issues/860) where notifications may fail to be scheduled to an error parsing the specified date that could occur for some users depending on their locale and if they had turned on/off the setting for showing 24 hour time on their device. Thanks to the PR from [Eugene Alitz](https://github.com/psycura)
+* [iOS][macOS] fixed issue [860](https://github.com/MaikuB/flutter_local_notifications/issues/860) where notifications may fail to be scheduled to an error parsing the specified date that could occur for some users depending on their locale and if they had turned off the setting for showing 24 hour time on their device. Thanks to the PR from [Eugene Alitz](https://github.com/psycura)
 
 # [2.0.1+1]
 

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -597,10 +597,22 @@ static FlutterError *getFlutterError(NSError *error) {
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSTimeZone *timezone = [NSTimeZone timeZoneWithName:timeZoneName];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+
+    // Needed for some countries, when phone DateTime format is 12H
+    NSLocale *currentLocale= [NSLocale currentLocale];
+    NSString *countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
+    NSString *langCode = [currentLocale objectForKey:NSLocaleLanguageCode];
+    NSString *posixString = [NSString stringWithFormat:@"%@_%@_POSIX", langCode,countryCode];
+    NSLocale *localeWithPosix = [[NSLocale alloc] initWithLocaleIdentifier:posixString];
+
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
     [dateFormatter setTimeZone:timezone];
+    [dateFormatter setLocale:localeWithPosix];
+
     NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
+
     calendar.timeZone = timezone;
+
     if(scheduledNotificationRepeatFrequency != nil) {
         if([scheduledNotificationRepeatFrequency integerValue] == DailyFrequency) {
             NSDateComponents *dateComponents    = [calendar components:(

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -599,15 +599,10 @@ static FlutterError *getFlutterError(NSError *error) {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
 
     // Needed for some countries, when phone DateTime format is 12H
-    NSLocale *currentLocale= [NSLocale currentLocale];
-    NSString *countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
-    NSString *langCode = [currentLocale objectForKey:NSLocaleLanguageCode];
-    NSString *posixString = [NSString stringWithFormat:@"%@_%@_POSIX", langCode,countryCode];
-    NSLocale *localeWithPosix = [[NSLocale alloc] initWithLocaleIdentifier:posixString];
 
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
     [dateFormatter setTimeZone:timezone];
-    [dateFormatter setLocale:localeWithPosix];
+    [dateFormatter setLocale:"en_US_POSIX"];
 
     NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
 

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -599,10 +599,11 @@ static FlutterError *getFlutterError(NSError *error) {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
 
     // Needed for some countries, when phone DateTime format is 12H
+    NSLocale *posix = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
 
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
     [dateFormatter setTimeZone:timezone];
-    [dateFormatter setLocale:"en_US_POSIX"];
+    [dateFormatter setLocale:posix];
 
     NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
 

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -395,6 +395,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         let timeZoneName = arguments[MethodCallArguments.timeZoneName] as! String
         let timeZone = TimeZone.init(identifier: timeZoneName)
         let dateFormatter = DateFormatter.init()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = DateFormatStrings.isoFormat
         dateFormatter.timeZone = timeZone
         let date = dateFormatter.date(from: scheduledDateTime)!

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local notifications for Flutter applications with the ability to customise for each platform.
-version: 2.0.1+1
+version: 2.0.2
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
The fix taken from [StackOverflow](https://stackoverflow.com/questions/16706293/ios-nsdate-comparison-works-differently-when-the-24-hour-time-in-date-settings-t/16706425#16706425)

We need to set the date formatter's locale to the special locale that include POSIX string, for example **en_US_POSIX**

Closes #860 
