### PR TITLE
[flutter_local_notifications] Throw ArgumentError when trying to initialize LocalNotification without  per Platform settings

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [9.4.1]
+
+* Calling `initialize()` on a platform with passing the appropriate initialisation settings for it will now throw an `ArgumentError`. Whilst this may be technically a breaking change, it's been done as a minor change as the call was already throwing an unhandled exception in these scenarios. This change is to help provide more information on why it fails. Documentation has also been updated to provide more on information on this as the intialisation settings for each platform are nullable so developers aren't forced to provide settings for platforms they don't target. Thanks to the PR from [Zlati Pehlivanov](https://github.com/talamaska)
+
 # [9.4.0]
 * [Android] Added `tag` to `ActiveNotification` that would allow for finding the notification's taf. Thanks to the PR from [Simon Ser](https://github.com/emersion)
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -307,6 +307,7 @@ await flutterLocalNotificationsPlugin.initialize(initializationSettings,
 ```
 
 Initialisation can be done in the `main` function of your application or can be done within the first page shown in your app. Developers can refer to the example app that has code for the initialising within the `main` function. The code above has been simplified for explaining the concepts. Here we have specified the default icon to use for notifications on Android (refer to the *Android setup* section) and designated the function (`selectNotification`) that should fire when a notification has been tapped on via the `onSelectNotification` callback. Specifying this callback is entirely optional but here it will trigger navigation to another page and display the payload associated with the notification.
+
 Note that all settings are nullable, because we don't want to force developers so specify settings for platforms they don't target. You will get a runtime ArgumentError Exception if you forgot to pass the settings for the platform you target.
 
 ```dart

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -307,7 +307,7 @@ await flutterLocalNotificationsPlugin.initialize(initializationSettings,
 ```
 
 Initialisation can be done in the `main` function of your application or can be done within the first page shown in your app. Developers can refer to the example app that has code for the initialising within the `main` function. The code above has been simplified for explaining the concepts. Here we have specified the default icon to use for notifications on Android (refer to the *Android setup* section) and designated the function (`selectNotification`) that should fire when a notification has been tapped on via the `onSelectNotification` callback. Specifying this callback is entirely optional but here it will trigger navigation to another page and display the payload associated with the notification.
-Note that all settings are nullable, because we don't want to force developers so specify settings fro platforms they don't target. You will get a runtime ArgumentError Exception if you forgot to pass the settings for the platform you target.
+Note that all settings are nullable, because we don't want to force developers so specify settings for platforms they don't target. You will get a runtime ArgumentError Exception if you forgot to pass the settings for the platform you target.
 
 ```dart
 void selectNotification(String payload) async {

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -307,6 +307,7 @@ await flutterLocalNotificationsPlugin.initialize(initializationSettings,
 ```
 
 Initialisation can be done in the `main` function of your application or can be done within the first page shown in your app. Developers can refer to the example app that has code for the initialising within the `main` function. The code above has been simplified for explaining the concepts. Here we have specified the default icon to use for notifications on Android (refer to the *Android setup* section) and designated the function (`selectNotification`) that should fire when a notification has been tapped on via the `onSelectNotification` callback. Specifying this callback is entirely optional but here it will trigger navigation to another page and display the payload associated with the notification.
+Note that all settings are nullable, because we don't want to force developers so specify settings fro platforms they don't target. You will get a runtime ArgumentError Exception if you forgot to pass the settings for the platform you target.
 
 ```dart
 void selectNotification(String payload) async {

--- a/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
@@ -60,7 +60,7 @@ void main() {
         }
         if (Platform.isMacOS) {
           expect(e.message,
-              'MacOS settings must be set when targeting macOS platform.');
+              'macOS settings must be set when targeting macOS platform.');
         }
       }
     });

--- a/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
@@ -34,6 +34,35 @@ void main() {
           .initialize(initializationSettings);
       expect(initialised, isTrue);
     });
+
+    testWidgets('initialize should throw an ArgumentError',
+        (WidgetTester tester) async {
+      const InitializationSettings initializationSettings =
+          InitializationSettings();
+      try {
+        await flutterLocalNotificationsPlugin
+            .initialize(initializationSettings);
+        // ignore: avoid_catches_without_on_clauses
+      } catch (e) {
+        expect(e, isArgumentError);
+        if (Platform.isAndroid) {
+          expect(e.message,
+              'Android settings must be set when targeting Android platform');
+        }
+        if (Platform.isIOS) {
+          expect(e.message,
+              'iOS settings must be set when targeting iOS platform');
+        }
+        if (Platform.isLinux) {
+          expect(e.message,
+              'Linux settings must be set when targeting Linux platform');
+        }
+        if (Platform.isMacOS) {
+          expect(e.message,
+              'MacOS settings must be set when targeting MacOS platform');
+        }
+      }
+    });
   });
   group('resolvePlatformSpecificImplementation()', () {
     setUpAll(() async {

--- a/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/example/integration_test/flutter_local_notifications_test.dart
@@ -35,7 +35,8 @@ void main() {
       expect(initialised, isTrue);
     });
 
-    testWidgets('initialize should throw an ArgumentError',
+    testWidgets(
+        'initialize with settings equal to null for the targeting platform should throw an ArgumentError',
         (WidgetTester tester) async {
       const InitializationSettings initializationSettings =
           InitializationSettings();
@@ -47,19 +48,19 @@ void main() {
         expect(e, isArgumentError);
         if (Platform.isAndroid) {
           expect(e.message,
-              'Android settings must be set when targeting Android platform');
+              'Android settings must be set when targeting Android platform.');
         }
         if (Platform.isIOS) {
           expect(e.message,
-              'iOS settings must be set when targeting iOS platform');
+              'iOS settings must be set when targeting iOS platform.');
         }
         if (Platform.isLinux) {
           expect(e.message,
-              'Linux settings must be set when targeting Linux platform');
+              'Linux settings must be set when targeting Linux platform.');
         }
         if (Platform.isMacOS) {
           expect(e.message,
-              'MacOS settings must be set when targeting MacOS platform');
+              'MacOS settings must be set when targeting macOS platform.');
         }
       }
     });

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
@@ -119,38 +118,43 @@ class FlutterLocalNotificationsPlugin {
     if (kIsWeb) {
       return true;
     }
-    if (Platform.isAndroid && initializationSettings.android == null) {
-      throw ArgumentError(
-          'Android settings must be set when targeting Android platform');
-    }
-    if (Platform.isIOS && initializationSettings.iOS == null) {
-      throw ArgumentError(
-          'iOS settings must be set when targeting iOS platform');
-    }
-    if (Platform.isLinux && initializationSettings.linux == null) {
-      throw ArgumentError(
-          'Linux settings must be set when targeting Linux platform');
-    }
-    if (Platform.isMacOS && initializationSettings.macOS == null) {
-      throw ArgumentError(
-          'MacOS settings must be set when targeting MacOS platform');
-    }
+
     if (defaultTargetPlatform == TargetPlatform.android) {
+      if (initializationSettings.android == null) {
+        throw ArgumentError(
+            'Android settings must be set when targeting Android platform.');
+      }
+
       return resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()
           ?.initialize(initializationSettings.android!,
               onSelectNotification: onSelectNotification);
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+      if (initializationSettings.iOS == null) {
+        throw ArgumentError(
+            'iOS settings must be set when targeting iOS platform.');
+      }
+
       return await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
           ?.initialize(initializationSettings.iOS!,
               onSelectNotification: onSelectNotification);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+      if (initializationSettings.macOS == null) {
+        throw ArgumentError(
+            'MacOS settings must be set when targeting macOS platform.');
+      }
+
       return await resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin>()
           ?.initialize(initializationSettings.macOS!,
               onSelectNotification: onSelectNotification);
     } else if (defaultTargetPlatform == TargetPlatform.linux) {
+      if (initializationSettings.linux == null) {
+        throw ArgumentError(
+            'Linux settings must be set when targeting Linux platform.');
+      }
+
       return await resolvePlatformSpecificImplementation<
               LinuxFlutterLocalNotificationsPlugin>()
           ?.initialize(initializationSettings.linux!,

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
@@ -117,6 +118,22 @@ class FlutterLocalNotificationsPlugin {
   }) async {
     if (kIsWeb) {
       return true;
+    }
+    if (Platform.isAndroid && initializationSettings.android == null) {
+      throw ArgumentError(
+          'Android settings must be set when targeting Android platform');
+    }
+    if (Platform.isIOS && initializationSettings.iOS == null) {
+      throw ArgumentError(
+          'iOS settings must be set when targeting iOS platform');
+    }
+    if (Platform.isLinux && initializationSettings.linux == null) {
+      throw ArgumentError(
+          'Linux settings must be set when targeting Linux platform');
+    }
+    if (Platform.isMacOS && initializationSettings.macOS == null) {
+      throw ArgumentError(
+          'MacOS settings must be set when targeting MacOS platform');
     }
     if (defaultTargetPlatform == TargetPlatform.android) {
       return resolvePlatformSpecificImplementation<

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -142,7 +142,7 @@ class FlutterLocalNotificationsPlugin {
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       if (initializationSettings.macOS == null) {
         throw ArgumentError(
-            'MacOS settings must be set when targeting macOS platform.');
+            'macOS settings must be set when targeting macOS platform.');
       }
 
       return await resolvePlatformSpecificImplementation<

--- a/flutter_local_notifications/lib/src/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/initialization_settings.dart
@@ -15,14 +15,22 @@ class InitializationSettings {
   });
 
   /// Settings for Android.
+  /// It is nullable, because we don't want to force users to specify settings
+  /// for platforms that they don't target.
   final AndroidInitializationSettings? android;
 
   /// Settings for iOS.
+  /// It is nullable, because we don't want to force users to specify settings
+  /// for platforms that they don't target.
   final IOSInitializationSettings? iOS;
 
   /// Settings for macOS.
+  /// It is nullable, because we don't want to force users to specify settings
+  /// for platforms that they don't target.
   final MacOSInitializationSettings? macOS;
 
   /// Settings for Linux.
+  /// It is nullable, because we don't want to force users to specify settings
+  /// for platforms that they don't target.
   final LinuxInitializationSettings? linux;
 }

--- a/flutter_local_notifications/lib/src/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/initialization_settings.dart
@@ -15,21 +15,25 @@ class InitializationSettings {
   });
 
   /// Settings for Android.
+  ///
   /// It is nullable, because we don't want to force users to specify settings
   /// for platforms that they don't target.
   final AndroidInitializationSettings? android;
 
   /// Settings for iOS.
+  ///
   /// It is nullable, because we don't want to force users to specify settings
   /// for platforms that they don't target.
   final IOSInitializationSettings? iOS;
 
   /// Settings for macOS.
+  ///
   /// It is nullable, because we don't want to force users to specify settings
   /// for platforms that they don't target.
   final MacOSInitializationSettings? macOS;
 
   /// Settings for Linux.
+  ///
   /// It is nullable, because we don't want to force users to specify settings
   /// for platforms that they don't target.
   final LinuxInitializationSettings? linux;

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 9.4.0
+version: 9.4.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
change: throw ArgumentError when trying to initialize LocalNotification without  per Platform settings
add: tests
add: inline docs


