### PR TITLE
update logic on iOS and macOS to set notification categories without querying for existing categories

### DIFF
--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -301,7 +301,7 @@ static FlutterError *getFlutterError(NSError *error) {
                   withCompletionHandler:(void (^)(void))completionHandler {
   if (@available(iOS 10.0, *)) {
     if ([self containsKey:@"notificationCategories" forDictionary:arguments]) {
-      NSMutableSet<UNNotificationCategory *> *newCategories =
+      NSMutableSet<UNNotificationCategory *> *notificationCategories =
           [NSMutableSet set];
 
       NSArray *categories = arguments[@"notificationCategories"];
@@ -341,32 +341,24 @@ static FlutterError *getFlutterError(NSError *error) {
           }
         }
 
-        UNNotificationCategory *newCategory = [UNNotificationCategory
+        UNNotificationCategory *notificationCategory = [UNNotificationCategory
             categoryWithIdentifier:category[@"identifier"]
                            actions:newActions
                  intentIdentifiers:@[]
                            options:[Converters parseNotificationCategoryOptions:
                                                    category[@"options"]]];
 
-        [newCategories addObject:newCategory];
+        [notificationCategories addObject:notificationCategory];
       }
 
-      if (newCategories.count > 0) {
+      if (notificationCategories.count > 0) {
         UNUserNotificationCenter *center =
             [UNUserNotificationCenter currentNotificationCenter];
-        [center getNotificationCategoriesWithCompletionHandler:^(
-                    NSSet<UNNotificationCategory *> *_Nonnull existing) {
-          if (existing) {
-            [center setNotificationCategories:
-                        [existing setByAddingObjectsFromSet:newCategories]];
-          } else {
-            [center setNotificationCategories:newCategories];
-          }
-          [[NSUserDefaults standardUserDefaults]
-              setObject:foregroundActionIdentifiers
-                 forKey:FOREGROUND_ACTION_IDENTIFIERS];
-          completionHandler();
-        }];
+        [center setNotificationCategories:notificationCategories];
+        [[NSUserDefaults standardUserDefaults]
+            setObject:foregroundActionIdentifiers
+               forKey:FOREGROUND_ACTION_IDENTIFIERS];
+        completionHandler();
       } else {
         completionHandler();
       }

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -255,11 +255,11 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                     notificationCategories.insert(notificationCategory)
                 }
 
-                if (!notificationCategories.isEmpty) {
+                if !notificationCategories.isEmpty {
                     let center = UNUserNotificationCenter.current()
                     center.setNotificationCategories(notificationCategories)
                 }
-                
+
                 completionHandler()
 
             } else {

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -212,7 +212,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                                          withCompletionHandler completionHandler: @escaping () -> Void) {
         if #available(OSX 10.14, *) {
             if let categories = arguments["notificationCategories"] as? [[String: AnyObject]] {
-                var newCategories = Set<UNNotificationCategory>()
+                var notificationCategories = Set<UNNotificationCategory>()
 
                 for category in categories {
                     var newActions = [UNNotificationAction]()
@@ -243,7 +243,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                         }
                     }
 
-                    let newCategory = UNNotificationCategory(
+                    let notificationCategory = UNNotificationCategory(
                         identifier: category["identifier"] as! String,
                         actions: newActions,
                         intentIdentifiers: [],
@@ -252,15 +252,15 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                         options: Converters.parseNotificationCategoryOptions(category["options"] as! [NSNumber])
                     )
 
-                    newCategories.insert(newCategory)
-
+                    notificationCategories.insert(notificationCategory)
                 }
 
-                let center = UNUserNotificationCenter.current()
-                center.getNotificationCategories { _  in
-                    center.setNotificationCategories(newCategories)
-                    completionHandler()
+                if (!notificationCategories.isEmpty) {
+                    let center = UNUserNotificationCenter.current()
+                    center.setNotificationCategories(notificationCategories)
                 }
+                
+                completionHandler()
 
             } else {
                 completionHandler()


### PR DESCRIPTION
Closes #1481 