### PR TITLE
Don't request empty permissions

### DIFF
--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -253,6 +253,10 @@ static FlutterError *getFlutterError(NSError *error) {
                alertPermission:(bool)alertPermission
                badgePermission:(bool)badgePermission
                         result:(FlutterResult _Nonnull)result{
+    if(!soundPermission && !alertPermission && !badgePermission) {
+        result(@NO)
+        return
+    }
     if(@available(iOS 10.0, *)) {
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -254,8 +254,8 @@ static FlutterError *getFlutterError(NSError *error) {
                badgePermission:(bool)badgePermission
                         result:(FlutterResult _Nonnull)result{
     if(!soundPermission && !alertPermission && !badgePermission) {
-        result(@NO)
-        return
+        result(@NO);
+        return;
     }
     if(@available(iOS 10.0, *)) {
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -441,6 +441,10 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     
     @available(OSX 10.14, *)
     func requestPermissionsImpl(soundPermission: Bool, alertPermission: Bool, badgePermission: Bool, result: @escaping FlutterResult) {
+        if(!soundPermission && !alertPermission && !badgePermission) {
+            result(false)
+            return
+        }
         var options: UNAuthorizationOptions = []
         if(soundPermission) {
             options.insert(.sound)


### PR DESCRIPTION
This fix prevents asking for permissions on the plugin initialization

Fixes https://github.com/MaikuB/flutter_local_notifications/issues/1062
