### PR TITLE
[flutter_local_notifications] Fix potential android npe

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -709,7 +709,8 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             // only create/update the channel when needed/specified. Allow this happen to when channelAction may be null to support cases where notifications had been
             // created on older versions of the plugin where channel management options weren't available back then
             if ((notificationChannel == null && (notificationChannelDetails.channelAction == null || notificationChannelDetails.channelAction == NotificationChannelAction.CreateIfNotExists)) || (notificationChannel != null && notificationChannelDetails.channelAction == NotificationChannelAction.Update)) {
-                notificationChannel = new NotificationChannel(notificationChannelDetails.id, notificationChannelDetails.name, notificationChannelDetails.importance);
+                int importance = notificationChannelDetails.importance != null ? notificationChannelDetails.importance : NotificationManager.IMPORTANCE_LOW;
+                notificationChannel = new NotificationChannel(notificationChannelDetails.id, notificationChannelDetails.name, importance);
                 notificationChannel.setDescription(notificationChannelDetails.description);
                 notificationChannel.setGroup(notificationChannelDetails.groupId);
                 if (notificationChannelDetails.playSound) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -710,8 +710,9 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             // created on older versions of the plugin where channel management options weren't available back then
             if ((notificationChannel == null && (notificationChannelDetails.channelAction == null || notificationChannelDetails.channelAction == NotificationChannelAction.CreateIfNotExists)) || (notificationChannel != null && notificationChannelDetails.channelAction == NotificationChannelAction.Update)) {
                 int importance = notificationChannelDetails.importance != null ? notificationChannelDetails.importance : NotificationManager.IMPORTANCE_LOW;
+                String description = Objects.toString(notificationChannelDetails.description, "");
                 notificationChannel = new NotificationChannel(notificationChannelDetails.id, notificationChannelDetails.name, importance);
-                notificationChannel.setDescription(notificationChannelDetails.description);
+                notificationChannel.setDescription(description);
                 notificationChannel.setGroup(notificationChannelDetails.groupId);
                 if (notificationChannelDetails.playSound) {
                     AudioAttributes audioAttributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION).build();


### PR DESCRIPTION
From time to time I've got an NPE from app user coming from native Android code of `flutter_local_notifications`. I wasn't able to reproduce those errors locally. But patching the code and releasing new app with forked version seems to solve those random NPE's. I haven't seen them for about a week now.