### PR TITLE
[flutter_local_notifications] Make manifest compatible with SDK 31+

### DIFF
--- a/flutter_local_notifications/android/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/android/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application>
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
-        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>


### PR DESCRIPTION
To make an app installable to Android 12+ you need to specify that property
