### PR TITLE
[flutter_local_notifications] Add support for setUsesChronometer on Android.

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -191,6 +191,10 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             builder.setWhen(notificationDetails.when);
         }
 
+        if (notificationDetails.usesChronometer != null) {
+            builder.setUsesChronometer(notificationDetails.usesChronometer);
+        }
+
         if (BooleanUtils.getValue(notificationDetails.fullScreenIntent)) {
             builder.setFullScreenIntent(pendingIntent, true);
         }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -106,6 +106,7 @@ public class NotificationDetails {
     private static final String TIMEOUT_AFTER = "timeoutAfter";
     private static final String SHOW_WHEN = "showWhen";
     private static final String WHEN = "when";
+    private static final String USES_CHRONOMETER = "usesChronometer";
     private static final String ADDITIONAL_FLAGS = "additionalFlags";
 
     private static final String SCHEDULED_DATE_TIME = "scheduledDateTime";
@@ -165,6 +166,7 @@ public class NotificationDetails {
     public String category;
     public int[] additionalFlags;
     public Boolean showWhen;
+    public Boolean usesChronometer;
     public String scheduledDateTime;
     public String timeZoneName;
     public ScheduledNotificationRepeatFrequency scheduledNotificationRepeatFrequency;
@@ -231,6 +233,7 @@ public class NotificationDetails {
             notificationDetails.onlyAlertOnce = (Boolean) platformChannelSpecifics.get(ONLY_ALERT_ONCE);
             notificationDetails.showWhen = (Boolean) platformChannelSpecifics.get(SHOW_WHEN);
             notificationDetails.when = parseLong(platformChannelSpecifics.get(WHEN));
+            notificationDetails.usesChronometer = (Boolean) platformChannelSpecifics.get(USES_CHRONOMETER);
             readProgressInformation(notificationDetails, platformChannelSpecifics);
             readColor(notificationDetails, platformChannelSpecifics);
             readChannelInformation(notificationDetails, platformChannelSpecifics);

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -487,6 +487,12 @@ class _HomePageState extends State<HomePage> {
                         },
                       ),
                       PaddedRaisedButton(
+                        buttonText: 'Show notification with chronometer',
+                        onPressed: () async {
+                          await _showNotificationWithChronometer();
+                        },
+                      ),
+                      PaddedRaisedButton(
                         buttonText: 'Show full-screen notification',
                         onPressed: () async {
                           await _showFullScreenNotification();
@@ -1275,6 +1281,24 @@ class _HomePageState extends State<HomePage> {
     );
     final NotificationDetails platformChannelSpecifics =
         NotificationDetails(android: androidPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        0, 'plain title', 'plain body', platformChannelSpecifics,
+        payload: 'item x');
+  }
+
+  Future<void> _showNotificationWithChronometer() async {
+    final AndroidNotificationDetails androidPlatformChannelSpecifics =
+    AndroidNotificationDetails(
+      'your channel id',
+      'your channel name',
+      'your channel description',
+      importance: Importance.max,
+      priority: Priority.high,
+      when: DateTime.now().millisecondsSinceEpoch - 120 * 1000,
+      usesChronometer: true,
+    );
+    final NotificationDetails platformChannelSpecifics =
+    NotificationDetails(android: androidPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
         0, 'plain title', 'plain body', platformChannelSpecifics,
         payload: 'item x');

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -230,6 +230,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'onlyAlertOnce': onlyAlertOnce,
         'showWhen': showWhen,
         'when': when,
+        'usesChronometer': usesChronometer,
         'showProgress': showProgress,
         'maxProgress': maxProgress,
         'progress': progress,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -31,6 +31,7 @@ class AndroidNotificationDetails {
     this.onlyAlertOnce,
     this.showWhen = true,
     this.when,
+    this.usesChronometer = false,
     this.channelShowBadge = true,
     this.showProgress = false,
     this.maxProgress = 0,
@@ -169,6 +170,13 @@ class AndroidNotificationDetails {
   /// timestamp should be shown (i.e. [showWhen] is set to `true`),
   /// then Android will default to showing when the notification occurred.
   final int when;
+
+  /// Show [when] as a stopwatch.
+  ///
+  /// Instead of presenting [when] as a timestamp, the notification will show an
+  /// automatically updating display of the minutes and seconds since [when].
+  /// Useful when showing an elapsed time (like an ongoing phone call).
+  final bool usesChronometer;
 
   /// Specifies if the notification will be used to show progress.
   final bool showProgress;

--- a/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
@@ -121,6 +121,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -197,6 +198,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -275,6 +277,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': timestamp,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -301,6 +304,86 @@ void main() {
             },
           }));
     });
+
+    test(
+      'show with default Android-specific details with a chronometer',
+          () async {
+      const AndroidInitializationSettings androidInitializationSettings =
+      AndroidInitializationSettings('app_icon');
+      const InitializationSettings initializationSettings =
+      InitializationSettings(android: androidInitializationSettings);
+      await flutterLocalNotificationsPlugin.initialize(initializationSettings);
+      final int timestamp = DateTime.now().millisecondsSinceEpoch;
+
+      final AndroidNotificationDetails androidNotificationDetails =
+      AndroidNotificationDetails(
+          'channelId', 'channelName', 'channelDescription',
+          when: timestamp,
+          usesChronometer: true);
+      await flutterLocalNotificationsPlugin.show(
+          1,
+          'notification title',
+          'notification body',
+          NotificationDetails(android: androidNotificationDetails));
+      expect(
+          log.last,
+          isMethodCall('show', arguments: <String, Object>{
+            'id': 1,
+            'title': 'notification title',
+            'body': 'notification body',
+            'payload': '',
+            'platformSpecifics': <String, Object>{
+              'icon': null,
+              'channelId': 'channelId',
+              'channelName': 'channelName',
+              'channelDescription': 'channelDescription',
+              'channelShowBadge': true,
+              'channelAction':
+              AndroidNotificationChannelAction.createIfNotExists.index,
+              'importance': Importance.defaultImportance.value,
+              'priority': Priority.defaultPriority.value,
+              'playSound': true,
+              'enableVibration': true,
+              'vibrationPattern': null,
+              'groupKey': null,
+              'setAsGroupSummary': null,
+              'groupAlertBehavior': GroupAlertBehavior.all.index,
+              'autoCancel': true,
+              'ongoing': null,
+              'colorAlpha': null,
+              'colorRed': null,
+              'colorGreen': null,
+              'colorBlue': null,
+              'onlyAlertOnce': null,
+              'showWhen': true,
+              'when': timestamp,
+              'usesChronometer': true,
+              'showProgress': false,
+              'maxProgress': 0,
+              'progress': 0,
+              'indeterminate': false,
+              'enableLights': false,
+              'ledColorAlpha': null,
+              'ledColorRed': null,
+              'ledColorGreen': null,
+              'ledColorBlue': null,
+              'ledOnMs': null,
+              'ledOffMs': null,
+              'ticker': null,
+              'visibility': null,
+              'timeoutAfter': null,
+              'category': null,
+              'additionalFlags': null,
+              'fullScreenIntent': false,
+              'shortcutId': null,
+              'style': AndroidNotificationStyle.defaultStyle.index,
+              'styleInformation': <String, Object>{
+                'htmlFormatContent': false,
+                'htmlFormatTitle': false,
+              },
+            },
+          }));
+      });
 
     test(
         'show with default Android-specific details and custom sound from raw '
@@ -357,6 +440,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -438,6 +522,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -518,6 +603,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -600,6 +686,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -697,6 +784,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -788,6 +876,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -885,6 +974,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -974,6 +1064,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1067,6 +1158,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1151,6 +1243,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1232,6 +1325,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1320,6 +1414,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1437,6 +1532,7 @@ void main() {
               'onlyAlertOnce': null,
               'showWhen': true,
               'when': null,
+              'usesChronometer': false,
               'showProgress': false,
               'maxProgress': 0,
               'progress': 0,
@@ -1543,6 +1639,7 @@ void main() {
                 'onlyAlertOnce': null,
                 'showWhen': true,
                 'when': null,
+                'usesChronometer': false,
                 'showProgress': false,
                 'maxProgress': 0,
                 'progress': 0,
@@ -1631,6 +1728,7 @@ void main() {
                 'onlyAlertOnce': null,
                 'showWhen': true,
                 'when': null,
+                'usesChronometer': false,
                 'showProgress': false,
                 'maxProgress': 0,
                 'progress': 0,
@@ -1720,6 +1818,7 @@ void main() {
                 'onlyAlertOnce': null,
                 'showWhen': true,
                 'when': null,
+                'usesChronometer': false,
                 'showProgress': false,
                 'maxProgress': 0,
                 'progress': 0,


### PR DESCRIPTION
Addresses #938

Just adds an extra boolean option to AndroidNotificationDetails, with test & example.
