### PR TITLE
[flutter_local_notifications] Check if parcelable notification is present on received intent

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
@@ -29,14 +29,15 @@ public class ScheduledNotificationReceiver extends BroadcastReceiver {
         if (StringUtils.isNullOrEmpty(notificationDetailsJson)) {
             // This logic is needed for apps that used the plugin prior to 0.3.4
             Notification notification = intent.getParcelableExtra("notification");
-            notification.when = System.currentTimeMillis();
-            int notificationId = intent.getIntExtra("notification_id",
-                    0);
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-            notificationManager.notify(notificationId, notification);
-            boolean repeat = intent.getBooleanExtra("repeat", false);
-            if (!repeat) {
-                FlutterLocalNotificationsPlugin.removeNotificationFromCache(context, notificationId);
+            if (notification != null) {
+                notification.when = System.currentTimeMillis();
+                int notificationId = intent.getIntExtra("notification_id", 0);
+                NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+                notificationManager.notify(notificationId, notification);
+                boolean repeat = intent.getBooleanExtra("repeat", false);
+                if (!repeat) {
+                    FlutterLocalNotificationsPlugin.removeNotificationFromCache(context, notificationId);
+                }
             }
         } else {
             Gson gson = FlutterLocalNotificationsPlugin.buildGson();


### PR DESCRIPTION
Using the FlutterLocalNotification plugin in a production app we get some crashes reported to Crashlytics, because there is no "notificationDetails" or "notification" item attached to the intent. We were not able yet to identify the cause, where these incomplete notifications gets scheduled. But we think it would be good to have this sanity check in the notification receiver, dropping any malformed notifications that are received.
