### PR TITLE
[flutter_local_notifications] iOS Time Sensitive notifications

### DIFF
--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -505,11 +505,13 @@ class IOSFlutterLocalNotificationsPlugin
     bool sound = false,
     bool alert = false,
     bool badge = false,
+    bool critical = false,
   }) =>
       _channel.invokeMethod<bool?>('requestPermissions', <String, bool>{
         'sound': sound,
         'alert': alert,
         'badge': badge,
+        'critical': critical,
       });
 
   /// Schedules a notification to be shown at the specified date and time with

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/initialization_settings.dart
@@ -7,6 +7,7 @@ class IOSInitializationSettings {
     this.requestAlertPermission = true,
     this.requestSoundPermission = true,
     this.requestBadgePermission = true,
+    this.requestCriticalPermission = true,
     this.defaultPresentAlert = true,
     this.defaultPresentSound = true,
     this.defaultPresentBadge = true,
@@ -27,6 +28,14 @@ class IOSInitializationSettings {
   ///
   /// Default value is true.
   final bool requestBadgePermission;
+
+  /// Request permission to show critical notifications.
+  ///
+  /// Subject to specific approval from Apple:
+  /// https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
+  ///
+  /// Default value is true.
+  final bool requestCriticalPermission;
 
   /// Configures the default setting on if an alert should be displayed when a
   /// notification is triggered while app is in the foreground.

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/method_channel_mappers.dart
@@ -8,6 +8,7 @@ extension IOSInitializationSettingsMapper on IOSInitializationSettings {
         'requestAlertPermission': requestAlertPermission,
         'requestSoundPermission': requestSoundPermission,
         'requestBadgePermission': requestBadgePermission,
+        'requestCriticalPermission': requestCriticalPermission,
         'defaultPresentAlert': defaultPresentAlert,
         'defaultPresentSound': defaultPresentSound,
         'defaultPresentBadge': defaultPresentBadge
@@ -30,6 +31,7 @@ extension IOSNotificationDetailsMapper on IOSNotificationDetails {
         'sound': sound,
         'badgeNumber': badgeNumber,
         'threadIdentifier': threadIdentifier,
+        'interruptionLevel': interruptionLevel?.index,
         'attachments': attachments
             ?.map((a) => a.toMap()) // ignore: always_specify_types
             .toList()

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
@@ -3,16 +3,17 @@ import 'notification_attachment.dart';
 /// Configures notification details specific to iOS.
 class IOSNotificationDetails {
   /// Constructs an instance of [IOSNotificationDetails].
-  const IOSNotificationDetails(
-      {this.presentAlert,
-      this.presentBadge,
-      this.presentSound,
-      this.sound,
-      this.badgeNumber,
-      this.attachments,
-      this.subtitle,
-      this.threadIdentifier,
-      this.interruptionLevel});
+  const IOSNotificationDetails({
+    this.presentAlert,
+    this.presentBadge,
+    this.presentSound,
+    this.sound,
+    this.badgeNumber,
+    this.attachments,
+    this.subtitle,
+    this.threadIdentifier,
+    this.interruptionLevel,
+  });
 
   /// Display an alert when the notification is triggered while app is
   /// in the foreground.
@@ -82,7 +83,6 @@ class IOSNotificationDetails {
 /// Constants that indicate the importance and delivery
 /// timing of a notification.
 enum InterruptionLevel {
-
   /// The system adds the notification to the notification
   /// list without lighting up the screen or playing a sound.
   passive,

--- a/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/ios/notification_details.dart
@@ -3,16 +3,16 @@ import 'notification_attachment.dart';
 /// Configures notification details specific to iOS.
 class IOSNotificationDetails {
   /// Constructs an instance of [IOSNotificationDetails].
-  const IOSNotificationDetails({
-    this.presentAlert,
-    this.presentBadge,
-    this.presentSound,
-    this.sound,
-    this.badgeNumber,
-    this.attachments,
-    this.subtitle,
-    this.threadIdentifier,
-  });
+  const IOSNotificationDetails(
+      {this.presentAlert,
+      this.presentBadge,
+      this.presentSound,
+      this.sound,
+      this.badgeNumber,
+      this.attachments,
+      this.subtitle,
+      this.threadIdentifier,
+      this.interruptionLevel});
 
   /// Display an alert when the notification is triggered while app is
   /// in the foreground.
@@ -71,4 +71,39 @@ class IOSNotificationDetails {
   ///
   /// This property is only applicable to iOS 10 or newer.
   final String? threadIdentifier;
+
+  /// The interruption level that indicates the priority and
+  /// delivery timing of a notification.
+  ///
+  /// This property is only applicable to iOS 10 or newer.
+  final InterruptionLevel? interruptionLevel;
+}
+
+/// Constants that indicate the importance and delivery
+/// timing of a notification.
+enum InterruptionLevel {
+
+  /// The system adds the notification to the notification
+  /// list without lighting up the screen or playing a sound.
+  passive,
+
+  /// The system presents the notification immediately,
+  /// lights up the screen, and can play a sound.
+  active,
+
+  /// The system presents the notification immediately,
+  /// lights up the screen, and can play a sound,
+  /// but won’t break through system notification controls.
+  ///
+  /// In order for this to work, the 'Time Sensitive Notifications'
+  /// capability needs to be added to the iOS project.
+  /// See https://help.apple.com/xcode/mac/current/#/dev88ff319e7
+  timeSensitive,
+
+  /// The system presents the notification immediately,
+  /// lights up the screen, and bypasses the mute switch to play a sound.
+  ///
+  /// Subject to specific approval from Apple:
+  /// https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
+  critical,
 }

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -46,6 +46,7 @@ void main() {
           'requestAlertPermission': true,
           'requestSoundPermission': true,
           'requestBadgePermission': true,
+          'requestCriticalPermission': true,
           'defaultPresentAlert': true,
           'defaultPresentSound': true,
           'defaultPresentBadge': true,
@@ -59,6 +60,7 @@ void main() {
               requestAlertPermission: false,
               requestBadgePermission: false,
               requestSoundPermission: false,
+              requestCriticalPermission: false,
               defaultPresentAlert: false,
               defaultPresentBadge: false,
               defaultPresentSound: false);
@@ -70,6 +72,7 @@ void main() {
           'requestAlertPermission': false,
           'requestSoundPermission': false,
           'requestBadgePermission': false,
+          'requestCriticalPermission': false,
           'defaultPresentAlert': false,
           'defaultPresentSound': false,
           'defaultPresentBadge': false,
@@ -133,6 +136,7 @@ void main() {
               'sound': 'sound.mp3',
               'badgeNumber': 1,
               'threadIdentifier': null,
+              'interruptionLevel': null,
               'attachments': <Map<String, Object>>[
                 <String, Object>{
                   'filePath': 'video.mp4',
@@ -192,6 +196,7 @@ void main() {
                     'sound': 'sound.mp3',
                     'badgeNumber': 1,
                     'threadIdentifier': null,
+                    'interruptionLevel': null,
                     'attachments': <Map<String, Object>>[
                       <String, Object>{
                         'filePath': 'video.mp4',
@@ -258,6 +263,7 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
+                'interruptionLevel': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -321,6 +327,7 @@ void main() {
                 'subtitle': null,
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
+                'interruptionLevel': null,
                 'threadIdentifier': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
@@ -387,6 +394,7 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
+                'interruptionLevel': null,
                 'attachments': <Map<String, Object>>[
                   <String, Object>{
                     'filePath': 'video.mp4',
@@ -407,6 +415,7 @@ void main() {
           'sound': false,
           'badge': false,
           'alert': false,
+          'critical': false,
         })
       ]);
     });
@@ -414,12 +423,18 @@ void main() {
       await flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()!
-          .requestPermissions(sound: true, badge: true, alert: true);
+          .requestPermissions(
+            sound: true,
+            badge: true,
+            alert: true,
+            critical: true,
+          );
       expect(log, <Matcher>[
         isMethodCall('requestPermissions', arguments: <String, Object>{
           'sound': true,
           'badge': true,
           'alert': true,
+          'critical': true,
         })
       ]);
     });


### PR DESCRIPTION
Hi!

Fixes #1495 

Note that I also added support for "critical" notifications simply because they appeared in the same enumeration in the API as "time sensitive" ones:

https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc
https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/unnotificationinterruptionlevelcritical?language=objc

However, I was not able to test how these work. I understand that it needs special approval from Apple, which I do not have:
https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/

Also note that this is my first time ever writing (seeing?) Objective-C code, i was mainly copy-pasting and adapting already existing code from the same file. I hope I did it right.

Probably also my first PR on Github. :)

Cheers,
Marton
