### PR TITLE
[flutter_local_notifications_linux] Allow disabling Linux default action

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -787,6 +787,12 @@ class _HomePageState extends State<HomePage> {
                           await _showLinuxNotificationDifferentLocation();
                         },
                       ),
+                      PaddedElevatedButton(
+                        buttonText: 'Show non-clickable notification',
+                        onPressed: () async {
+                          await _showLinuxNotificationNonClickable();
+                        },
+                      )
                     ],
                   ],
                 ),
@@ -2232,6 +2238,20 @@ Future<void> _showLinuxNotificationDifferentLocation() async {
   await flutterLocalNotificationsPlugin.show(
     0,
     'notification on different screen location',
+    null,
+    platformChannelSpecifics,
+  );
+}
+
+Future<void> _showLinuxNotificationNonClickable() async {
+  const LinuxNotificationDetails linuxPlatformChannelSpecifics =
+      LinuxNotificationDetails(enableDefaultAction: false);
+  const NotificationDetails platformChannelSpecifics = NotificationDetails(
+    linux: linuxPlatformChannelSpecifics,
+  );
+  await flutterLocalNotificationsPlugin.show(
+    0,
+    'notification that is not clickable',
     null,
     platformChannelSpecifics,
   );

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -24,6 +24,10 @@ dev_dependencies:
   integration_test:
     sdk: flutter
 
+dependency_overrides:
+  flutter_local_notifications_linux:
+    path: ../../flutter_local_notifications_linux
+
 flutter:
   uses-material-design: true
   assets:

--- a/flutter_local_notifications_linux/lib/src/model/initialization_settings.dart
+++ b/flutter_local_notifications_linux/lib/src/model/initialization_settings.dart
@@ -15,7 +15,8 @@ class LinuxInitializationSettings {
   /// the notification).
   /// The name can be anything, though implementations are free not to
   /// display it.
-  final String defaultActionName;
+  /// This can be null if the notification should not be clickable.
+  final String? defaultActionName;
 
   /// Specifies the default icon for notifications.
   final LinuxNotificationIcon? defaultIcon;

--- a/flutter_local_notifications_linux/lib/src/model/notification_details.dart
+++ b/flutter_local_notifications_linux/lib/src/model/notification_details.dart
@@ -22,6 +22,7 @@ class LinuxNotificationDetails {
     this.transient = false,
     this.location,
     this.defaultActionName,
+    this.enableDefaultAction = true,
     this.customHints,
   });
 
@@ -73,6 +74,11 @@ class LinuxNotificationDetails {
   /// The name can be anything, though implementations are free not to
   /// display it.
   final String? defaultActionName;
+
+  /// Don't make this notification clickable if this is set to false.
+  /// Setting this overrides defaultActionName from both
+  /// LinuxNotificationDetails and LinuxInitializationSettings
+  final bool enableDefaultAction;
 
   /// Custom hints list to provide extra data to a notification server that
   /// the server may be able to make use of. Before using, make sure that

--- a/flutter_local_notifications_linux/lib/src/notifications_manager.dart
+++ b/flutter_local_notifications_linux/lib/src/notifications_manager.dart
@@ -206,12 +206,21 @@ class LinuxNotificationManager {
   List<String> _buildActions(
     LinuxNotificationDetails? details,
     LinuxInitializationSettings initSettings,
-  ) =>
-      // Add default action, which is triggered when the notification is clicked
-      <String>[
-        _kDefaultActionName,
-        details?.defaultActionName ?? initSettings.defaultActionName,
-      ];
+  ) {
+    //if enableDefaultAction is set (or by default)
+    final String? defaultActionName = details?.enableDefaultAction ?? true
+        // return one of the available defaultActionNames
+        ? details?.defaultActionName ?? initSettings.defaultActionName
+        : null; //if enableDefaultAction is false, then don't set a name
+
+    // Add default action, which is triggered when the notification is clicked
+    return defaultActionName != null
+        ? <String>[
+            _kDefaultActionName,
+            defaultActionName,
+          ]
+        : <String>[];
+  }
 
   /// Cancel notification with the given [id].
   Future<void> cancel(int id) async {

--- a/flutter_local_notifications_linux/test/notifications_manager_test.dart
+++ b/flutter_local_notifications_linux/test/notifications_manager_test.dart
@@ -143,7 +143,7 @@ void main() {
             DBusString(body ?? ''),
             // actions
             DBusArray.string(
-                <String>['default', kDefaultActionName, ...?actions]),
+                actions ?? <String>['default', kDefaultActionName ]),
             // hints
             DBusDict.stringVariant(hints ?? <String, DBusValue>{}),
             // expire_timeout
@@ -198,6 +198,132 @@ void main() {
 
         await manager.initialize(initSettings);
         await manager.show(notify.id, 'Title', 'Body');
+
+        verifyNotifyMethod(values).called(1);
+        verify(
+          () => mockStorage.insert(notify),
+        ).called(1);
+      });
+
+      test('Simple notification with default initializer actions', () async {
+        const LinuxInitializationSettings initSettings =
+            LinuxInitializationSettings(defaultActionName: kDefaultActionName);
+
+        const LinuxNotificationInfo notify = LinuxNotificationInfo(
+          id: 0,
+          systemId: 1,
+        );
+
+        final List<DBusValue> values = buildNotifyMethodValues(
+          actions: <String>["default", kDefaultActionName],
+        );
+
+        mockNotifyMethod(notify.systemId);
+        when(
+          () => mockStorage.getById(notify.id),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockStorage.insert(notify),
+        ).thenAnswer((_) async => true);
+
+        await manager.initialize(initSettings);
+        await manager.show(notify.id, null, null);
+
+        verifyNotifyMethod(values).called(1);
+        verify(
+          () => mockStorage.insert(notify),
+        ).called(1);
+      });
+
+      test('Simple notification with details actions', () async {
+        const LinuxInitializationSettings initSettings =
+            LinuxInitializationSettings(defaultActionName: kDefaultActionName);
+
+        const LinuxNotificationInfo notify = LinuxNotificationInfo(
+          id: 0,
+          systemId: 1,
+        );
+
+        const LinuxNotificationDetails details =
+            LinuxNotificationDetails(defaultActionName: 'Other name');
+
+        final List<DBusValue> values = buildNotifyMethodValues(
+          actions: <String>['default', 'Other name'],
+        );
+
+        mockNotifyMethod(notify.systemId);
+        when(
+          () => mockStorage.getById(notify.id),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockStorage.insert(notify),
+        ).thenAnswer((_) async => true);
+
+        await manager.initialize(initSettings);
+        await manager.show(notify.id, null, null, details: details);
+
+        verifyNotifyMethod(values).called(1);
+        verify(
+          () => mockStorage.insert(notify),
+        ).called(1);
+      });
+
+      test('Simple notification with no actions - details', () async {
+   const LinuxInitializationSettings initSettings =
+            LinuxInitializationSettings(defaultActionName: kDefaultActionName);
+
+        const LinuxNotificationInfo notify = LinuxNotificationInfo(
+          id: 0,
+          systemId: 1,
+        );
+
+        const LinuxNotificationDetails details =
+            LinuxNotificationDetails(enableDefaultAction: false);
+
+        final List<DBusValue> values = buildNotifyMethodValues(
+          actions: <String>[],
+        );
+
+        mockNotifyMethod(notify.systemId);
+        when(
+          () => mockStorage.getById(notify.id),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockStorage.insert(notify),
+        ).thenAnswer((_) async => true);
+
+        await manager.initialize(initSettings);
+        await manager.show(notify.id, null, null, details: details);
+
+        verifyNotifyMethod(values).called(1);
+        verify(
+          () => mockStorage.insert(notify),
+        ).called(1);
+      });
+
+      test('Simple notification with no actions - initializer', () async {
+        const LinuxInitializationSettings initSettings =
+            LinuxInitializationSettings(defaultActionName: null);
+
+        const LinuxNotificationInfo notify = LinuxNotificationInfo(
+          id: 0,
+          systemId: 1,
+        );
+
+        final List<DBusValue> values = buildNotifyMethodValues(
+          actions: <String>[],
+        );
+
+        mockNotifyMethod(notify.systemId);
+        when(
+          () => mockStorage.getById(notify.id),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockStorage.insert(notify),
+        ).thenAnswer((_) async => true);
+
+        await manager.initialize(initSettings);
+        await manager.show(notify.id, null, null);
 
         verifyNotifyMethod(values).called(1);
         verify(


### PR DESCRIPTION
The following commits are part of this PR:
- [flutter_local_notifications_linux] Allow disabling the default action (#1355)
   - make `LinuxInitializationSettings.defaultActionName` nullable to indicate removing the default action
   - add bool `LinuxNotificationDetails.enableDefaultAction` (default true) to indicate whether one specific notification should have the default action 
   - update LinuxNotificationManager._buildActions to account for the above
- [flutter_local_notifications_linux] Add tests for actions
  - change `buildNotifyMethodValues` to use passed in actions OR default actions if null
  - this doesn't affect any other tests since they don't use actions
  - add tests for actions
- [flutter_local_notifications] add non-clickable linux-specific example
  - this uses only the `LinuxNotificationDetails.enableDefaultAction` way of disabling actions
      rather than the Initializer way
- 5fd2236c is a change necessary for testing. IDK if it should be kept or not?