### PR TITLE
Adds support for melos 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pubspec.lock
 .vscode
+*.idea
+*.DS_Store

--- a/flutter_local_notifications/lib/src/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/initialization_settings.dart
@@ -23,6 +23,6 @@ class InitializationSettings {
   /// Settings for macOS.
   final MacOSInitializationSettings? macOS;
 
-   /// Settings for Linux.
+  /// Settings for Linux.
   final LinuxInitializationSettings? linux;
 }

--- a/flutter_local_notifications_linux/lib/src/model/categories.dart
+++ b/flutter_local_notifications_linux/lib/src/model/categories.dart
@@ -107,8 +107,7 @@ class LinuxNotificationCategory {
       return true;
     }
 
-    return other is LinuxNotificationCategory &&
-      other.name == name;
+    return other is LinuxNotificationCategory && other.name == name;
   }
 
   @override

--- a/flutter_local_notifications_linux/test/posix_test.dart
+++ b/flutter_local_notifications_linux/test/posix_test.dart
@@ -14,5 +14,5 @@ void main() {
     test('getpid', () {
       expect(posix.getpid(), equals(pid));
     });
-  });
+  }, skip: !Platform.isLinux);
 }

--- a/flutter_local_notifications_platform_interface/test/flutter_local_notifications_platform_interface_test.dart
+++ b/flutter_local_notifications_platform_interface/test/flutter_local_notifications_platform_interface_test.dart
@@ -1,6 +1,5 @@
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,21 @@
+name: flutter_local_notifications
+repository: https://github.com/MaikuB/flutter_local_notifications
+packages:
+  - flutter_local_notifications/*
+  - flutter_local_notifications_linux/*
+  - flutter_local_notifications_platform_interface/*
+
+ide:
+  intellij: false
+
+scripts:
+  analyze:
+    run: melos exec -c 1 -- "dart analyze . --fatal-infos"
+    description: Run dart analyzer in a specific package.
+  test:
+    description: Run tests in a specific package.
+    run: melos exec --concurrency=1 -- "flutter test"
+    select-package:
+      dir-exists:
+        - "test/"
+  format: dart format -o write .


### PR DESCRIPTION
During the work on #880 I noticed the project could be managed slightly easier rgd. dependencies, tests and so on.

The `melos` package could help with this - now you can run things like this:

```
melos bootstrap
melos exec flutter pub get
melos run test
melos run analyze
```

The `test` commands is probably the most useful as it can run for all the packages.

It is not integrated in the CI process, yet, but could be.