### PR TITLE
[flutter_local_notifications] add ability to set app icon badge number on iOS

### DIFF
--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -14,6 +14,7 @@
 }
 
 NSString *const INITIALIZE_METHOD = @"initialize";
+NSString *const SET_BADGE_NUMBER_METHOD = @"setBadgeNumber";
 NSString *const SHOW_METHOD = @"show";
 NSString *const SCHEDULE_METHOD = @"schedule";
 NSString *const ZONED_SCHEDULE_METHOD = @"zonedSchedule";
@@ -66,6 +67,7 @@ NSString *const SCHEDULED_DATE_TIME = @"scheduledDateTime";
 NSString *const TIME_ZONE_NAME = @"timeZoneName";
 NSString *const MATCH_DATE_TIME_COMPONENTS = @"matchDateTimeComponents";
 NSString *const UILOCALNOTIFICATION_DATE_INTERPRETATION = @"uiLocalNotificationDateInterpretation";
+NSString *const VALUE = @"value";
 
 NSString *const NOTIFICATION_ID = @"NotificationId";
 NSString *const PAYLOAD = @"payload";
@@ -120,6 +122,8 @@ static FlutterError *getFlutterError(NSError *error) {
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if([INITIALIZE_METHOD isEqualToString:call.method]) {
         [self initialize:call.arguments result:result];
+    } else if([SET_BADGE_NUMBER_METHOD isEqualToString:call.method]) {
+        [self setBadgeNumber:call.arguments result:result];
     } else if([SHOW_METHOD isEqualToString:call.method]) {
         [self show:call.arguments result:result];
     } else if([ZONED_SCHEDULE_METHOD isEqualToString:call.method]) {
@@ -230,6 +234,16 @@ static FlutterError *getFlutterError(NSError *error) {
     [self requestPermissionsImpl:requestedSoundPermission alertPermission:requestedAlertPermission badgePermission:requestedBadgePermission checkLaunchNotification:true result:result];
     
     _initialized = true;
+}
+
+- (void)setBadgeNumber:(NSDictionary * _Nonnull)arguments result:(FlutterResult _Nonnull)result {
+    int value = 0;
+    if([self containsKey:VALUE forDictionary:arguments]) {
+        value = [arguments[VALUE] intValue];
+    }
+    
+    [UIApplication sharedApplication].applicationIconBadgeNumber = value;
+    result(nil);
 }
 
 - (void)requestPermissions:(NSDictionary * _Nonnull)arguments result:(FlutterResult _Nonnull)result {

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -351,6 +351,12 @@ class IOSFlutterLocalNotificationsPlugin
         'badge': badge,
       });
 
+  /// Sets badge number.
+  Future<void> setBadgeNumber(int value) =>
+      _channel.invokeMethod<bool>('setBadgeNumber', <String, int>{
+        'value': value,
+      });
+
   /// Schedules a notification to be shown at the specified date and time with
   /// an optional payload that is passed through when a notification is tapped.
   @Deprecated(


### PR DESCRIPTION
## Problem

Plugin provider an ability to set counter when we schedule a notification on iOS, but after that we can't change (or reset it) without schedule another notification.

## Solution

Added method `setBadgeNumber` In the platform implementation `IOSFlutterLocalNotificationsPlugin`

See #492 for more information.