### PR TITLE
[flutter_local_notifications_platform_interface] upgrade plugin_platform_interface to latest version 2.0.0

### DIFF
--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,13 +2,13 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 4.0.1+2
+version: 4.0.1+1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_local_notifications_platform_interface: ^2.0.0+2
+  flutter_local_notifications_platform_interface: ^2.0.0+1
   platform: ">=2.0.0 <4.0.0"
   timezone: ^0.6.1
 
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.3
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^1.0.2
 
 flutter:
   plugin:

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,13 +2,13 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 4.0.1+1
+version: 4.0.1+2
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_local_notifications_platform_interface: ^2.0.0+1
+  flutter_local_notifications_platform_interface: ^2.0.0+2
   platform: ">=2.0.0 <4.0.0"
   timezone: ^0.6.1
 
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.3
-  plugin_platform_interface: ^1.0.3
+  plugin_platform_interface: ^2.0.0
 
 flutter:
   plugin:

--- a/flutter_local_notifications_platform_interface/pubspec.yaml
+++ b/flutter_local_notifications_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications_platform_interface
 description: A common platform interface for the flutter_local_notifications plugin.
-version: 2.0.0+1
+version: 2.0.0+2
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications_platform_interface
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^1.0.2
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Other common packages such as **firebase_messaging** now depend  on `plugin_platform_interface ^2.0.0`. This package will therefore be incompatible if not upgraded.