### PR TITLE
[flutter_local_notifications] Increase timezone version dependency

### DIFF
--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications_platform_interface: ^4.0.1
   platform: ^3.0.0
-  timezone: ^0.7.0
+  timezone: ^0.8.0
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
[`timezone`](https://pub.dev/packages/timezone) has a new version. Would be great to support it.