### PR TITLE
[flutter_local_notifications] Check if parcelable notification is present on received intent

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
@@ -29,14 +29,15 @@ public class ScheduledNotificationReceiver extends BroadcastReceiver {
         if (StringUtils.isNullOrEmpty(notificationDetailsJson)) {
             // This logic is needed for apps that used the plugin prior to 0.3.4
             Notification notification = intent.getParcelableExtra("notification");
-            notification.when = System.currentTimeMillis();
-            int notificationId = intent.getIntExtra("notification_id",
-                    0);
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-            notificationManager.notify(notificationId, notification);
-            boolean repeat = intent.getBooleanExtra("repeat", false);
-            if (!repeat) {
-                FlutterLocalNotificationsPlugin.removeNotificationFromCache(context, notificationId);
+            if (notification != null) {
+                notification.when = System.currentTimeMillis();
+                int notificationId = intent.getIntExtra("notification_id", 0);
+                NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+                notificationManager.notify(notificationId, notification);
+                boolean repeat = intent.getBooleanExtra("repeat", false);
+                if (!repeat) {
+                    FlutterLocalNotificationsPlugin.removeNotificationFromCache(context, notificationId);
+                }
             }
         } else {
             Gson gson = FlutterLocalNotificationsPlugin.buildGson();

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -344,11 +344,13 @@ class IOSFlutterLocalNotificationsPlugin
     bool sound,
     bool alert,
     bool badge,
+    bool provisional,
   }) =>
       _channel.invokeMethod<bool>('requestPermissions', <String, bool>{
         'sound': sound,
         'alert': alert,
         'badge': badge,
+        'provisional': provisional,
       });
 
   /// Schedules a notification to be shown at the specified date and time with

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/initialization_settings.dart
@@ -7,6 +7,7 @@ class IOSInitializationSettings {
     this.requestAlertPermission = true,
     this.requestSoundPermission = true,
     this.requestBadgePermission = true,
+    this.requestProvisionalPermission = false,
     this.defaultPresentAlert = true,
     this.defaultPresentSound = true,
     this.defaultPresentBadge = true,
@@ -14,6 +15,7 @@ class IOSInitializationSettings {
   })  : assert(requestAlertPermission != null),
         assert(requestSoundPermission != null),
         assert(requestBadgePermission != null),
+        assert(requestProvisionalPermission != null),
         assert(defaultPresentAlert != null),
         assert(defaultPresentBadge != null),
         assert(defaultPresentSound != null);
@@ -32,6 +34,11 @@ class IOSInitializationSettings {
   ///
   /// Default value is true.
   final bool requestBadgePermission;
+
+  /// Request provisional permission, available since iOS 12.0.
+  ///
+  /// Default value is false.
+  final bool requestProvisionalPermission;
 
   /// Configures the default setting on if an alert should be displayed when a
   /// notification is triggered while app is in the foreground.

--- a/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
@@ -2332,6 +2332,7 @@ void main() {
           'sound': null,
           'badge': null,
           'alert': null,
+          'provisional': null,
         })
       ]);
     });
@@ -2339,12 +2340,18 @@ void main() {
       await flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
-          .requestPermissions(sound: true, badge: true, alert: true);
+          .requestPermissions(
+            sound: true,
+            badge: true,
+            alert: true,
+            provisional: true,
+          );
       expect(log, <Matcher>[
         isMethodCall('requestPermissions', arguments: <String, Object>{
           'sound': true,
           'badge': true,
           'alert': true,
+          'provisional': true,
         })
       ]);
     });


### PR DESCRIPTION
Using the FlutterLocalNotification plugin in a production app we get some crashes reported to Crashlytics, because there is no "notificationDetails" or "notification" item attached to the intent. We were not able yet to identify the cause, where these incomplete notifications gets scheduled. But we think it would be good to have this sanity check in the notification receiver, dropping any malformed notifications that are received.
