### PR TITLE
flutter_local_notifications package zonedSchedule method multiple notifications

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [4.0.1+3]
+
+* [android/iOS] DateTimeComponents dayOfMonthAndTime added.
+
 # [4.0.1+2]
 
 * [iOS/macOS] fixed issue where not requesting any permissions (i.e. all the boolean flags were set to false) would still cause a permissions prompt to appear. Thanks to the PR from [Andrey Parvatkin](https://github.com/badver)

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -856,6 +856,11 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                     nextFireDate = nextFireDate.plusDays(1);
                 }
                 return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);
+            } else if (notificationDetails.matchDateTimeComponents == DateTimeComponents.DayOfMonthAndTime) {
+                while (nextFireDate.getDayOfMonth() != scheduledDateTime.getDayOfMonth()) {
+                    nextFireDate = nextFireDate.plusDays(1);
+                }
+                return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);
             }
         } else {
             org.threeten.bp.ZoneId zoneId = org.threeten.bp.ZoneId.of(notificationDetails.timeZoneName);
@@ -870,6 +875,11 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);
             } else if (notificationDetails.matchDateTimeComponents == DateTimeComponents.DayOfWeekAndTime) {
                 while (nextFireDate.getDayOfWeek() != scheduledDateTime.getDayOfWeek()) {
+                    nextFireDate = nextFireDate.plusDays(1);
+                }
+                return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);
+            } else if (notificationDetails.matchDateTimeComponents == DateTimeComponents.DayOfMonthAndTime) {
+                while (nextFireDate.getDayOfMonth() != scheduledDateTime.getDayOfMonth()) {
                     nextFireDate = nextFireDate.plusDays(1);
                 }
                 return org.threeten.bp.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/DateTimeComponents.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/DateTimeComponents.java
@@ -5,5 +5,6 @@ import androidx.annotation.Keep;
 @Keep
 public enum DateTimeComponents {
     Time,
-    DayOfWeekAndTime
+    DayOfWeekAndTime,
+    DayOfMonthAndTime,
 }

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -82,7 +82,8 @@ typedef NS_ENUM(NSInteger, RepeatInterval) {
 
 typedef NS_ENUM(NSInteger, DateTimeComponents) {
     Time,
-    DayOfWeekAndTime
+    DayOfWeekAndTime,
+    DayOfMonthAndTime,
 };
 
 typedef NS_ENUM(NSInteger, UILocalNotificationDateInterpretation) {
@@ -381,6 +382,8 @@ static FlutterError *getFlutterError(NSError *error) {
             if([matchDateComponents integerValue] == Time) {
                 notification.repeatInterval = NSCalendarUnitDay;
             } else if([matchDateComponents integerValue] == DayOfWeekAndTime) {
+                notification.repeatInterval = NSCalendarUnitWeekOfYear;
+            } else if([matchDateComponents integerValue] == DayOfMonthAndTime) {
                 notification.repeatInterval = NSCalendarUnitWeekOfYear;
             }
         }

--- a/flutter_local_notifications/lib/src/types.dart
+++ b/flutter_local_notifications/lib/src/types.dart
@@ -66,4 +66,7 @@ enum DateTimeComponents {
 
   /// The day of the week and time.
   dayOfWeekAndTime,
+
+  /// The day of the month and time.
+  dayOfMonthAndTime,
 }

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 4.0.1+2
+version: 4.0.1+3
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
Hey there this package helps me to create some local notifications for reminders but since the app that I'm using schedules notifications like every n day (n depending on the user )

so for example, if the user schedule notification every 1 day for one month, if I was using the `DateTimeComponents.dayOfWeekAndTime` I'm getting the notification 4 times on every scheduled this is because of its only checks the **week and time** if I was using the `DateTimeComponents.time`, I'm getting the notification 30 times because this time its only checks time so that I think we need a more clear match in here so I was thinking adding a `DateTimeComponents.dayOfMonthAndTime` with the help of that we should be fine under 1-year schedules.

I did not have enough ios knowledge maybe you can help me with the ios side after that we can test this whole thing if it looks fine for you