### PR TITLE
[flutter_local_notifications] Allow past dates when using DateComponents and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pubspec.lock
+.vscode

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -318,6 +318,14 @@ class _HomePageState extends State<HomePage> {
                     ),
                     PaddedRaisedButton(
                       buttonText:
+                          'Schedule daily in 5 seconds last year notification '
+                          'in your local time zone',
+                      onPressed: () async {
+                        await _scheduleDailyInFiveSecondsLastYearNotification();
+                      },
+                    ),
+                    PaddedRaisedButton(
+                      buttonText:
                           'Schedule weekly 10:00:00 am notification in your '
                           'local time zone',
                       onPressed: () async {
@@ -1079,6 +1087,25 @@ class _HomePageState extends State<HomePage> {
         matchDateTimeComponents: DateTimeComponents.time);
   }
 
+  /// To test we don't validate past dates when using `matchDateTimeComponents`
+  Future<void> _scheduleDailyInFiveSecondsLastYearNotification() async {
+    await flutterLocalNotificationsPlugin.zonedSchedule(
+        0,
+        'daily scheduled notification title',
+        'daily scheduled notification body',
+        _nextInstanceOfInFiveSecondsLastYear(),
+        const NotificationDetails(
+          android: AndroidNotificationDetails(
+              'daily notification channel id',
+              'daily notification channel name',
+              'daily notification description'),
+        ),
+        androidAllowWhileIdle: true,
+        uiLocalNotificationDateInterpretation:
+            UILocalNotificationDateInterpretation.absoluteTime,
+        matchDateTimeComponents: DateTimeComponents.time);
+  }
+
   Future<void> _scheduleWeeklyTenAMNotification() async {
     await flutterLocalNotificationsPlugin.zonedSchedule(
         0,
@@ -1123,6 +1150,19 @@ class _HomePageState extends State<HomePage> {
       scheduledDate = scheduledDate.add(const Duration(days: 1));
     }
     return scheduledDate;
+  }
+
+  tz.TZDateTime _nextInstanceOfInFiveSecondsLastYear() {
+    final now = tz.TZDateTime.now(tz.local);
+    return tz.TZDateTime(
+      tz.local,
+      now.year - 1,
+      now.month,
+      now.day,
+      now.hour,
+      now.minute,
+      now.second + 5,
+    );
   }
 
   tz.TZDateTime _nextInstanceOfMondayTenAM() {
@@ -1288,7 +1328,7 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _showNotificationWithChronometer() async {
     final AndroidNotificationDetails androidPlatformChannelSpecifics =
-    AndroidNotificationDetails(
+        AndroidNotificationDetails(
       'your channel id',
       'your channel name',
       'your channel description',
@@ -1298,7 +1338,7 @@ class _HomePageState extends State<HomePage> {
       usesChronometer: true,
     );
     final NotificationDetails platformChannelSpecifics =
-    NotificationDetails(android: androidPlatformChannelSpecifics);
+        NotificationDetails(android: androidPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
         0, 'plain title', 'plain body', platformChannelSpecifics,
         payload: 'item x');

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -298,7 +298,7 @@ class FlutterLocalNotificationsPlugin {
               id, title, body, scheduledDate, notificationDetails?.android,
               payload: payload,
               androidAllowWhileIdle: androidAllowWhileIdle,
-              matchDateComponents: matchDateTimeComponents);
+              matchDateTimeComponents: matchDateTimeComponents);
     } else if (_platform.isIOS) {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -294,7 +294,7 @@ class FlutterLocalNotificationsPlugin {
     if (_platform.isAndroid) {
       await resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()
-          .zonedSchedule(
+          .zonedScheduleAndroid(
               id, title, body, scheduledDate, notificationDetails?.android,
               payload: payload,
               androidAllowWhileIdle: androidAllowWhileIdle,
@@ -302,7 +302,7 @@ class FlutterLocalNotificationsPlugin {
     } else if (_platform.isIOS) {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
-          ?.zonedSchedule(
+          ?.zonedScheduleIOS(
               id, title, body, scheduledDate, notificationDetails?.iOS,
               uiLocalNotificationDateInterpretation:
                   uiLocalNotificationDateInterpretation,
@@ -311,7 +311,7 @@ class FlutterLocalNotificationsPlugin {
     } else if (_platform.isMacOS) {
       await resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin>()
-          ?.zonedSchedule(
+          ?.zonedScheduleMacOS(
               id, title, body, scheduledDate, notificationDetails?.macOS,
               payload: payload,
               matchDateTimeComponents: matchDateTimeComponents);

--- a/flutter_local_notifications/lib/src/helpers.dart
+++ b/flutter_local_notifications/lib/src/helpers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_local_notifications/src/types.dart';
 import 'package:timezone/timezone.dart';
 
 /// Helper method for validating notification IDs.
@@ -10,9 +11,15 @@ void validateId(int id) {
   }
 }
 
-/// Helper method for validating a date/time value represents a
-/// future point in time.
-void validateDateIsInTheFuture(TZDateTime scheduledDate) {
+/// Helper method for validating a date/time value represents a future point in
+/// time where `matchDateTimeComponents` is null.
+void validateDateIsInTheFuture(
+  TZDateTime scheduledDate,
+  DateTimeComponents matchDateComponents,
+) {
+  if (matchDateComponents != null) {
+    return;
+  }
   if (scheduledDate.isBefore(DateTime.now())) {
     throw ArgumentError.value(
         scheduledDate, 'scheduledDate', 'Must be a date in the future');

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -122,10 +122,10 @@ class AndroidFlutterLocalNotificationsPlugin
     AndroidNotificationDetails notificationDetails, {
     @required bool androidAllowWhileIdle,
     String payload,
-    DateTimeComponents matchDateComponents,
+    DateTimeComponents matchDateTimeComponents,
   }) async {
     validateId(id);
-    validateDateIsInTheFuture(scheduledDate);
+    validateDateIsInTheFuture(scheduledDate, matchDateTimeComponents);
     ArgumentError.checkNotNull(androidAllowWhileIdle, 'androidAllowWhileIdle');
     final Map<String, Object> serializedPlatformSpecifics =
         notificationDetails?.toMap() ?? <String, Object>{};
@@ -140,10 +140,10 @@ class AndroidFlutterLocalNotificationsPlugin
           'payload': payload ?? ''
         }
           ..addAll(scheduledDate.toMap())
-          ..addAll(matchDateComponents == null
+          ..addAll(matchDateTimeComponents == null
               ? <String, Object>{}
               : <String, Object>{
-                  'matchDateTimeComponents': matchDateComponents.index
+                  'matchDateTimeComponents': matchDateTimeComponents.index
                 }));
   }
 
@@ -400,7 +400,7 @@ class IOSFlutterLocalNotificationsPlugin
     DateTimeComponents matchDateTimeComponents,
   }) async {
     validateId(id);
-    validateDateIsInTheFuture(scheduledDate);
+    validateDateIsInTheFuture(scheduledDate, matchDateTimeComponents);
     ArgumentError.checkNotNull(uiLocalNotificationDateInterpretation,
         'uiLocalNotificationDateInterpretation');
     final Map<String, Object> serializedPlatformSpecifics =
@@ -589,7 +589,7 @@ class MacOSFlutterLocalNotificationsPlugin
     DateTimeComponents matchDateTimeComponents,
   }) async {
     validateId(id);
-    validateDateIsInTheFuture(scheduledDate);
+    validateDateIsInTheFuture(scheduledDate, matchDateTimeComponents);
     final Map<String, Object> serializedPlatformSpecifics =
         notificationDetails?.toMap() ?? <String, Object>{};
     await _channel.invokeMethod(

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -114,7 +114,7 @@ class AndroidFlutterLocalNotificationsPlugin
 
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
-  Future<void> zonedSchedule(
+  Future<void> zonedScheduleAndroid(
     int id,
     String title,
     String body,
@@ -387,7 +387,7 @@ class IOSFlutterLocalNotificationsPlugin
   /// except for when the time zone used in the [scheduledDate] matches the
   /// device's time zone and [uiLocalNotificationDateInterpretation] is set to
   /// [UILocalNotificationDateInterpretation.wallClockTime].
-  Future<void> zonedSchedule(
+  Future<void> zonedScheduleIOS(
     int id,
     String title,
     String body,
@@ -579,7 +579,7 @@ class MacOSFlutterLocalNotificationsPlugin
 
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
-  Future<void> zonedSchedule(
+  Future<void> zonedScheduleMacOS(
     int id,
     String title,
     String body,


### PR DESCRIPTION
This fixes the problem with not being allowed to use previous dates when doing repeating daily notifications as discussed in #971. I also added a new example for this.

I also renamed `zonedSchedule` per platform to easier distinguish between these. These methods are however very similar and i think it makes sense to refactor these into a single `zonedSchedulePlatform` in a future PR, by making a common `NotificationsDetails` class.

I also added `.vscode` to gitignore.