### PR TITLE
[flutter_local_notifications_linux] Add actions support in Linux

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -485,18 +485,28 @@ class _HomePageState extends State<HomePage> {
                         await _showNotificationWithActions();
                       },
                     ),
-                    PaddedElevatedButton(
-                      buttonText: 'Show notification with text actions',
-                      onPressed: () async {
-                        await _showNotificationWithTextAction();
-                      },
-                    ),
-                    PaddedElevatedButton(
-                      buttonText: 'Show notification with text choice',
-                      onPressed: () async {
-                        await _showNotificationWithTextChoice();
-                      },
-                    ),
+                    if (Platform.isLinux)
+                      PaddedElevatedButton(
+                        buttonText:
+                            'Show notification with icon action (if supported)',
+                        onPressed: () async {
+                          await _showNotificationWithIconAction();
+                        },
+                      ),
+                    if (!Platform.isLinux)
+                      PaddedElevatedButton(
+                        buttonText: 'Show notification with text actions',
+                        onPressed: () async {
+                          await _showNotificationWithTextAction();
+                        },
+                      ),
+                    if (!Platform.isLinux)
+                      PaddedElevatedButton(
+                        buttonText: 'Show notification with text choice',
+                        onPressed: () async {
+                          await _showNotificationWithTextChoice();
+                        },
+                      ),
                     const Divider(),
                     if (Platform.isAndroid) ...<Widget>[
                       const Text(
@@ -813,6 +823,14 @@ class _HomePageState extends State<HomePage> {
                                     value: caps.sound,
                                   ),
                                   _InfoValueString(
+                                    title: 'Actions:',
+                                    value: caps.actions,
+                                  ),
+                                  _InfoValueString(
+                                    title: 'Action icons:',
+                                    value: caps.actionIcons,
+                                  ),
+                                  _InfoValueString(
                                     title: 'Other capabilities:',
                                     value: caps.otherCapabilities,
                                   ),
@@ -925,7 +943,7 @@ class _HomePageState extends State<HomePage> {
       ticker: 'ticker',
       actions: <AndroidNotificationAction>[
         AndroidNotificationAction(
-          'id_1',
+          urlLaunchActionId,
           'Action 1',
           icon: DrawableResourceAndroidBitmap('food'),
           contextual: true,
@@ -958,10 +976,25 @@ class _HomePageState extends State<HomePage> {
       categoryIdentifier: iosNotificationCategoryPlain,
     );
 
+    const LinuxNotificationDetails linuxNotificationDetails =
+        LinuxNotificationDetails(
+      actions: <LinuxNotificationAction>[
+        LinuxNotificationAction(
+          key: urlLaunchActionId,
+          label: 'Action 1',
+        ),
+        LinuxNotificationAction(
+          key: navigationActionId,
+          label: 'Action 2',
+        ),
+      ],
+    );
+
     const NotificationDetails notificationDetails = NotificationDetails(
       android: androidNotificationDetails,
       iOS: iosNotificationDetails,
       macOS: macOSNotificationDetails,
+      linux: linuxNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
         id++, 'plain title', 'plain body', notificationDetails,
@@ -1005,6 +1038,25 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(id++, 'Text Input Notification',
         'Expand to see input action', notificationDetails,
         payload: 'item x');
+  }
+
+  Future<void> _showNotificationWithIconAction() async {
+    const LinuxNotificationDetails linuxNotificationDetails =
+        LinuxNotificationDetails(
+      actions: <LinuxNotificationAction>[
+        LinuxNotificationAction(
+          key: 'media-eject',
+          label: 'Eject',
+        ),
+      ],
+    );
+
+    const NotificationDetails notificationDetails = NotificationDetails(
+      linux: linuxNotificationDetails,
+    );
+    await flutterLocalNotificationsPlugin.show(
+        id++, 'plain title', 'plain body', notificationDetails,
+        payload: 'item z');
   }
 
   Future<void> _showNotificationWithTextChoice() async {

--- a/flutter_local_notifications/example/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter_local_notifications/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,8 +2,14 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/flutter_local_notifications/example/linux/flutter/generated_plugin_registrant.h
+++ b/flutter_local_notifications/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/flutter_local_notifications/example/linux/flutter/generated_plugins.cmake
+++ b/flutter_local_notifications/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications.dart
@@ -25,17 +25,23 @@ class LinuxFlutterLocalNotificationsPlugin
   /// Initializes the plugin.
   ///
   /// Call this method on application before using the plugin further.
+  ///
   /// This should only be done once. When a notification created by this plugin
-  /// was used to launch the app, calling `initialize` is what will trigger to
-  /// the `onSelectNotification` callback to be fire.
+  /// was used to launch the app, calling [initialize] is what will trigger to
+  /// the [onSelectNotification] callback to be fire.
+  ///
+  /// [onSelectNotificationAction] specifies a callback handler which receives
+  /// notification action IDs.
   @override
   Future<bool?> initialize(
     LinuxInitializationSettings initializationSettings, {
     SelectNotificationCallback? onSelectNotification,
+    SelectNotificationActionCallback? onSelectNotificationAction,
   }) =>
       _manager.initialize(
         initializationSettings,
         onSelectNotification: onSelectNotification,
+        onSelectNotificationAction: onSelectNotificationAction,
       );
 
   /// Show a notification with an optional payload that will be passed back to

--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications_platform_linux.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications_platform_linux.dart
@@ -13,9 +13,13 @@ abstract class FlutterLocalNotificationsPlatformLinux
   /// Initializes the plugin.
   ///
   /// Call this method on application before using the plugin further.
+  /// 
+  /// [onSelectNotificationAction] specifies a callback handler which receives
+  /// notification action IDs.
   Future<bool?> initialize(
     LinuxInitializationSettings initializationSettings, {
     SelectNotificationCallback? onSelectNotification,
+    SelectNotificationActionCallback? onSelectNotificationAction,
   });
 
   /// Show a notification with an optional payload that will be passed back to

--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications_stub.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications_stub.dart
@@ -24,6 +24,7 @@ class LinuxFlutterLocalNotificationsPlugin
   Future<bool?> initialize(
     LinuxInitializationSettings initializationSettings, {
     SelectNotificationCallback? onSelectNotification,
+    SelectNotificationActionCallback? onSelectNotificationAction,
   }) async {
     assert(false);
   }

--- a/flutter_local_notifications_linux/lib/src/model/capabilities.dart
+++ b/flutter_local_notifications_linux/lib/src/model/capabilities.dart
@@ -4,8 +4,6 @@ import 'initialization_settings.dart';
 import 'notification_details.dart';
 import 'sound.dart';
 
-// TODO(proninyaroslav): add actions
-
 /// Represents capabilities, implemented by the Linux notification server.
 @immutable
 class LinuxServerCapabilities {
@@ -20,6 +18,8 @@ class LinuxServerCapabilities {
     required this.iconStatic,
     required this.persistence,
     required this.sound,
+    required this.actions,
+    required this.actionIcons,
   });
 
   /// Set of unknown capabilities.
@@ -71,6 +71,16 @@ class LinuxServerCapabilities {
   /// and [LinuxInitializationSettings.defaultSuppressSound].
   final bool sound;
 
+  /// The server will provide the specified actions to the user.
+  /// Even if this capability is missing, actions may still be specified by the
+  /// client, however the server is free to ignore them.
+  final bool actions;
+
+  /// Supports using icons instead of text for displaying actions.
+  /// Using icons for actions must be enabled on a per-notification basis using
+  /// [LinuxNotificationDetails.actionKeyAsIconName].
+  final bool actionIcons;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
@@ -86,7 +96,9 @@ class LinuxServerCapabilities {
         other.iconMulti == iconMulti &&
         other.iconStatic == iconStatic &&
         other.persistence == persistence &&
-        other.sound == sound;
+        other.sound == sound &&
+        other.actions == actions &&
+        other.actionIcons == actionIcons;
   }
 
   @override
@@ -99,7 +111,9 @@ class LinuxServerCapabilities {
       iconMulti.hashCode ^
       iconStatic.hashCode ^
       persistence.hashCode ^
-      sound.hashCode;
+      sound.hashCode ^
+      actions.hashCode ^
+      actionIcons.hashCode;
 
   /// Creates a copy of this object,
   /// but with the given fields replaced with the new values.
@@ -113,6 +127,8 @@ class LinuxServerCapabilities {
     bool? iconStatic,
     bool? persistence,
     bool? sound,
+    bool? actions,
+    bool? actionIcons,
   }) =>
       LinuxServerCapabilities(
         otherCapabilities: otherCapabilities ?? this.otherCapabilities,
@@ -124,6 +140,8 @@ class LinuxServerCapabilities {
         iconStatic: iconStatic ?? this.iconStatic,
         persistence: persistence ?? this.persistence,
         sound: sound ?? this.sound,
+        actions: actions ?? this.actions,
+        actionIcons: actionIcons ?? this.actionIcons,
       );
 
   @override
@@ -131,5 +149,6 @@ class LinuxServerCapabilities {
       '$otherCapabilities, body: $body, bodyHyperlinks: $bodyHyperlinks, '
       'bodyImages: $bodyImages, bodyMarkup: $bodyMarkup, '
       'iconMulti: $iconMulti, iconStatic: $iconStatic, '
-      'persistence: $persistence, sound: $sound)';
+      'persistence: $persistence, sound: $sound, actions: $actions, '
+      'actionIcons: $actionIcons)';
 }

--- a/flutter_local_notifications_linux/lib/src/model/notification_details.dart
+++ b/flutter_local_notifications_linux/lib/src/model/notification_details.dart
@@ -23,6 +23,8 @@ class LinuxNotificationDetails {
     this.location,
     this.defaultActionName,
     this.customHints,
+    this.actions = const <LinuxNotificationAction>[],
+    this.actionKeyAsIconName = false,
   });
 
   /// Specifies the notification icon.
@@ -76,6 +78,44 @@ class LinuxNotificationDetails {
 
   /// Custom hints list to provide extra data to a notification server that
   /// the server may be able to make use of. Before using, make sure that
-  /// the server supports this capability, see [LinuxServerCapabilities].
+  /// the server supports this capability, please see [LinuxServerCapabilities].
   final List<LinuxNotificationCustomHint>? customHints;
+
+  /// Specify a list of actions associated with this notifications.
+  final List<LinuxNotificationAction> actions;
+
+  /// If `true`, the server will attempt to interpret
+  /// [LinuxNotificationAction.key] as a named icon.
+  /// [LinuxNotificationAction.label] will be used to annotate the icon for
+  /// accessibility purposes. The icon name should be compliant with the
+  /// Freedesktop.org Icon Naming Specification https://specifications.freedesktop.org/icon-naming-spec/latest/
+  ///
+  /// Note: before using, make sure that the server supports this capability,
+  /// please see [LinuxServerCapabilities].
+  final bool actionKeyAsIconName;
+}
+
+/// Represents an action, that send a request message back to the notification
+/// client when invoked. This functionality may not be implemented by the
+/// notification server, conforming clients should check if it's available using
+/// [LinuxServerCapabilities].
+/// For more information, please see Desktop Notifications Specification https://specifications.freedesktop.org/notification-spec/latest/ar01s02.html
+class LinuxNotificationAction {
+  /// Constructs a [LinuxNotificationAction] object.
+  const LinuxNotificationAction({
+    required this.key,
+    required this.label,
+  });
+
+  /// Unique ID for this action. This ID will be sent back in the action handler
+  /// defined in [FlutterLocalNotificationsPlugin].
+  ///
+  /// If [LinuxNotificationDetails.keyAsIconName] is `true`,
+  /// the server will attempt to interpret [key] as a named icon.
+  /// [label] will be used to annotate the icon for accessibility purposes.
+  /// The icon name should be compliant with the Freedesktop.org Icon Naming Specification https://specifications.freedesktop.org/icon-naming-spec/latest/
+  final String key;
+
+  /// Label to show to the user.
+  final String label;
 }

--- a/flutter_local_notifications_linux/lib/src/notification_info.dart
+++ b/flutter_local_notifications_linux/lib/src/notification_info.dart
@@ -8,15 +8,24 @@ class LinuxNotificationInfo {
     required this.id,
     required this.systemId,
     this.payload,
+    this.actions = const <LinuxNotificationActionInfo>[],
   });
 
   /// Constructs an instance of [LinuxPlatformInfoData] from [json].
-  factory LinuxNotificationInfo.fromJson(Map<String, dynamic> json) =>
-      LinuxNotificationInfo(
-        id: json['id'] as int,
-        systemId: json['systemId'] as int,
-        payload: json['payload'] as String?,
-      );
+  factory LinuxNotificationInfo.fromJson(Map<String, dynamic> json) {
+    final List<dynamic>? actionsJson = json['actions'] as List<dynamic>?;
+    final List<LinuxNotificationActionInfo>? actions = actionsJson
+        // ignore: avoid_annotating_with_dynamic
+        ?.map((dynamic json) =>
+            LinuxNotificationActionInfo.fromJson(json as Map<String, dynamic>))
+        .toList();
+    return LinuxNotificationInfo(
+      id: json['id'] as int,
+      systemId: json['systemId'] as int,
+      payload: json['payload'] as String?,
+      actions: actions ?? <LinuxNotificationActionInfo>[],
+    );
+  }
 
   /// Notification id
   final int id;
@@ -29,11 +38,16 @@ class LinuxNotificationInfo {
   /// when a notification is tapped on.
   final String? payload;
 
+  /// List of actions info
+  final List<LinuxNotificationActionInfo> actions;
+
   /// Returns the object as a key-value map
   Map<String, dynamic> toJson() => <String, dynamic>{
         'id': id,
         'systemId': systemId,
         'payload': payload,
+        'actions':
+            actions.map((LinuxNotificationActionInfo a) => a.toJson()).toList(),
       };
 
   /// Creates a copy of this object,
@@ -42,11 +56,13 @@ class LinuxNotificationInfo {
     int? id,
     int? systemId,
     String? payload,
+    List<LinuxNotificationActionInfo>? actions,
   }) =>
       LinuxNotificationInfo(
         id: id ?? this.id,
         systemId: systemId ?? this.systemId,
         payload: payload ?? this.payload,
+        actions: actions ?? this.actions,
       );
 
   @override
@@ -58,9 +74,50 @@ class LinuxNotificationInfo {
     return other is LinuxNotificationInfo &&
         other.id == id &&
         other.systemId == systemId &&
-        other.payload == payload;
+        other.payload == payload &&
+        listEquals(other.actions, actions);
   }
 
   @override
-  int get hashCode => id.hashCode ^ systemId.hashCode ^ payload.hashCode;
+  int get hashCode =>
+      id.hashCode ^ systemId.hashCode ^ payload.hashCode ^ actions.hashCode;
+}
+
+/// Represents a Linux notification action information
+@immutable
+class LinuxNotificationActionInfo {
+  /// Constructs an instance of [LinuxNotificationActionInfo].
+  const LinuxNotificationActionInfo({
+    required this.key,
+  });
+
+  /// Constructs an instance of [LinuxNotificationActionInfo] from [json].
+  factory LinuxNotificationActionInfo.fromJson(Map<String, dynamic> json) =>
+      LinuxNotificationActionInfo(key: json['key'] as String);
+
+  /// Unique action key.
+  final String key;
+
+  /// Returns the object as a key-value map
+  Map<String, dynamic> toJson() => <String, dynamic>{'key': key};
+
+  /// Creates a copy of this object,
+  /// but with the given fields replaced with the new values.
+  LinuxNotificationActionInfo copyWith({
+    String? key,
+    String? payload,
+  }) =>
+      LinuxNotificationActionInfo(key: key ?? this.key);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is LinuxNotificationActionInfo && other.key == key;
+  }
+
+  @override
+  int get hashCode => key.hashCode;
 }

--- a/flutter_local_notifications_linux/lib/src/notifications_manager.dart
+++ b/flutter_local_notifications_linux/lib/src/notifications_manager.dart
@@ -45,6 +45,7 @@ class LinuxNotificationManager {
 
   late final LinuxInitializationSettings _initializationSettings;
   late final SelectNotificationCallback? _onSelectNotification;
+  late final SelectNotificationActionCallback? _onSelectNotificationAction;
   late final LinuxPlatformInfoData _platformData;
 
   bool _initialized = false;
@@ -54,6 +55,7 @@ class LinuxNotificationManager {
   Future<bool> initialize(
     LinuxInitializationSettings initializationSettings, {
     SelectNotificationCallback? onSelectNotification,
+    SelectNotificationActionCallback? onSelectNotificationAction,
   }) async {
     if (_initialized) {
       return _initialized;
@@ -61,6 +63,7 @@ class LinuxNotificationManager {
     _initialized = true;
     _initializationSettings = initializationSettings;
     _onSelectNotification = onSelectNotification;
+    _onSelectNotificationAction = onSelectNotificationAction;
     _dbus.build(
       destination: _DBusInterfaceSpec.destination,
       path: _DBusInterfaceSpec.path,
@@ -110,16 +113,25 @@ class LinuxNotificationManager {
       ],
       replySignature: DBusSignature('u'),
     );
+    final List<LinuxNotificationActionInfo>? actionsInfo = details?.actions
+        .map(
+          (LinuxNotificationAction action) => LinuxNotificationActionInfo(
+            key: action.key,
+          ),
+        )
+        .toList();
 
     final int systemId = (result.returnValues[0] as DBusUint32).value;
     final LinuxNotificationInfo notify = prevNotify?.copyWith(
           systemId: systemId,
           payload: payload,
+          actions: actionsInfo,
         ) ??
         LinuxNotificationInfo(
           id: id,
           systemId: systemId,
           payload: payload,
+          actions: actionsInfo ?? <LinuxNotificationActionInfo>[],
         );
     await _storage.insert(notify);
   }
@@ -184,6 +196,9 @@ class LinuxNotificationManager {
       hints['x'] = DBusByte(location.x);
       hints['y'] = DBusByte(location.y);
     }
+    if (details?.actionKeyAsIconName ?? false) {
+      hints['action-icons'] = const DBusBoolean(true);
+    }
     if (details?.customHints != null) {
       hints.addAll(_buildCustomHints(details!.customHints!));
     }
@@ -203,16 +218,24 @@ class LinuxNotificationManager {
         ),
       );
 
-  // TODO(proninyaroslav): add actions
   List<String> _buildActions(
     LinuxNotificationDetails? details,
     LinuxInitializationSettings initSettings,
-  ) =>
-      // Add default action, which is triggered when the notification is clicked
-      <String>[
-        _kDefaultActionName,
-        details?.defaultActionName ?? initSettings.defaultActionName,
-      ];
+  ) {
+    // Add default action, which is triggered when the notification is clicked
+    final List<String> actions = <String>[
+      _kDefaultActionName,
+      details?.defaultActionName ?? initSettings.defaultActionName,
+    ];
+    if (details != null) {
+      for (final LinuxNotificationAction action in details.actions) {
+        actions
+          ..add(action.key)
+          ..add(action.label);
+      }
+    }
+    return actions;
+  }
 
   /// Cancel notification with the given [id].
   Future<void> cancel(int id) async {
@@ -257,6 +280,8 @@ class LinuxNotificationManager {
       iconStatic: capsSet.remove('icon-static'),
       persistence: capsSet.remove('persistence'),
       sound: capsSet.remove('sound'),
+      actions: capsSet.remove('actions'),
+      actionIcons: capsSet.remove('action-icons'),
     );
     return capabilities.copyWith(otherCapabilities: capsSet);
   }
@@ -309,11 +334,29 @@ class LinuxNotificationManager {
 
         final int systemId = (s.values[0] as DBusUint32).value;
         final String actionKey = (s.values[1] as DBusString).value;
-        // TODO(proninyaroslav): add actions
+        final LinuxNotificationInfo? notify =
+            await _storage.getBySystemId(systemId);
+        if (notify == null) {
+          return;
+        }
         if (actionKey == _kDefaultActionName) {
-          final LinuxNotificationInfo? notify =
-              await _storage.getBySystemId(systemId);
-          _onSelectNotification?.call(notify?.payload);
+          _onSelectNotification?.call(notify.payload);
+        } else {
+          final LinuxNotificationActionInfo? actionInfo =
+              notify.actions.firstWhere(
+            (LinuxNotificationActionInfo a) => a.key == actionKey,
+          );
+          if (actionInfo == null) {
+            return;
+          }
+          _onSelectNotificationAction?.call(
+            NotificationActionDetails(
+              id: notify.id,
+              actionId: actionInfo.key,
+              input: null,
+              payload: notify.payload,
+            ),
+          );
         }
       },
     );

--- a/flutter_local_notifications_linux/test/mock/mock.dart
+++ b/flutter_local_notifications_linux/test/mock/mock.dart
@@ -3,5 +3,5 @@ export 'mock_dbus_wrapper.dart';
 export 'mock_file.dart';
 export 'mock_file_system.dart';
 export 'mock_platform_info.dart';
-export 'mock_select_notification_callback.dart';
 export 'mock_storage.dart';
+export 'mock_typedef.dart';

--- a/flutter_local_notifications_linux/test/mock/mock_select_notification_callback.dart
+++ b/flutter_local_notifications_linux/test/mock/mock_select_notification_callback.dart
@@ -1,9 +1,0 @@
-import 'package:mocktail/mocktail.dart';
-
-// ignore: one_member_abstracts
-abstract class _SelectNotificationCallback {
-  Future<dynamic> call(String? payload);
-}
-
-class MockSelectNotificationCallback extends Mock
-    implements _SelectNotificationCallback {}

--- a/flutter_local_notifications_linux/test/mock/mock_typedef.dart
+++ b/flutter_local_notifications_linux/test/mock/mock_typedef.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart';
+import 'package:mocktail/mocktail.dart';
+
+// ignore: one_member_abstracts
+abstract class _SelectNotificationCallback {
+  Future<dynamic> call(String? payload);
+}
+
+// ignore: one_member_abstracts
+abstract class _SelectNotificationActionCallback {
+  Future<dynamic> call(NotificationActionDetails details);
+}
+
+class MockSelectNotificationCallback extends Mock
+    implements _SelectNotificationCallback {}
+
+class MockSelectNotificationActionCallback extends Mock
+    implements _SelectNotificationActionCallback {}

--- a/flutter_local_notifications_linux/test/storage_test.dart
+++ b/flutter_local_notifications_linux/test/storage_test.dart
@@ -55,6 +55,15 @@ void main() {
           systemId: 2,
           payload: 'test',
         ),
+        LinuxNotificationInfo(
+          id: 3,
+          systemId: 3,
+          payload: 'test',
+          actions: <LinuxNotificationActionInfo>[
+            LinuxNotificationActionInfo(key: '1'),
+            LinuxNotificationActionInfo(key: '2'),
+          ],
+        ),
       ];
 
       when(() => mockStorageFile.existsSync()).thenReturn(false);
@@ -68,10 +77,11 @@ void main() {
 
       expect(await storage.insert(notifications[0]), isTrue);
       expect(await storage.insert(notifications[1]), isTrue);
+      expect(await storage.insert(notifications[2]), isTrue);
 
       verify(
         () => mockStorageFile.createSync(recursive: true),
-      ).called(2);
+      ).called(3);
       verify(
         () => mockStorageFile.writeAsStringSync(
           jsonEncode(<LinuxNotificationInfo>[notifications[0]]),
@@ -124,6 +134,14 @@ void main() {
           systemId: 2,
           payload: 'test',
         ),
+        LinuxNotificationInfo(
+            id: 3,
+            systemId: 3,
+            payload: 'test',
+            actions: <LinuxNotificationActionInfo>[
+              LinuxNotificationActionInfo(key: '1'),
+              LinuxNotificationActionInfo(key: '2'),
+            ]),
       ];
 
       when(() => mockStorageFile.existsSync()).thenReturn(true);
@@ -144,6 +162,7 @@ void main() {
       ).thenReturn(jsonEncode(notifications));
       await storage.insert(notifications[0]);
       await storage.insert(notifications[1]);
+      await storage.insert(notifications[2]);
 
       expect(
         await storage.getAll(),


### PR DESCRIPTION
All action features that are available in the Desktop Notification Specification have been implemented. Actions such as textbox are not implemented due to the lack of a standardized implementation. The `onSelectNotificationAction` callback currently doesn't work, because `flutter_local_notifications` depends on the old version of `linux_local_notifications_linux` and I can't map `onSelectNotificationAction` to Linux implementation. After the release of Linux plugin, you need to add it here:
https://github.com/MaikuB/flutter_local_notifications/blob/3a9eae23cd723175908d7809a9d58374c4243e16/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart#L141-L146
For the test, you can change `pubspec.yaml` of  `flutter_local_notifications` this way:
```YAML
flutter_local_notifications_linux:
    path: '../flutter_local_notifications_linux'
```

Tested on Fedora 35 (GNOME 41):

![Снимок экрана от 2022-01-04 20-18-29](https://user-images.githubusercontent.com/7840559/148098342-623198d9-a611-4565-80e2-a5a81b88aa3e.png)

