### PR TITLE
[flutter_local_notifications] Update build.gradle - swap "android-S" to 31

### DIFF
--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion "android-S"
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Instead of specifying the compileSdkVersion by the preview name, it is best to use the actual API number, and android-S's version number is 31.

By difference, some machines cannot fetch version "android-S", as it is a preview SDK build, whereas 31 is a non-preview build, and can be fetched by all machines.