### PR TITLE
[flutter_local_notifications_linux] Using TMPDIR env as a primary temporary path

### DIFF
--- a/flutter_local_notifications_linux/lib/src/platform_info.dart
+++ b/flutter_local_notifications_linux/lib/src/platform_info.dart
@@ -27,8 +27,15 @@ class LinuxPlatformInfo {
         final int pid = _posix.getpid();
         final int userId = _posix.getuid();
         final int sessionId = _posix.getsid(pid);
+        final Map<String, String> env = Platform.environment;
+        final String? tmpdir = env['TMPDIR'];
         runtimeDir = Directory(
-          path.join('/tmp', processName, '$userId', '$sessionId'),
+          path.join(
+            tmpdir == null || tmpdir.isEmpty ? '/tmp' : tmpdir,
+            processName,
+            '$userId',
+            '$sessionId',
+          ),
         );
       } else {
         runtimeDir = Directory(path.join(xdg.runtimeDir!.path, processName));


### PR DESCRIPTION
TMPDIR is a standard variable on UNIX/Linux systems, and is often used in containers such as Flatpak to redirect to a temporary folder inside a sandbox. This allows not to make hard bindings to the /tmp directory