### PR TITLE
[flutter_local_notifications]: allow byte arrays as source for icons

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -492,7 +492,8 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         return context.getResources().getIdentifier(name, DRAWABLE, context.getPackageName());
     }
 
-    private static byte[] objectDataToByteArray(Object data) {
+    @SuppressWarnings("unchecked")
+    private static byte[] castObjectToByteArray(Object data) {
         byte[] byteArray;
         // if data is deserialized by gson, it is of the wrong type and we have to convert it
         if (data instanceof ArrayList) {
@@ -507,7 +508,6 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         return byteArray;
     }
 
-    @SuppressWarnings("unchecked")
     private static Bitmap getBitmapFromSource(Context context, Object data, BitmapSource bitmapSource) {
         Bitmap bitmap = null;
         if (bitmapSource == BitmapSource.DrawableResource) {
@@ -515,7 +515,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         } else if (bitmapSource == BitmapSource.FilePath) {
             bitmap = BitmapFactory.decodeFile((String) data);
         } else if (bitmapSource == BitmapSource.ByteArray) {
-            byte[] byteArray = objectDataToByteArray(data);
+            byte[] byteArray = castObjectToByteArray(data);
             bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.length);
         }
 
@@ -547,7 +547,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 }
                 break;
             case ByteArray:
-                byte[] byteArray = objectDataToByteArray(data);
+                byte[] byteArray = castObjectToByteArray(data);
                 icon = IconCompat.createWithData(byteArray, 0, byteArray.length);
             default:
                 break;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -517,22 +517,22 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         return bitmap;
     }
 
-    private static IconCompat getIconFromSource(Context context, String iconPath, IconSource iconSource) {
+    private static IconCompat getIconFromSource(Context context, Object data, IconSource iconSource) {
         IconCompat icon = null;
         switch (iconSource) {
             case DrawableResource:
-                icon = IconCompat.createWithResource(context, getDrawableResourceId(context, iconPath));
+                icon = IconCompat.createWithResource(context, getDrawableResourceId(context, (String) data));
                 break;
             case BitmapFilePath:
-                icon = IconCompat.createWithBitmap(BitmapFactory.decodeFile(iconPath));
+                icon = IconCompat.createWithBitmap(BitmapFactory.decodeFile((String) data));
                 break;
             case ContentUri:
-                icon = IconCompat.createWithContentUri(iconPath);
+                icon = IconCompat.createWithContentUri((String) data);
                 break;
             case FlutterBitmapAsset:
                 try {
                     FlutterLoader flutterLoader = FlutterInjector.instance().flutterLoader();
-                    AssetFileDescriptor assetFileDescriptor = context.getAssets().openFd(flutterLoader.getLookupKeyForAsset(iconPath));
+                    AssetFileDescriptor assetFileDescriptor = context.getAssets().openFd(flutterLoader.getLookupKeyForAsset((String) data));
                     FileInputStream fileInputStream = assetFileDescriptor.createInputStream();
                     icon = IconCompat.createWithBitmap(BitmapFactory.decodeStream(fileInputStream));
                     fileInputStream.close();
@@ -541,6 +541,19 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                     throw new RuntimeException(e);
                 }
                 break;
+            case ByteArray:
+                byte[] byteArray;
+                // if data is deserialized by gson, it is of the wrong type and we have to convert it
+                if (data instanceof ArrayList) {
+                    List<Double> l = (ArrayList<Double>) data;
+                    byteArray = new byte[l.size()];
+                    for (int i = 0; i < l.size(); i++) {
+                        byteArray[i] = (byte) l.get(i).intValue();
+                    }
+                } else {
+                    byteArray = (byte[]) data;
+                }
+                icon = IconCompat.createWithData(byteArray, 0, byteArray.length);
             default:
                 break;
         }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -492,6 +492,21 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         return context.getResources().getIdentifier(name, DRAWABLE, context.getPackageName());
     }
 
+    private static byte[] objectDataToByteArray(Object data) {
+        byte[] byteArray;
+        // if data is deserialized by gson, it is of the wrong type and we have to convert it
+        if (data instanceof ArrayList) {
+            List<Double> l = (ArrayList<Double>) data;
+            byteArray = new byte[l.size()];
+            for (int i = 0; i < l.size(); i++) {
+                byteArray[i] = (byte) l.get(i).intValue();
+            }
+        } else {
+            byteArray = (byte[]) data;
+        }
+        return byteArray;
+    }
+
     @SuppressWarnings("unchecked")
     private static Bitmap getBitmapFromSource(Context context, Object data, BitmapSource bitmapSource) {
         Bitmap bitmap = null;
@@ -500,17 +515,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
         } else if (bitmapSource == BitmapSource.FilePath) {
             bitmap = BitmapFactory.decodeFile((String) data);
         } else if (bitmapSource == BitmapSource.ByteArray) {
-            byte[] byteArray;
-            // if data is deserialized by gson, it is of the wrong type and we have to convert it
-            if (data instanceof ArrayList) {
-                List<Double> l = (ArrayList<Double>) data;
-                byteArray = new byte[l.size()];
-                for (int i = 0; i < l.size(); i++) {
-                    byteArray[i] = (byte) l.get(i).intValue();
-                }
-            } else {
-                byteArray = (byte[]) data;
-            }
+            byte[] byteArray = objectDataToByteArray(data);
             bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.length);
         }
 
@@ -542,17 +547,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 }
                 break;
             case ByteArray:
-                byte[] byteArray;
-                // if data is deserialized by gson, it is of the wrong type and we have to convert it
-                if (data instanceof ArrayList) {
-                    List<Double> l = (ArrayList<Double>) data;
-                    byteArray = new byte[l.size()];
-                    for (int i = 0; i < l.size(); i++) {
-                        byteArray[i] = (byte) l.get(i).intValue();
-                    }
-                } else {
-                    byteArray = (byte[]) data;
-                }
+                byte[] byteArray = objectDataToByteArray(data);
                 icon = IconCompat.createWithData(byteArray, 0, byteArray.length);
             default:
                 break;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/IconSource.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/IconSource.java
@@ -7,5 +7,6 @@ public enum IconSource {
     DrawableResource,
     BitmapFilePath,
     ContentUri,
-    FlutterBitmapAsset
+    FlutterBitmapAsset,
+    ByteArray
 }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -191,10 +191,10 @@ public class NotificationDetails implements Serializable {
         notificationDetails.body = (String) arguments.get(BODY);
         notificationDetails.scheduledDateTime = (String) arguments.get(SCHEDULED_DATE_TIME);
         notificationDetails.timeZoneName = (String) arguments.get(TIME_ZONE_NAME);
-        if(arguments.containsKey(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)) {
+        if (arguments.containsKey(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)) {
             notificationDetails.scheduledNotificationRepeatFrequency = ScheduledNotificationRepeatFrequency.values()[(Integer) arguments.get(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)];
         }
-        if(arguments.containsKey(MATCH_DATE_TIME_COMPONENTS)) {
+        if (arguments.containsKey(MATCH_DATE_TIME_COMPONENTS)) {
             notificationDetails.matchDateTimeComponents = DateTimeComponents.values()[(Integer) arguments.get(MATCH_DATE_TIME_COMPONENTS)];
         }
         if (arguments.containsKey(MILLISECONDS_SINCE_EPOCH)) {
@@ -214,7 +214,7 @@ public class NotificationDetails implements Serializable {
         if (arguments.containsKey(DAY)) {
             notificationDetails.day = (Integer) arguments.get(DAY);
         }
-        
+
         readPlatformSpecifics(arguments, notificationDetails);
         return notificationDetails;
     }
@@ -299,8 +299,8 @@ public class NotificationDetails implements Serializable {
     private static void readSoundInformation(NotificationDetails notificationDetails, Map<String, Object> platformChannelSpecifics) {
         notificationDetails.playSound = (Boolean) platformChannelSpecifics.get(PLAY_SOUND);
         notificationDetails.sound = (String) platformChannelSpecifics.get(SOUND);
-        Integer soundSourceIndex = (Integer)platformChannelSpecifics.get(SOUND_SOURCE);
-        if(soundSourceIndex != null) {
+        Integer soundSourceIndex = (Integer) platformChannelSpecifics.get(SOUND_SOURCE);
+        if (soundSourceIndex != null) {
             notificationDetails.soundSource = SoundSource.values()[soundSourceIndex];
         }
     }
@@ -372,7 +372,7 @@ public class NotificationDetails implements Serializable {
             return null;
         }
         Boolean bot = (Boolean) person.get(BOT);
-        String icon = (String) person.get(ICON);
+        Object icon = person.get(ICON);
         Integer iconSourceIndex = (Integer) person.get(ICON_SOURCE);
         IconSource iconSource = iconSourceIndex == null ? null : IconSource.values()[iconSourceIndex];
         Boolean important = (Boolean) person.get(IMPORTANT);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/PersonDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/PersonDetails.java
@@ -7,14 +7,14 @@ import java.io.Serializable;
 @Keep
 public class PersonDetails implements Serializable {
     public Boolean bot;
-    public String icon;
+    public Object icon;
     public IconSource iconBitmapSource;
     public Boolean important;
     public String key;
     public String name;
     public String uri;
 
-    public PersonDetails(Boolean bot, String icon, IconSource iconSource, Boolean important, String key, String name, String uri) {
+    public PersonDetails(Boolean bot, Object icon, IconSource iconSource, Boolean important, String key, String name, String uri) {
         this.bot = bot;
         this.icon = icon;
         this.iconBitmapSource = iconSource;

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1239,7 +1239,7 @@ class _HomePageState extends State<HomePage> {
         key: '3',
         uri: 'tel:111222333444',
         icon: ByteArrayAndroidIcon.fromBase64String(
-            await _base64encodedImage('http://placekitten.com/48/48')));
+            await _base64encodedImage('https://placekitten.com/48/48')));
 
     final List<Message> messages = <Message>[
       Message('Hi', DateTime.now(), null),

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1234,6 +1234,13 @@ class _HomePageState extends State<HomePage> {
       bot: true,
       icon: BitmapFilePathAndroidIcon(largeIconPath),
     );
+    final Person chef = Person(
+        name: 'Master Chef',
+        key: '3',
+        uri: 'tel:111222333444',
+        icon: ByteArrayAndroidIcon.fromBase64String(
+            await _base64encodedImage('http://placekitten.com/48/48')));
+
     final List<Message> messages = <Message>[
       Message('Hi', DateTime.now(), null),
       Message("What's up?", DateTime.now().add(const Duration(minutes: 5)),
@@ -1242,6 +1249,8 @@ class _HomePageState extends State<HomePage> {
           dataMimeType: 'image/png', dataUri: imageUri),
       Message('What kind of food would you prefer?',
           DateTime.now().add(const Duration(minutes: 10)), lunchBot),
+      Message('You do not have time eat! Keep working!',
+          DateTime.now().add(const Duration(minutes: 11)), chef),
     ];
     final MessagingStyleInformation messagingStyle = MessagingStyleInformation(
         me,
@@ -1262,8 +1271,8 @@ class _HomePageState extends State<HomePage> {
 
     // wait 10 seconds and add another message to simulate another response
     await Future<void>.delayed(const Duration(seconds: 10), () async {
-      messages.add(Message(
-          'Thai', DateTime.now().add(const Duration(minutes: 11)), null));
+      messages.add(Message("I'm so sorry!!! But I really like thai food ...",
+          DateTime.now().add(const Duration(minutes: 11)), null));
       await flutterLocalNotificationsPlugin.show(
           0, 'message title', 'message body', platformChannelSpecifics);
     });
@@ -2250,6 +2259,7 @@ class SecondPage extends StatefulWidget {
 
 class SecondPageState extends State<SecondPage> {
   String? _payload;
+
   @override
   void initState() {
     super.initState();

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -24,7 +24,10 @@ enum AndroidIconSource {
   contentUri,
 
   /// A Flutter asset that is a bitmap.
-  flutterBitmapAsset
+  flutterBitmapAsset,
+
+  /// A byte array bitmap.
+  byteArray,
 }
 
 /// The available notification styles on Android.
@@ -229,6 +232,7 @@ class Priority {
 
   @override
   int get hashCode => value;
+
   @override
   bool operator ==(Object other) => other is Priority && other.value == value;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/icon.dart
@@ -1,12 +1,20 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'enums.dart';
+
 /// Represents an icon on Android.
-abstract class AndroidIcon {
+abstract class AndroidIcon<T> {
   /// The location to the icon;
-  String get icon;
+  T get data;
+
+  /// The subclass source type
+  AndroidIconSource get source;
 }
 
 /// Represents a drawable resource belonging to the Android application that
 /// should be used as an icon on Android.
-class DrawableResourceAndroidIcon implements AndroidIcon {
+class DrawableResourceAndroidIcon implements AndroidIcon<String> {
   /// Constructs an instance of [DrawableResourceAndroidIcon].
   const DrawableResourceAndroidIcon(this._icon);
 
@@ -16,12 +24,15 @@ class DrawableResourceAndroidIcon implements AndroidIcon {
   ///
   /// For example if the drawable resource is located at `res/drawable/app_icon.png`, the icon should be `app_icon`
   @override
-  String get icon => _icon;
+  String get data => _icon;
+
+  @override
+  AndroidIconSource get source => AndroidIconSource.drawableResource;
 }
 
 /// Represents a file path to a bitmap that should be used for as an icon on
 /// Android.
-class BitmapFilePathAndroidIcon implements AndroidIcon {
+class BitmapFilePathAndroidIcon implements AndroidIcon<String> {
   /// Constructs an instance of [BitmapFilePathAndroidIcon].
   const BitmapFilePathAndroidIcon(this._icon);
 
@@ -29,11 +40,14 @@ class BitmapFilePathAndroidIcon implements AndroidIcon {
 
   /// A file path on the Android device that refers to the location of the icon.
   @override
-  String get icon => _icon;
+  String get data => _icon;
+
+  @override
+  AndroidIconSource get source => AndroidIconSource.bitmapFilePath;
 }
 
 /// Represents a content URI that should be used for as an icon on Android.
-class ContentUriAndroidIcon implements AndroidIcon {
+class ContentUriAndroidIcon implements AndroidIcon<String> {
   /// Constructs an instance of [ContentUriAndroidIcon].
   const ContentUriAndroidIcon(this._icon);
 
@@ -41,12 +55,15 @@ class ContentUriAndroidIcon implements AndroidIcon {
 
   /// A content URI that refers to the location of the icon.
   @override
-  String get icon => _icon;
+  String get data => _icon;
+
+  @override
+  AndroidIconSource get source => AndroidIconSource.contentUri;
 }
 
 /// Represents a bitmap asset belonging to the Flutter application that should
 /// be used for as an icon on Android.
-class FlutterBitmapAssetAndroidIcon implements AndroidIcon {
+class FlutterBitmapAssetAndroidIcon implements AndroidIcon<String> {
   /// Constructs an instance of [FlutterBitmapAssetAndroidIcon].
   const FlutterBitmapAssetAndroidIcon(this._icon);
 
@@ -64,5 +81,28 @@ class FlutterBitmapAssetAndroidIcon implements AndroidIcon {
   ///
   /// then the path to the asset would be `icons/coworker.png`.
   @override
-  String get icon => _icon;
+  String get data => _icon;
+
+  @override
+  AndroidIconSource get source => AndroidIconSource.flutterBitmapAsset;
+}
+
+/// Represents a bitmap asset belonging to the Flutter application that should
+/// be used for as an icon on Android.
+class ByteArrayAndroidIcon implements AndroidIcon<Uint8List> {
+  /// Constructs an instance of [FlutterBitmapAssetAndroidIcon].
+  const ByteArrayAndroidIcon(this._icon);
+
+  /// Constructs an instance of [ByteArrayAndroidIcon] from a base64 string.
+  factory ByteArrayAndroidIcon.fromBase64String(String base64Image) =>
+      ByteArrayAndroidIcon(base64Decode(base64Image));
+
+  final Uint8List _icon;
+
+  /// Byte array data of the icon.
+  @override
+  Uint8List get data => _icon;
+
+  @override
+  AndroidIconSource get source => AndroidIconSource.byteArray;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -1,5 +1,4 @@
 import 'enums.dart';
-import 'icon.dart';
 import 'initialization_settings.dart';
 import 'message.dart';
 import 'notification_channel.dart';
@@ -86,29 +85,13 @@ extension PersonMapper on Person {
       }..addAll(_convertIconToMap());
 
   Map<String, Object> _convertIconToMap() {
-    if (icon is DrawableResourceAndroidIcon) {
-      return <String, Object>{
-        'icon': icon!.icon,
-        'iconSource': AndroidIconSource.drawableResource.index,
-      };
-    } else if (icon is BitmapFilePathAndroidIcon) {
-      return <String, Object>{
-        'icon': icon!.icon,
-        'iconSource': AndroidIconSource.bitmapFilePath.index,
-      };
-    } else if (icon is ContentUriAndroidIcon) {
-      return <String, Object>{
-        'icon': icon!.icon,
-        'iconSource': AndroidIconSource.contentUri.index,
-      };
-    } else if (icon is FlutterBitmapAssetAndroidIcon) {
-      return <String, Object>{
-        'icon': icon!.icon,
-        'iconSource': AndroidIconSource.flutterBitmapAsset.index,
-      };
-    } else {
+    if (icon == null) {
       return <String, Object>{};
     }
+    return <String, Object>{
+      'icon': icon!.data,
+      'iconSource': icon!.source.index,
+    };
   }
 }
 


### PR DESCRIPTION
Implements the same change that has been done in #1227 but for icons (e.g. used for `PersonDetails`)