### PR TITLE
[flutter_local_notifications_linux] Replace 'developer.gnome.org' links to 'specifications.freedesktop.org'

### DIFF
--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications.dart
@@ -81,7 +81,7 @@ class LinuxFlutterLocalNotificationsPlugin
   /// Note: the system ID is unique only within the current user session,
   /// so it's undesirable to save it to persistable storage without any
   /// invalidation/update. For more information, please see
-  /// Desktop Notifications Specification https://developer.gnome.org/notification-spec/#basic-design
+  /// Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/ar01s02.html
   @override
   Future<Map<int, int>> getSystemIdMap() => _manager.getSystemIdMap();
 }

--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications_platform_linux.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications_platform_linux.dart
@@ -43,6 +43,6 @@ abstract class FlutterLocalNotificationsPlatformLinux
   /// Note: the system ID is unique only within the current user session,
   /// so it's undesirable to save it to persistable storage without any
   /// invalidation/update. For more information, please see
-  /// Desktop Notifications Specification https://developer.gnome.org/notification-spec/#basic-design
+  /// Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/ar01s02.html
   Future<Map<int, int>> getSystemIdMap();
 }

--- a/flutter_local_notifications_linux/lib/src/model/capabilities.dart
+++ b/flutter_local_notifications_linux/lib/src/model/capabilities.dart
@@ -41,7 +41,7 @@ class LinuxServerCapabilities {
 
   /// Supports markup in the body text. The markup is XML-based, and consists
   /// of a small subset of HTML along with a few additional tags.
-  /// For more information, see Desktop Notifications Specification https://developer.gnome.org/notification-spec/#markup
+  /// For more information, see Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/ar01s04.html
   /// If marked up text is sent to a server
   /// that does not give this cap, the markup will show through as regular text
   /// so must be stripped clientside.

--- a/flutter_local_notifications_linux/lib/src/model/hint.dart
+++ b/flutter_local_notifications_linux/lib/src/model/hint.dart
@@ -5,7 +5,7 @@ import 'enums.dart';
 /// Represents a custom Linux notification hint.
 /// Hints are a way to provide extra data to a notification server that
 /// the server may be able to make use of.
-/// For more information, please see Desktop Notifications Specification https://developer.gnome.org/notification-spec/#hints
+/// For more information, please see Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/ar01s08.html
 @optionalTypeArgs
 class LinuxNotificationCustomHint<T> {
   /// Constructs an instance of [LinuxNotificationCustomHint].

--- a/flutter_local_notifications_linux/lib/src/model/icon.dart
+++ b/flutter_local_notifications_linux/lib/src/model/icon.dart
@@ -70,7 +70,7 @@ class LinuxRawIconData {
     this.hasAlpha = false,
   }) : rowStride = rowStride ?? ((width * channels * bitsPerSample) / 8).ceil();
 
-  /// Raw data for the image in bytes.
+  /// Raw data (decoded from the image format) for the image in bytes.
   final Uint8List data;
 
   /// Width of the image in pixels

--- a/flutter_local_notifications_linux/lib/src/model/icon.dart
+++ b/flutter_local_notifications_linux/lib/src/model/icon.dart
@@ -86,6 +86,7 @@ class LinuxRawIconData {
   final int bitsPerSample;
 
   /// The number of channels in the image (e.g. 3 for RGB, 4 for RGBA).
+  /// If [hasAlpha] is `true`, must be 4.
   final int channels;
 
   /// Determines if the image has an alpha channel

--- a/flutter_local_notifications_linux/lib/src/model/initialization_settings.dart
+++ b/flutter_local_notifications_linux/lib/src/model/initialization_settings.dart
@@ -21,6 +21,7 @@ class LinuxInitializationSettings {
   final LinuxNotificationIcon? defaultIcon;
 
   /// Specifies the default sound for notifications.
+  /// Typical value is `ThemeLinuxSound('message')`
   final LinuxNotificationSound? defaultSound;
 
   /// Causes the server to suppress playing any sounds, if it has that ability.

--- a/flutter_local_notifications_linux/lib/src/model/notification_details.dart
+++ b/flutter_local_notifications_linux/lib/src/model/notification_details.dart
@@ -29,6 +29,7 @@ class LinuxNotificationDetails {
   final LinuxNotificationIcon? icon;
 
   /// Specifies the notification sound.
+  /// Typical value is `ThemeLinuxSound('message')`
   final LinuxNotificationSound? sound;
 
   /// Specifies the category for notification.

--- a/flutter_local_notifications_linux/lib/src/notification_info.dart
+++ b/flutter_local_notifications_linux/lib/src/notification_info.dart
@@ -22,7 +22,7 @@ class LinuxNotificationInfo {
   final int id;
 
   /// Notification id, which is returned by the system,
-  /// see Desktop Notifications Specification https://developer.gnome.org/notification-spec/
+  /// see Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/
   final int systemId;
 
   /// Notification payload, that will be passed back to the app


### PR DESCRIPTION
GNOME refresh the developer portal and removed some of the old links.
