### PR TITLE
[flutter_local_notifications] Add tag and threadIdentifier platform-specific properties

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -37,7 +37,7 @@ A cross platform plugin for displaying local notifications.
    - [Periodically show a notification with a specified interval](#periodically-show-a-notification-with-a-specified-interval)
    - [Retrieveing pending notification requests](#retrieveing-pending-notification-requests)
    - [[Android only] Retrieving active notifications](#android-only-retrieving-active-notifications)
-   - [[Android only] Grouping notifications](#android-only-grouping-notifications)
+   - [Grouping notifications](#grouping-notifications)
    - [Cancelling/deleting a notification](#cancellingdeleting-a-notification)
    - [Cancelling/deleting all notifications](#cancellingdeleting-all-notifications)
    - [Getting details on if the app was launched via a notification created by this plugin](#getting-details-on-if-the-app-was-launched-via-a-notification-created-by-this-plugin)
@@ -448,7 +448,7 @@ await flutterLocalNotificationsPlugin.periodicallyShow(0, 'repeating title',
     androidAllowWhileIdle: true);
 ```
 
-### Retrieveing pending notification requests
+### Retrieving pending notification requests
 
 ```dart
 final List<PendingNotificationRequest> pendingNotificationRequests =
@@ -465,10 +465,20 @@ final List<ActiveNotification> activeNotifications =
         ?.getActiveNotifications();
 ```
 
-### [Android only] Grouping notifications
+### Grouping notifications
+
+#### iOS
+
+For iOS, you can specify `threadIdentifier` in `IOSNotificationDetails`. Notifications with the same `threadIdentifier` will get grouped together automatically.
+
+```dart
+const IOSNotificationDetails iOSPlatformChannelSpecifics =
+    IOSNotificationDetails(threadIdentifier: 'thread_id');
+```
+
+#### Android
 
 This is a "translation" of the sample available at https://developer.android.com/training/notify-user/group.html
-For iOS, you can specify `threadIdentifier` in `iOSNotificationDetails`. You could also display the summary notification (not shown in the example) as otherwise the following code would show three notifications.
 
 ```dart
 const String groupKey = 'com.android.example.WORK_EMAIL';

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -35,7 +35,7 @@ A cross platform plugin for displaying local notifications.
    - [Displaying a notification](#displaying-a-notification)
    - [Scheduling a notification](#scheduling-a-notification)
    - [Periodically show a notification with a specified interval](#periodically-show-a-notification-with-a-specified-interval)
-   - [Retrieveing pending notification requests](#retrieveing-pending-notification-requests)
+   - [Retrieving pending notification requests](#retrieving-pending-notification-requests)
    - [[Android only] Retrieving active notifications](#android-only-retrieving-active-notifications)
    - [Grouping notifications](#grouping-notifications)
    - [Cancelling/deleting a notification](#cancellingdeleting-a-notification)

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -468,7 +468,7 @@ final List<ActiveNotification> activeNotifications =
 ### [Android only] Grouping notifications
 
 This is a "translation" of the sample available at https://developer.android.com/training/notify-user/group.html
-For iOS, you could just display the summary notification (not shown in the example) as otherwise the following code would show three notifications 
+For iOS, you can specify `threadIdentifier` in `iOSNotificationDetails`. You could also display the summary notification (not shown in the example) as otherwise the following code would show three notifications.
 
 ```dart
 const String groupKey = 'com.android.example.WORK_EMAIL';

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -118,6 +118,8 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     private static final String NOTIFICATION_LAUNCHED_APP = "notificationLaunchedApp";
     private static final String INVALID_DRAWABLE_RESOURCE_ERROR_MESSAGE = "The resource %s could not be found. Please make sure it has been added as a drawable resource to your Android head project.";
     private static final String INVALID_RAW_RESOURCE_ERROR_MESSAGE = "The resource %s could not be found. Please make sure it has been added as a raw resource to your Android head project.";
+    private static final String CANCEL_ID = "id";
+    private static final String CANCEL_TAG = "tag";
     static String NOTIFICATION_DETAILS = "notificationDetails";
     static Gson gson;
     private MethodChannel channel;
@@ -983,8 +985,10 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     }
 
     private void cancel(MethodCall call, Result result) {
-        Integer id = call.arguments();
-        cancelNotification(id);
+        Map<String, Object> arguments = call.arguments();
+        Integer id = (Integer) arguments.get(CANCEL_ID);
+        String tag = (String) arguments.get(CANCEL_TAG);
+        cancelNotification(id, tag);
         result.success(null);
     }
 
@@ -1115,13 +1119,17 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         return !StringUtils.isNullOrEmpty(icon) && !isValidDrawableResource(applicationContext, icon, result, INVALID_ICON_ERROR_CODE);
     }
 
-    private void cancelNotification(Integer id) {
+    private void cancelNotification(Integer id, String tag) {
         Intent intent = new Intent(applicationContext, ScheduledNotificationReceiver.class);
         PendingIntent pendingIntent = PendingIntent.getBroadcast(applicationContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         AlarmManager alarmManager = getAlarmManager(applicationContext);
         alarmManager.cancel(pendingIntent);
         NotificationManagerCompat notificationManager = getNotificationManager(applicationContext);
-        notificationManager.cancel(id);
+        if (tag == null) {
+            notificationManager.cancel(id);
+        } else {
+            notificationManager.cancel(tag, id);
+        }
         removeNotificationFromCache(applicationContext, id);
     }
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -770,7 +770,12 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     static void showNotification(Context context, NotificationDetails notificationDetails) {
         Notification notification = createNotification(context, notificationDetails);
         NotificationManagerCompat notificationManagerCompat = getNotificationManager(context);
-        notificationManagerCompat.notify(notificationDetails.id, notification);
+
+        if (notificationDetails.tag != null) {
+            notificationManagerCompat.notify(notificationDetails.tag, notificationDetails.id, notification);
+        } else {
+            notificationManagerCompat.notify(notificationDetails.id, notification);
+        }
     }
 
     static void zonedScheduleNextNotification(Context context, NotificationDetails notificationDetails) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -41,6 +41,7 @@ public class NotificationDetails {
     private static final String SOUND_SOURCE = "soundSource";
     private static final String ENABLE_VIBRATION = "enableVibration";
     private static final String VIBRATION_PATTERN = "vibrationPattern";
+    private static final String TAG = "tag";
     private static final String GROUP_KEY = "groupKey";
     private static final String SET_AS_GROUP_SUMMARY = "setAsGroupSummary";
     private static final String GROUP_ALERT_BEHAVIOR = "groupAlertBehavior";
@@ -176,6 +177,7 @@ public class NotificationDetails {
     public Boolean fullScreenIntent;
     public String shortcutId;
     public String subText;
+    public String tag;
 
 
 
@@ -250,6 +252,7 @@ public class NotificationDetails {
             notificationDetails.shortcutId = (String) platformChannelSpecifics.get(SHORTCUT_ID);
             notificationDetails.additionalFlags = (int[]) platformChannelSpecifics.get(ADDITIONAL_FLAGS);
             notificationDetails.subText = (String) platformChannelSpecifics.get(SUB_TEXT);
+            notificationDetails.tag = (String) platformChannelSpecifics.get(TAG);
         }
     }
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -449,6 +449,12 @@ class _HomePageState extends State<HomePage> {
                         },
                       ),
                       PaddedRaisedButton(
+                        buttonText: 'Show notifications with tag',
+                        onPressed: () async {
+                          await _showNotificationsWithTag();
+                        },
+                      ),
+                      PaddedRaisedButton(
                         buttonText: 'Show ongoing notification',
                         onPressed: () async {
                           await _showOngoingNotification();
@@ -556,6 +562,12 @@ class _HomePageState extends State<HomePage> {
                         buttonText: 'Show notification with attachment',
                         onPressed: () async {
                           await _showNotificationWithAttachment();
+                        },
+                      ),
+                      PaddedRaisedButton(
+                        buttonText: 'Show notifications with thread identifier',
+                        onPressed: () async {
+                          await _showNotificationsWithThreadIdentifier();
                         },
                       ),
                     ],
@@ -1017,6 +1029,24 @@ class _HomePageState extends State<HomePage> {
         3, 'Attention', 'Two messages', platformChannelSpecifics);
   }
 
+  Future<void> _showNotificationsWithTag() async {
+    const AndroidNotificationDetails androidPlatformChannelSpecifics =
+        AndroidNotificationDetails(
+            'your channel id', 'your channel name', 'your channel description',
+            importance: Importance.max, priority: Priority.high, tag: 'tag');
+    const NotificationDetails platformChannelSpecifics = NotificationDetails(
+      android: androidPlatformChannelSpecifics,
+    );
+    await flutterLocalNotificationsPlugin.show(
+        0, 'first notification', null, platformChannelSpecifics);
+
+    await Future<void>.delayed(
+      const Duration(seconds: 10),
+      () => flutterLocalNotificationsPlugin.show(
+          0, 'second notification', null, platformChannelSpecifics),
+    );
+  }
+
   Future<void> _checkPendingNotificationRequests() async {
     final List<PendingNotificationRequest> pendingNotificationRequests =
         await flutterLocalNotificationsPlugin.pendingNotificationRequests();
@@ -1259,6 +1289,39 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(
         0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
         payload: 'item x');
+  }
+
+  Future<void> _showNotificationsWithThreadIdentifier() async {
+    NotificationDetails buildNotificationDetailsForThread(
+      String threadIdentifier,
+    ) {
+      final IOSNotificationDetails iOSPlatformChannelSpecifics =
+          IOSNotificationDetails(threadIdentifier: threadIdentifier);
+      final MacOSNotificationDetails macOSPlatformChannelSpecifics =
+          MacOSNotificationDetails(threadIdentifier: threadIdentifier);
+      return NotificationDetails(
+          iOS: iOSPlatformChannelSpecifics,
+          macOS: macOSPlatformChannelSpecifics);
+    }
+
+    final NotificationDetails thread1PlatformChannelSpecifics =
+        buildNotificationDetailsForThread('thread1');
+    final NotificationDetails thread2PlatformChannelSpecifics =
+        buildNotificationDetailsForThread('thread2');
+
+    await flutterLocalNotificationsPlugin.show(
+        0, 'thread 1', 'first notification', thread1PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        1, 'thread 1', 'second notification', thread1PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        2, 'thread 1', 'third notification', thread1PlatformChannelSpecifics);
+
+    await flutterLocalNotificationsPlugin.show(
+        3, 'thread 2', 'first notification', thread2PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        4, 'thread 2', 'second notification', thread2PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        5, 'thread 2', 'third notification', thread2PlatformChannelSpecifics);
   }
 
   Future<void> _showNotificationWithoutTimestamp() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -455,6 +455,12 @@ class _HomePageState extends State<HomePage> {
                         },
                       ),
                       PaddedRaisedButton(
+                        buttonText: 'Cancel notification with tag',
+                        onPressed: () async {
+                          await _cancelNotificationWithTag();
+                        },
+                      ),
+                      PaddedRaisedButton(
                         buttonText: 'Show ongoing notification',
                         onPressed: () async {
                           await _showOngoingNotification();
@@ -667,6 +673,10 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _cancelNotification() async {
     await flutterLocalNotificationsPlugin.cancel(0);
+  }
+
+  Future<void> _cancelNotificationWithTag() async {
+    await flutterLocalNotificationsPlugin.cancel(0, tag: 'tag');
   }
 
   Future<void> _showNotificationCustomSound() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -449,9 +449,9 @@ class _HomePageState extends State<HomePage> {
                         },
                       ),
                       PaddedRaisedButton(
-                        buttonText: 'Show notifications with tag',
+                        buttonText: 'Show notification with tag',
                         onPressed: () async {
-                          await _showNotificationsWithTag();
+                          await _showNotificationWithTag();
                         },
                       ),
                       PaddedRaisedButton(
@@ -1039,7 +1039,7 @@ class _HomePageState extends State<HomePage> {
         3, 'Attention', 'Two messages', platformChannelSpecifics);
   }
 
-  Future<void> _showNotificationsWithTag() async {
+  Future<void> _showNotificationWithTag() async {
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
             'your channel id', 'your channel name', 'your channel description',
@@ -1049,12 +1049,6 @@ class _HomePageState extends State<HomePage> {
     );
     await flutterLocalNotificationsPlugin.show(
         0, 'first notification', null, platformChannelSpecifics);
-
-    await Future<void>.delayed(
-      const Duration(seconds: 10),
-      () => flutterLocalNotificationsPlugin.show(
-          0, 'second notification', null, platformChannelSpecifics),
-    );
   }
 
   Future<void> _checkPendingNotificationRequests() async {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -52,6 +52,7 @@ NSString *const SOUND = @"sound";
 NSString *const ATTACHMENTS = @"attachments";
 NSString *const ATTACHMENT_IDENTIFIER = @"identifier";
 NSString *const ATTACHMENT_FILE_PATH = @"filePath";
+NSString *const THREAD_IDENTIFIER = @"threadIdentifier";
 NSString *const PRESENT_ALERT = @"presentAlert";
 NSString *const PRESENT_SOUND = @"presentSound";
 NSString *const PRESENT_BADGE = @"presentBadge";
@@ -557,6 +558,9 @@ static FlutterError *getFlutterError(NSError *error) {
         }
         if([self containsKey:BADGE_NUMBER forDictionary:platformSpecifics]) {
             content.badge = [platformSpecifics objectForKey:BADGE_NUMBER];
+        }
+        if([self containsKey:THREAD_IDENTIFIER forDictionary:platformSpecifics]) {
+            content.threadIdentifier = platformSpecifics[THREAD_IDENTIFIER];
         }
         if([self containsKey:ATTACHMENTS forDictionary:platformSpecifics]) {
             NSArray<NSDictionary *> *attachments = platformSpecifics[ATTACHMENTS];

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -203,8 +203,18 @@ class FlutterLocalNotificationsPlugin {
   ///
   /// This applies to notifications that have been scheduled and those that
   /// have already been presented.
-  Future<void> cancel(int id) async {
-    await FlutterLocalNotificationsPlatform.instance?.cancel(id);
+  ///
+  /// The [tag] parameter specifies the Android tag. If it is provided,
+  /// then the notification that matches both the id and the tag will
+  /// be canceled. [tag] has no effect on other platforms.
+  Future<void> cancel(int id, {String tag}) async {
+    if (_platform.isAndroid) {
+      await resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.cancel(id, tag: tag);
+    } else {
+      await FlutterLocalNotificationsPlatform.instance?.cancel(id);
+    }
   }
 
   /// Cancels/removes all notifications.

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -204,9 +204,9 @@ class FlutterLocalNotificationsPlugin {
   /// This applies to notifications that have been scheduled and those that
   /// have already been presented.
   ///
-  /// The [tag] parameter specifies the Android tag. If it is provided,
+  /// The `tag` parameter specifies the Android tag. If it is provided,
   /// then the notification that matches both the id and the tag will
-  /// be canceled. [tag] has no effect on other platforms.
+  /// be canceled. `tag` has no effect on other platforms.
   Future<void> cancel(int id, {String tag}) async {
     if (_platform.isAndroid) {
       await resolvePlatformSpecificImplementation<

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -244,6 +244,16 @@ class AndroidFlutterLocalNotificationsPlugin
     });
   }
 
+  @override
+  Future<void> cancel(int id, {String tag}) async {
+    validateId(id);
+
+    return _channel.invokeMethod('cancel', <String, Object>{
+      'id': id,
+      'tag': tag,
+    });
+  }
+
   /// Creates a notification channel group.
   ///
   /// This method is only applicable to Android versions 8.0 or newer.

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -244,6 +244,14 @@ class AndroidFlutterLocalNotificationsPlugin
     });
   }
 
+  /// Cancel/remove the notification with the specified id.
+  ///
+  /// This applies to notifications that have been scheduled and those that
+  /// have already been presented.
+  ///
+  /// The `tag` parameter specifies the Android tag. If it is provided,
+  /// then the notification that matches both the id and the tag will
+  /// be canceled. `tag` has no effect on other platforms.
   @override
   Future<void> cancel(int id, {String tag}) async {
     validateId(id);

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -250,6 +250,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'shortcutId': shortcutId,
         'additionalFlags': additionalFlags,
         'subText': subText,
+        'tag': tag,
       }
         ..addAll(_convertStyleInformationToMap())
         ..addAll(_convertNotificationSoundToMap(sound))

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -270,5 +270,9 @@ class AndroidNotificationDetails {
   /// occupy the same place.
   final String subText;
 
+  /// The notification tag.
+  ///
+  /// Showing notification with the same (tag, id) pair as a currently visible
+  /// notification will replace the old notification with the new one.
   final String tag;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -50,6 +50,7 @@ class AndroidNotificationDetails {
     this.shortcutId,
     this.additionalFlags,
     this.subText,
+    this.tag,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -268,4 +269,6 @@ class AndroidNotificationDetails {
   /// setProgress(int, int, boolean) at the same time on those versions; they
   /// occupy the same place.
   final String subText;
+
+  final String tag;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/method_channel_mappers.dart
@@ -29,6 +29,7 @@ extension IOSNotificationDetailsMapper on IOSNotificationDetails {
         'subtitle': subtitle,
         'sound': sound,
         'badgeNumber': badgeNumber,
+        'threadIdentifier': threadIdentifier,
         'attachments': attachments
             ?.map((a) => a.toMap()) // ignore: always_specify_types
             ?.toList()

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
@@ -11,6 +11,7 @@ class IOSNotificationDetails {
     this.badgeNumber,
     this.attachments,
     this.subtitle,
+    this.threadIdentifier,
   });
 
   /// Display an alert when the notification is triggered while app is
@@ -64,4 +65,10 @@ class IOSNotificationDetails {
   ///
   /// This property is only applicable to iOS 10 or newer.
   final String subtitle;
+
+  /// Specifies the thread identifier that can be used to group
+  /// notifications together.
+  ///
+  /// This property is only applicable to iOS 10 or newer.
+  final String threadIdentifier;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/macos/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/macos/method_channel_mappers.dart
@@ -29,6 +29,7 @@ extension MacOSNotificationDetailsMapper on MacOSNotificationDetails {
         'subtitle': subtitle,
         'sound': sound,
         'badgeNumber': badgeNumber,
+        'threadIdentifier': threadIdentifier,
         'attachments': attachments
             ?.map((a) => a.toMap()) // ignore: always_specify_types
             ?.toList()

--- a/flutter_local_notifications/lib/src/platform_specifics/macos/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/macos/notification_details.dart
@@ -11,6 +11,7 @@ class MacOSNotificationDetails {
     this.badgeNumber,
     this.attachments,
     this.subtitle,
+    this.threadIdentifier,
   });
 
   /// Display an alert when the notification is triggered while app is
@@ -62,4 +63,10 @@ class MacOSNotificationDetails {
 
   /// Specifies the secondary description.
   final String subtitle;
+
+  /// Specifies the thread identifier that can be used to group
+  /// notifications together.
+  ///
+  /// This property is only applicable to macOS 10.14 or newer.
+  final String threadIdentifier;
 }

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -32,6 +32,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         static let attachments = "attachments"
         static let identifier = "identifier"
         static let filePath = "filePath"
+        static let threadIdentifier = "threadIdentifier"
     }
     
     struct DateFormatStrings {
@@ -371,6 +372,9 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
             }
             if !(platformSpecifics[MethodCallArguments.presentBadge] is NSNull) && platformSpecifics[MethodCallArguments.presentBadge] != nil {
                 presentBadge = platformSpecifics[MethodCallArguments.presentBadge] as! Bool
+            }
+            if let threadIdentifier = platformSpecifics[MethodCallArguments.threadIdentifier] as? String {
+                content.threadIdentifier = threadIdentifier
             }
             if let attachments = platformSpecifics[MethodCallArguments.attachments] as? [Dictionary<String, AnyObject>] {
                 content.attachments = []

--- a/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
@@ -146,6 +146,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -224,6 +225,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -304,6 +306,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -383,6 +386,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -467,6 +471,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -550,6 +555,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -632,6 +638,7 @@ void main() {
                 'htmlFormatContent': true,
                 'htmlFormatTitle': true,
               },
+              'tag': null,
             },
           }));
     });
@@ -723,6 +730,7 @@ void main() {
                 'htmlFormatSummaryText': false,
                 'hideExpandedLargeIcon': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -824,6 +832,7 @@ void main() {
                 'htmlFormatSummaryText': true,
                 'hideExpandedLargeIcon': true,
               },
+              'tag': null,
             },
           }));
     });
@@ -915,6 +924,7 @@ void main() {
                 'htmlFormatSummaryText': false,
                 'hideExpandedLargeIcon': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -1016,6 +1026,7 @@ void main() {
                 'htmlFormatSummaryText': true,
                 'hideExpandedLargeIcon': true,
               },
+              'tag': null,
             },
           }));
     });
@@ -1104,6 +1115,7 @@ void main() {
                 'htmlFormatSummaryText': false,
                 'htmlFormatLines': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -1199,6 +1211,7 @@ void main() {
                 'htmlFormatSummaryText': true,
                 'htmlFormatLines': true,
               },
+              'tag': null,
             },
           }));
     });
@@ -1279,6 +1292,7 @@ void main() {
                 'htmlFormatContent': false,
                 'htmlFormatTitle': false,
               },
+              'tag': null,
             },
           }));
     });
@@ -1362,6 +1376,7 @@ void main() {
                 'htmlFormatContent': true,
                 'htmlFormatTitle': true,
               },
+              'tag': null,
             },
           }));
     });
@@ -1470,6 +1485,7 @@ void main() {
                   }
                 ],
               },
+              'tag': null,
             },
           }));
     });
@@ -1591,6 +1607,7 @@ void main() {
                   }
                 ],
               },
+              'tag': null,
             },
           }));
     });
@@ -1679,6 +1696,7 @@ void main() {
                   'htmlFormatContent': false,
                   'htmlFormatTitle': false,
                 },
+                'tag': null,
               },
             }));
       });
@@ -1769,6 +1787,7 @@ void main() {
                   'htmlFormatContent': false,
                   'htmlFormatTitle': false,
                 },
+                'tag': null,
               },
             }));
       });
@@ -1860,6 +1879,7 @@ void main() {
                   'htmlFormatContent': false,
                   'htmlFormatTitle': false,
                 },
+                'tag': null,
               },
             }));
       });
@@ -2141,6 +2161,7 @@ void main() {
               'subtitle': 'a subtitle',
               'sound': 'sound.mp3',
               'badgeNumber': 1,
+              'threadIdentifier': null,
               'attachments': <Map<String, Object>>[
                 <String, Object>{
                   'filePath': 'video.mp4',
@@ -2203,6 +2224,7 @@ void main() {
                 'subtitle': null,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -2266,6 +2288,7 @@ void main() {
                 'subtitle': null,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -2330,6 +2353,7 @@ void main() {
                 'subtitle': null,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -2491,6 +2515,7 @@ void main() {
               presentSound: true,
               sound: 'sound.mp3',
               badgeNumber: 1,
+              threadIdentifier: 'thread',
               attachments: <MacOSNotificationAttachment>[
             MacOSNotificationAttachment('video.mp4',
                 identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373'),
@@ -2513,6 +2538,7 @@ void main() {
               'presentSound': true,
               'sound': 'sound.mp3',
               'badgeNumber': 1,
+              'threadIdentifier': 'thread',
               'attachments': <Map<String, Object>>[
                 <String, Object>{
                   'filePath': 'video.mp4',
@@ -2573,6 +2599,7 @@ void main() {
                 'presentSound': true,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -2634,6 +2661,7 @@ void main() {
                 'presentSound': true,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -2696,6 +2724,7 @@ void main() {
                 'presentSound': true,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',

--- a/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/platform_flutter_local_notifications_test.dart
@@ -2006,7 +2006,22 @@ void main() {
 
     test('cancel', () async {
       await flutterLocalNotificationsPlugin.cancel(1);
-      expect(log, <Matcher>[isMethodCall('cancel', arguments: 1)]);
+      expect(log, <Matcher>[
+        isMethodCall('cancel', arguments: <String, Object>{
+          'id': 1,
+          'tag': null,
+        })
+      ]);
+    });
+
+    test('cancel with tag', () async {
+      await flutterLocalNotificationsPlugin.cancel(1, tag: 'tag');
+      expect(log, <Matcher>[
+        isMethodCall('cancel', arguments: <String, Object>{
+          'id': 1,
+          'tag': 'tag',
+        })
+      ]);
     });
 
     test('cancelAll', () async {


### PR DESCRIPTION
This PR adds two platform-specific properties to `NotificationDetails`
- `tag` for Android which can be used for replacing notifications
- `threadIdentifier` for iOS and macOS which can be used for grouping notifications