### PR TITLE
[flutter_local_notifications] Fix progress notification in example app of 10.0.0

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1877,6 +1877,8 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _showProgressNotification() async {
+    id++;
+    final int progressId = id;
     const int maxProgress = 5;
     for (int i = 0; i <= maxProgress; i++) {
       await Future<void>.delayed(const Duration(seconds: 1), () async {
@@ -1893,7 +1895,7 @@ class _HomePageState extends State<HomePage> {
         final NotificationDetails notificationDetails =
             NotificationDetails(android: androidNotificationDetails);
         await flutterLocalNotificationsPlugin.show(
-            id++,
+            progressId,
             'progress notification title',
             'progress notification body',
             notificationDetails,


### PR DESCRIPTION
Progress notification are not updating the same notification in example app as showed in the video. Using one id should fix it.


https://user-images.githubusercontent.com/42274899/169070560-7b1a5dc1-8f60-4f11-b1b8-8b0de23bc792.mp4