### PR TITLE
[flutter_local_notifications] Add ActiveNotification.tag

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1595,6 +1595,7 @@ public class FlutterLocalNotificationsPlugin
         }
 
         activeNotificationPayload.put("groupKey", notification.getGroup());
+        activeNotificationPayload.put("tag", activeNotification.getTag());
         activeNotificationPayload.put(
             "title", notification.extras.getCharSequence("android.title"));
         activeNotificationPayload.put("body", notification.extras.getCharSequence("android.text"));

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2020,6 +2020,7 @@ class _HomePageState extends State<HomePage> {
                   Text(
                     'id: ${activeNotification.id}\n'
                     'channelId: ${activeNotification.channelId}\n'
+                    'tag: ${activeNotification.tag}\n'
                     'title: ${activeNotification.title}\n'
                     'body: ${activeNotification.body}',
                   ),

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -403,6 +403,7 @@ class AndroidFlutterLocalNotificationsPlugin
               a['channelId'],
               a['title'],
               a['body'],
+              tag: a['tag'],
             ))
         .toList();
   }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/active_notification.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/active_notification.dart
@@ -6,8 +6,9 @@ class ActiveNotification {
     this.id,
     this.channelId,
     this.title,
-    this.body,
-  );
+    this.body, {
+    this.tag,
+  });
 
   /// The notification's id.
   final int id;
@@ -22,4 +23,7 @@ class ActiveNotification {
 
   /// The notification's content.
   final String? body;
+
+  /// The notification's tag.
+  final String? tag;
 }


### PR DESCRIPTION
Allows users to fetch an active notification tag.

Closes: https://github.com/MaikuB/flutter_local_notifications/issues/1512