### PR TITLE
[flutter_local_notifications] Replace commit() by apply() in Android implementation to avoid blocking UI thread

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -273,7 +273,22 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         SharedPreferences sharedPreferences = context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(SCHEDULED_NOTIFICATIONS, json);
-        editor.apply();
+        tryCommittingInBackground(editor, 3);
+    }
+
+    private static void tryCommittingInBackground(final SharedPreferences.Editor editor, final int tries) {
+        if(tries == 0) {
+            return;
+        }
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                final boolean isCommitted = editor.commit();
+                if(!isCommitted) {
+                    tryCommittingInBackground(editor, tries - 1);
+                }
+            }
+        }).start();
     }
 
     static void removeNotificationFromCache(Context context, Integer notificationId) {
@@ -1046,7 +1061,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         SharedPreferences sharedPreferences = applicationContext.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(DEFAULT_ICON, defaultIcon);
-        editor.apply();
+        tryCommittingInBackground(editor, 3);
 
         if (mainActivity != null && !launchedActivityFromHistory(mainActivity.getIntent())) {
             sendNotificationPayloadMessage(mainActivity.getIntent());

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -273,7 +273,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         SharedPreferences sharedPreferences = context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(SCHEDULED_NOTIFICATIONS, json);
-        editor.commit();
+        editor.apply();
     }
 
     static void removeNotificationFromCache(Context context, Integer notificationId) {
@@ -1046,7 +1046,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         SharedPreferences sharedPreferences = applicationContext.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(DEFAULT_ICON, defaultIcon);
-        editor.commit();
+        editor.apply();
 
         if (mainActivity != null && !launchedActivityFromHistory(mainActivity.getIntent())) {
             sendNotificationPayloadMessage(mainActivity.getIntent());


### PR DESCRIPTION
Modify commit() to apply() to avoid framerate falls when scheduling many notifications. commit() is called on the main thread and is blocking to the contrary of apply(), and it should lead to no bug due to asynchronism whatsoever.

