### PR TITLE
[flutter_local_notifications] update example app to point https placeholder image URLs

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [3.0.1+6]
+
+* [Android] change how the intent that associated with the notification is determined so that the plugin. This is to allow the plugin to work with applications that use activity aliases as per issue [92](https://github.com/MaikuB/flutter_local_notifications/issues/912). Thanks the PR from  [crazecoder](https://github.com/crazecoder)
+* Fixed issue [924](https://github.com/MaikuB/flutter_local_notifications/issues/924), where example app will now use https URLs for downloading placeholder images. These images were used when displaying some of the notifications. Thanks to the PR from [Fareez](https://github.com/iqfareez)
+
 # [3.0.1+5]
 
 * Fixed links in table of contents in the readme. Thanks to the PR from [Dihak](https://github.com/dihak)

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="flutter_local_notifications_example"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="flutter_local_notifications_example"
-        android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -786,9 +786,9 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _showBigPictureNotification() async {
     final String largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
+        'https://via.placeholder.com/48x48', 'largeIcon');
     final String bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/400x800', 'bigPicture');
+        'https://via.placeholder.com/400x800', 'bigPicture');
     final BigPictureStyleInformation bigPictureStyleInformation =
         BigPictureStyleInformation(FilePathAndroidBitmap(bigPicturePath),
             largeIcon: FilePathAndroidBitmap(largeIconPath),
@@ -808,9 +808,9 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _showBigPictureNotificationHiddenLargeIcon() async {
     final String largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
+        'https://via.placeholder.com/48x48', 'largeIcon');
     final String bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/400x800', 'bigPicture');
+        'https://via.placeholder.com/400x800', 'bigPicture');
     final BigPictureStyleInformation bigPictureStyleInformation =
         BigPictureStyleInformation(FilePathAndroidBitmap(bigPicturePath),
             hideExpandedLargeIcon: true,
@@ -831,7 +831,7 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _showNotificationMediaStyle() async {
     final String largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/128x128/00FF00/000000', 'largeIcon');
+        'https://via.placeholder.com/128x128/00FF00/000000', 'largeIcon');
     final AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
       'media channel id',
@@ -908,7 +908,7 @@ class _HomePageState extends State<HomePage> {
     );
     // download the icon that would be use for the lunch bot person
     final String largeIconPath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/48x48', 'largeIcon');
+        'https://via.placeholder.com/48x48', 'largeIcon');
     // this person object will use an icon that was downloaded
     final Person lunchBot = Person(
       name: 'Lunch bot',
@@ -1282,7 +1282,7 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _showNotificationWithAttachment() async {
     final String bigPicturePath = await _downloadAndSaveFile(
-        'http://via.placeholder.com/600x200', 'bigPicture.jpg');
+        'https://via.placeholder.com/600x200', 'bigPicture.jpg');
     final IOSNotificationDetails iOSPlatformChannelSpecifics =
         IOSNotificationDetails(attachments: <IOSNotificationAttachment>[
       IOSNotificationAttachment(bigPicturePath)

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local notifications for Flutter applications with the ability to customise for each platform.
-version: 3.0.1+5
+version: 3.0.1+6
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
Fix the said issue #924 in `flutter_local_notifications\example` app. 

Tested on Android 9.0 Pie. Run on debug build. Works as expected.

Since I didn't have any iOS device, I didn't make any changes in iOS side. 

https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android
https://flutter.dev/docs/development/add-to-app/ios/project-setup#local-network-privacy-permissions