### PR TITLE
[flutter_local_notifications] use NotificationManager for managing channel groups, fixes for initialising Android ThreeTenBP lib

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [3.0.1+1]
+
+* Updated API docs for the `UriAndroidNotificationSound` class to further clarify that developers may need to write code that makes use of platform channels
+* [Android] fix an issue where recurring notifications may fail to schedule the next occurrence on older Android versions as the ThreeTen Android Backport library hadn't been initialised yet
+* [Android] switched implementation of `createNotificationChannelGroup` and `deleteNotificationChannelGroup` methods to use `NotificationManager` APIs instead of `NotificationManagerCompat` APIs. If you had issues with 3.0.1 then this should fix the issue (e.g. as reported in issue [871](https://github.com/MaikuB/flutter_local_notifications/issues/871)) as the the APIs that were previously being called would've required apps to use more recent versions of the AndroidX libraries
+
 # [3.0.1]
 
 * [Android] Added the `createNotificationChannelGroup` and `deleteNotificationChannelGroup` methods to the `AndroidFluttterLocalNotificationsPlugin` class that can be used to create and delete notification channel groups. The optional `groupId` parameter has been added to the `AndroidNotificationChannel` class that can be used to associated notification channels to a particular group. Example app has been updated to include code snippets for this.

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [3.0.1+1]
 
 * Updated API docs for the `UriAndroidNotificationSound` class to further clarify that developers may need to write code that makes use of platform channels
-* [Android] fix an issue where recurring notifications may fail to schedule the next occurrence on older Android versions as the ThreeTen Android Backport library hadn't been initialised yet
+* [Android] fix issue [881](https://github.com/MaikuB/flutter_local_notifications/issues/881) where recurring notifications may fail to schedule the next occurrence on older Android versions as the ThreeTen Android Backport library hadn't been initialised yet
 * [Android] switched implementation of `createNotificationChannelGroup` and `deleteNotificationChannelGroup` methods to use `NotificationManager` APIs instead of `NotificationManagerCompat` APIs. If you had issues with 3.0.1 then this should fix the issue (e.g. as reported in issue [871](https://github.com/MaikuB/flutter_local_notifications/issues/871)) as the the APIs that were previously being called would've required apps to use more recent versions of the AndroidX libraries
 
 # [3.0.1]

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Updated API docs for the `UriAndroidNotificationSound` class to further clarify that developers may need to write code that makes use of platform channels
 * [Android] fix issue [881](https://github.com/MaikuB/flutter_local_notifications/issues/881) where recurring notifications may fail to schedule the next occurrence on older Android versions as the ThreeTen Android Backport library hadn't been initialised yet
-* [Android] switched implementation of `createNotificationChannelGroup` and `deleteNotificationChannelGroup` methods to use `NotificationManager` APIs instead of `NotificationManagerCompat` APIs. If you had issues with 3.0.1 then this should fix the issue (e.g. as reported in issue [871](https://github.com/MaikuB/flutter_local_notifications/issues/871)) as the the APIs that were previously being called would've required apps to use more recent versions of the AndroidX libraries
+* [Android] switched implementation of `createNotificationChannelGroup` and `deleteNotificationChannelGroup` methods to use the `NotificationManager` APIs instead of the `NotificationManagerCompat` APIs. If you had issues with 3.0.1 then this should fix the issue (e.g. as reported in issue [871](https://github.com/MaikuB/flutter_local_notifications/issues/871)) as the the APIs that were previously being called would've required apps to use more recent versions of the AndroidX libraries
 
 # [3.0.1]
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -768,22 +768,22 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     }
 
     static void zonedScheduleNextNotification(Context context, NotificationDetails notificationDetails) {
+        initAndroidThreeTen(context);
         String nextFireDate = getNextFireDate(notificationDetails);
         if (nextFireDate == null) {
             return;
         }
         notificationDetails.scheduledDateTime = nextFireDate;
-        initAndroidThreeTen(context);
         zonedScheduleNotification(context, notificationDetails, true);
     }
 
     static void zonedScheduleNextNotificationMatchingDateComponents(Context context, NotificationDetails notificationDetails) {
+        initAndroidThreeTen(context);
         String nextFireDate = getNextFireDateMatchingDateTimeComponents(notificationDetails);
         if (nextFireDate == null) {
             return;
         }
         notificationDetails.scheduledDateTime = nextFireDate;
-        initAndroidThreeTen(context);
         zonedScheduleNotification(context, notificationDetails, true);
     }
 
@@ -1157,20 +1157,22 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         if (VERSION.SDK_INT >= VERSION_CODES.O) {
             Map<String, Object> arguments = call.arguments();
             NotificationChannelGroupDetails notificationChannelGroupDetails = NotificationChannelGroupDetails.from(arguments);
-            NotificationManagerCompat notificationManagerCompat = getNotificationManager(applicationContext);
+            NotificationManager notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
             NotificationChannelGroup notificationChannelGroup = new NotificationChannelGroup(notificationChannelGroupDetails.id, notificationChannelGroupDetails.name);
             if (VERSION.SDK_INT >= VERSION_CODES.P) {
                 notificationChannelGroup.setDescription(notificationChannelGroupDetails.description);
             }
-            notificationManagerCompat.createNotificationChannelGroup(notificationChannelGroup);
+            notificationManager.createNotificationChannelGroup(notificationChannelGroup);
         }
         result.success(null);
     }
 
     private void deleteNotificationChannelGroup(MethodCall call, Result result) {
-        NotificationManagerCompat notificationManagerCompat = getNotificationManager(applicationContext);
-        String groupId = call.arguments();
-        notificationManagerCompat.deleteNotificationChannelGroup(groupId);
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            NotificationManager notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+            String groupId = call.arguments();
+            notificationManager.deleteNotificationChannelGroup(groupId);
+        }
         result.success(null);
     }
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_sound.dart
@@ -22,7 +22,8 @@ class RawResourceAndroidNotificationSound implements AndroidNotificationSound {
 /// notification sound.
 ///
 /// One way of obtaining such URIs is to use the native Android RingtoneManager
-/// APIs, which may require developers to write their own to access the API.
+/// APIs, which may require developers to write their own code that makes use
+/// of platform channels.
 class UriAndroidNotificationSound implements AndroidNotificationSound {
   const UriAndroidNotificationSound(this._sound);
 

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local notifications for Flutter applications with the ability to customise for each platform.
-version: 3.0.1
+version: 3.0.1+1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
Closes #871 #881 