### PR TITLE
[flutter_local_notifications] fix api docs for getNotificationChannels and amend 4.0.1 changelog entry

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [4.0.1]
 
-* Added the `getNotificationChannels` method to the `AndroidFlutterLocalNotificationsPlugin` class. Thanks to the PR from [Shapovalova Vera](https://github.com/VAShapovalova)
+* [Android] added the `getNotificationChannels` method to the `AndroidFlutterLocalNotificationsPlugin` class. This can be used to a get list of all the notification channels on devices with Android 8.0 or newer. Thanks to the PR from [Shapovalova Vera](https://github.com/VAShapovalova)
 
 # [4.0.0]
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -316,7 +316,8 @@ class AndroidFlutterLocalNotificationsPlugin
 
   /// Returns the list of all notification channels.
   ///
-  /// This method will return an empty list on Android versions older than 6.0.
+  /// This method is only applicable on Android 8.0 or newer. On older versions,
+  /// it will return an empty list.
   Future<List<AndroidNotificationChannel>> getNotificationChannels() async {
     final List<Map<Object, Object>> notificationChannels =
         await _channel.invokeListMethod('getNotificationChannels');


### PR DESCRIPTION
Follow up to fix #997