### PR TITLE
[flutter_local_notifications] Android 12 Fix

### DIFF
--- a/flutter_local_notifications/android/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/android/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <application>
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
-        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+                  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 8.1.1+2
+version: 8.1.1+3
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
This adds the required exported flag required for broadcast receivers on android 12