### PR TITLE
[ flutter_local_notifications]: improved without android specific details

### DIFF
--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -191,6 +191,10 @@ class FlutterLocalNotificationsPlugin {
       return;
     }
     if (defaultTargetPlatform == TargetPlatform.android) {
+      assert(
+        notificationDetails != null,
+        'Notification details is required to Android Platform',
+      );
       await resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()
           ?.show(id, title, body,

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -59,17 +59,15 @@ void main() {
       const InitializationSettings initializationSettings =
           InitializationSettings(android: androidInitializationSettings);
       await flutterLocalNotificationsPlugin.initialize(initializationSettings);
-      await flutterLocalNotificationsPlugin.show(
-          1, 'notification title', 'notification body', null);
-      expect(
-          log.last,
-          isMethodCall('show', arguments: <String, Object?>{
-            'id': 1,
-            'title': 'notification title',
-            'body': 'notification body',
-            'payload': '',
-            'platformSpecifics': null,
-          }));
+
+      expect(() async {
+        await flutterLocalNotificationsPlugin.show(
+          1,
+          'notification title',
+          'notification body',
+          null,
+        );
+      }, throwsA(isA<AssertionError>()));
     });
 
     test('show with default Android-specific details', () async {


### PR DESCRIPTION
The according issue #1390, is necessary android specific details to Android Platform. But, it's can confuse, because field is optional.

A simple fix is been add [assert](https://dart.dev/guides/language/language-tour#assert) to validate field for Android Platform.
