### PR TITLE
[flutter_local_notifications] Fix table of contents in README

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -19,12 +19,12 @@ A cross platform plugin for displaying local notifications.
    - [Linux limitations](#linux-limitations)
 - **[📷 Screenshots](#-screenshots)**
 - **[👏 Acknowledgements](#-acknowledgements)**
-- **[⚙️ Android Setup](#️-android-setup)**
+- **[🔧 Android Setup](#-android-setup)**
    - [Custom notification icons and sounds](#custom-notification-icons-and-sounds)
    - [Scheduled notifications](#scheduling-a-notification)
    - [Fullscreen intent notifications](#full-screen-intent-notifications)
    - [Release build configuration](#release-build-configuration)
-- **[⚙️ iOS setup](#️-ios-setup)**
+- **[🔧 iOS setup](#-ios-setup)**
    - [General setup](#general-setup)
    - [Handling notifications whilst the app is in the foreground](#handling-notifications-whilst-the-app-is-in-the-foreground)
 - **[❓ Usage](#-usage)**
@@ -152,7 +152,7 @@ To respond to notification after the application is terminated, your application
 * [Zhang Jing](https://github.com/byrdkm17) for adding 'ticker' support for Android notifications
 * ...and everyone else for their contributions. They are greatly appreciated
 
-## ⚙️ Android Setup
+## 🔧 Android Setup
 
 Before proceeding, please make sure you are using the latest version of the plugin. The reason for this is that since version 3.0.1+4, the amount of setup needed has been reduced. Previously, applications needed changes done to the `AndroidManifest.xml` file and there was a bit more setup needed for release builds. If for some reason, your application still needs to use an older version of the plugin then make use of the release tags to refer back to older versions of readme.
 
@@ -194,7 +194,7 @@ Before creating the release build of your app (which is the default setting when
 
 
 
-## ⚙️ iOS setup
+## 🔧 iOS setup
 
 #### General setup
 


### PR DESCRIPTION
This fixes the table of contents at https://pub.dev/packages/flutter_local_notifications .

Android and iOS Setup do not work as the emoji breaks the link fragment.

Unfortunately I just realized, that GitHub seems to handle the #️Number Sign emoji differently, so it currently only works on GitHub.
With this fix it would work on pub.dev, but not on GitHub. :neutral_face: 