### PR TITLE
[flutter_local_notifications]remove addition of groupKey to ActiveNotification so that it goes in a major release

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,10 +1,14 @@
+# [9.1.4]
+
+* [Android] Reverted change in 9.1.0 that added the `groupKey` to `ActiveNotification` as this was a potentially breaking change. This will instead be part of a major release
+
 # [9.1.3]
 
 * [Android] Reverts Android changes done in 9.1.2 and 9.1.1 due to reported stability issues. Ths means issue [1378](https://github.com/MaikuB/flutter_local_notifications/issues/1378) may still occur though is a rare occurrence and may require a different solution and assistance from the community with regards to testing
 
 # [9.1.2+1]
 
-* [Android] some minor code clean up from 9.1.2 changes
+* **BAD** [Android] some minor code clean up from 9.1.2 changes
 * Fixed a grammar issue in readme. Thanks to the PR from [Clément Besnier](https://github.com/clemsciences)
 
 
@@ -19,7 +23,7 @@
 
 # [9.1.0]
 
-* [Android] Added `groupKey` to `ActiveNotification` that would allow for finding the notification's group. Thanks to the PR from [Roman](https://github.com/drstranges)
+* **BAD** [Android] Added `groupKey` to `ActiveNotification` that would allow for finding the notification's group. Thanks to the PR from [Roman](https://github.com/drstranges)
 * [Android] Migrate maven repository from jcenter to mavenCentral. Thanks to the PR from [tigertore](https://github.com/tigertore)
 
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1960,7 +1960,6 @@ class _HomePageState extends State<HomePage> {
                 children: <Widget>[
                   Text(
                     'id: ${activeNotification.id}\n'
-                    'group: ${activeNotification.groupKey}\n'
                     'channelId: ${activeNotification.channelId}\n'
                     'title: ${activeNotification.title}\n'
                     'body: ${activeNotification.body}',

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -400,7 +400,6 @@ class AndroidFlutterLocalNotificationsPlugin
         // ignore: always_specify_types
         ?.map((a) => ActiveNotification(
               a['id'],
-              a['groupKey'],
               a['channelId'],
               a['title'],
               a['body'],

--- a/flutter_local_notifications/lib/src/platform_specifics/android/active_notification.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/active_notification.dart
@@ -4,7 +4,6 @@ class ActiveNotification {
   /// Constructs an instance of [ActiveNotification].
   const ActiveNotification(
     this.id,
-    this.groupKey,
     this.channelId,
     this.title,
     this.body,
@@ -12,9 +11,6 @@ class ActiveNotification {
 
   /// The notification's id.
   final int id;
-
-  /// The notification's group.
-  final String? groupKey;
 
   /// The notification channel's id.
   ///

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 9.1.3
+version: 9.1.4
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
FYI @drstranges that i'll be removing this from the 9.x stable release as I should published the changes in your PR (#1376) as part of a major release