### PR TITLE
[flutter_local_notifications] Schedule multiple notifications with different data

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -87,7 +87,7 @@ import io.flutter.plugin.common.PluginRegistry;
  * FlutterLocalNotificationsPlugin
  */
 @Keep
-public class FlutterLocalNotificationsPlugin implements MethodCallHandler, PluginRegistry.NewIntentListener, FlutterPlugin, ActivityAware {
+public class  FlutterLocalNotificationsPlugin implements MethodCallHandler, PluginRegistry.NewIntentListener, FlutterPlugin, ActivityAware {
     private static final String SHARED_PREFERENCES_KEY = "notification_plugin_cache";
     private static final String DRAWABLE = "drawable";
     private static final String DEFAULT_ICON = "defaultIcon";
@@ -108,6 +108,7 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
     private static final String CANCEL_ALL_METHOD = "cancelAll";
     private static final String SCHEDULE_METHOD = "schedule";
     private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
+    private static final String MULTIPle_ZONED_SCHEDULE_METHOD = "multipleZonedSchedule";
     private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
     private static final String SHOW_DAILY_AT_TIME_METHOD = "showDailyAtTime";
     private static final String SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD = "showWeeklyAtDayAndTime";
@@ -1032,6 +1033,10 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
                 zonedSchedule(call, result);
                 break;
             }
+            case MULTIPle_ZONED_SCHEDULE_METHOD: {
+                multipleZonedSchedule(call, result);
+                break;
+            }
             case PERIODICALLY_SHOW_METHOD:
             case SHOW_DAILY_AT_TIME_METHOD:
             case SHOW_WEEKLY_AT_DAY_AND_TIME_METHOD: {
@@ -1128,6 +1133,19 @@ public class FlutterLocalNotificationsPlugin implements MethodCallHandler, Plugi
             zonedScheduleNotification(applicationContext, notificationDetails, true);
             result.success(null);
         }
+    }
+    private void multipleZonedSchedule(MethodCall call, Result result) {
+        List<Map<String, Object>> arguments = call.arguments();
+        for (Map<String, Object> argument : arguments) {
+            NotificationDetails notificationDetails = extractNotificationDetails(result, argument);
+            if (notificationDetails != null) {
+                if (notificationDetails.matchDateTimeComponents != null) {
+                    notificationDetails.scheduledDateTime = getNextFireDateMatchingDateTimeComponents(notificationDetails);
+                }
+                zonedScheduleNotification(applicationContext, notificationDetails, true);
+            }
+        }
+        result.success(null);
     }
 
     private void show(MethodCall call, Result result) {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -305,6 +305,14 @@ class _HomePageState extends State<HomePage> {
                         await _showNotificationCustomSound();
                       },
                     ),
+                    if (Platform.isAndroid) ...<Widget>[
+                      PaddedElevatedButton(
+                        buttonText: 'Schedule 5 diffrent notification every minutes',
+                        onPressed: () async {
+                          await _multipleZonedScheduleNotification();
+                        },
+                      ),
+                    ],
                     if (kIsWeb || !Platform.isLinux) ...<Widget>[
                       PaddedElevatedButton(
                         buttonText:
@@ -962,6 +970,22 @@ class _HomePageState extends State<HomePage> {
         androidAllowWhileIdle: true,
         uiLocalNotificationDateInterpretation:
             UILocalNotificationDateInterpretation.absoluteTime);
+  }
+
+  Future<void> _multipleZonedScheduleNotification() async {
+    final List<NotificationData> notificationsData = [];
+    for(int i = 0 ; i < 5 ; i++){
+      notificationsData.add(NotificationData(
+        i, 'multiple scheduled title $i' , 'multiple scheduled body $i',
+        tz.TZDateTime.now(tz.local).add(Duration(minutes: i + 1)),
+        const NotificationDetails(
+            android: AndroidNotificationDetails(
+                'your multiple scheduled channel id', 'your multiple scheduled channel name',
+                channelDescription: 'your channel description')),
+        androidAllowWhileIdle: true,
+      ));
+    }
+    await flutterLocalNotificationsPlugin.multipleZonedSchedule(notificationsData);
   }
 
   Future<void> _showNotificationWithNoSound() async {

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -39,3 +39,4 @@ export 'src/platform_specifics/macos/notification_attachment.dart';
 export 'src/platform_specifics/macos/notification_details.dart';
 export 'src/typedefs.dart';
 export 'src/types.dart';
+export 'src/platform_specifics/android/notification_data.dart';

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/src/platform_specifics/android/notification_data.dart';
 import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
 import 'package:timezone/timezone.dart';
@@ -351,6 +352,22 @@ class FlutterLocalNotificationsPlugin {
               id, title, body, scheduledDate, notificationDetails.macOS,
               payload: payload,
               matchDateTimeComponents: matchDateTimeComponents);
+    }
+  }
+
+  Future<void> multipleZonedSchedule(
+  List<NotificationData> notificatinsData) async {
+    if (kIsWeb) {
+      return;
+    }
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      await resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>()!
+          .multipleZonedSchedule(notificatinsData);
+    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return;
+    } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+      return;
     }
   }
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_data.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_data.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart';
+
+/// Contains notification data specific to Android.
+class NotificationData{
+
+  /// Constructs an instance of [NotificationData].
+  NotificationData(this.id, this.title, this.body,
+      this.scheduledDate, this.notificationDetails,
+      {this.androidAllowWhileIdle, this.payload, this.matchDateTimeComponents});
+
+  /// The notificatin's id.
+  final int id;
+
+  /// The notificatin's title.
+  final String? title;
+
+  /// The notificatin's body text.
+  final String? body;
+
+  /// The notificatin's scheduled date time.
+  final TZDateTime scheduledDate;
+
+  /// The notificatin's details.
+  final NotificationDetails notificationDetails;
+
+  /// On Android, the `androidAllowWhileIdle` is used to determine if
+  ///the notification should be delivered at the specified time even when
+  ///the device in a low-power idle mode.
+  final bool? androidAllowWhileIdle;
+
+  /// The notificatin's payload.
+  final String? payload;
+
+  ///There is an optional `matchDateTimeComponents` parameter that can be used
+  ///to schedule a notification to appear on a daily or weekly basis by telling
+  ///the plugin to match on the time or a combination of day of the week
+  ///and time respectively.
+  final DateTimeComponents? matchDateTimeComponents;
+
+
+
+
+
+
+}


### PR DESCRIPTION
flutter channel process cost in android can be high, so we can schedule multiple notifications with one channel method call.
we can add a list of notification data including id, title, body,  scheduled date, notification details, and more. with this method, w register all notifications just with one channel method call.