### PR TITLE
[flutter_local_notifications] Fix the getNotificationAppLaunchDetails() example in the README

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -551,7 +551,7 @@ await flutterLocalNotificationsPlugin.cancelAll();
 
 ```dart
 final NotificationAppLaunchDetails notificationAppLaunchDetails =
-    await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
+    await FlutterLocalNotificationsPlugin().getNotificationAppLaunchDetails();
 ```
 
 ### [iOS only] Periodic notifications showing up after reinstallation


### PR DESCRIPTION
The code in the example didn't compile. I played around until it worked :·) And here it is!