### PR TITLE
 [flutter_local_notifications_linux] Add support for the file path icons

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -177,6 +177,9 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  final TextEditingController _linuxIconPathController =
+      TextEditingController();
+
   @override
   void initState() {
     super.initState();
@@ -749,6 +752,39 @@ class _HomePageState extends State<HomePage> {
                         onPressed: () async {
                           await _showLinuxNotificationWithByteDataIcon();
                         },
+                      ),
+                      Builder(
+                        builder: (BuildContext context) => PaddedElevatedButton(
+                          buttonText: 'Show notification with file path icon',
+                          onPressed: () async {
+                            final String path = _linuxIconPathController.text;
+                            if (path.isEmpty) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text('Please enter the icon path'),
+                                ),
+                              );
+                              return;
+                            }
+                            await _showLinuxNotificationWithPathIcon(path);
+                          },
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(0, 0, 0, 8),
+                        child: TextField(
+                          controller: _linuxIconPathController,
+                          decoration: InputDecoration(
+                            hintText: 'Enter the icon path',
+                            constraints: const BoxConstraints.tightFor(
+                              width: 300,
+                            ),
+                            suffixIcon: IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () => _linuxIconPathController.clear(),
+                            ),
+                          ),
+                        ),
                       ),
                       PaddedElevatedButton(
                         buttonText: 'Show notification with theme icon',
@@ -2270,6 +2306,20 @@ Future<void> _showLinuxNotificationWithByteDataIcon() async {
   await flutterLocalNotificationsPlugin.show(
     0,
     'notification with byte data icon',
+    null,
+    platformChannelSpecifics,
+  );
+}
+
+Future<void> _showLinuxNotificationWithPathIcon(String path) async {
+  final LinuxNotificationDetails linuxPlatformChannelSpecifics =
+      LinuxNotificationDetails(icon: FilePathLinuxIcon(path));
+  final NotificationDetails platformChannelSpecifics = NotificationDetails(
+    linux: linuxPlatformChannelSpecifics,
+  );
+  await flutterLocalNotificationsPlugin.show(
+    0,
+    'notification with file path icon',
     null,
     platformChannelSpecifics,
   );

--- a/flutter_local_notifications_linux/lib/src/flutter_local_notifications_stub.dart
+++ b/flutter_local_notifications_linux/lib/src/flutter_local_notifications_stub.dart
@@ -26,6 +26,7 @@ class LinuxFlutterLocalNotificationsPlugin
     SelectNotificationCallback? onSelectNotification,
   }) async {
     assert(false);
+    return null;
   }
 
   /// Errors on attempted calling of the stub. It exists only to satisfy

--- a/flutter_local_notifications_linux/lib/src/model/enums.dart
+++ b/flutter_local_notifications_linux/lib/src/model/enums.dart
@@ -32,6 +32,9 @@ enum LinuxIconType {
 
   /// System theme icon, see [ThemeLinuxIcon].
   theme,
+
+  /// Icon located at the path in the file system, see [FilePathLinuxIcon].
+  filePath,
 }
 
 /// Specifies the Linux notification sound type.

--- a/flutter_local_notifications_linux/lib/src/model/icon.dart
+++ b/flutter_local_notifications_linux/lib/src/model/icon.dart
@@ -12,6 +12,8 @@ abstract class LinuxNotificationIcon {
 }
 
 /// Represents an icon from the Flutter Assets directory.
+/// Currently the assets directory is `data/flutter_assets`
+/// which is located on the path relative to the executable file.
 class AssetsLinuxIcon extends LinuxNotificationIcon {
   /// Constructs an instance of [AssetsLinuxIcon].
   AssetsLinuxIcon(this.relativePath);
@@ -91,4 +93,22 @@ class LinuxRawIconData {
 
   /// Determines if the image has an alpha channel
   final bool hasAlpha;
+}
+
+/// Represents an icon located at the path in the file system.
+/// It сan be either an absolute UNIX path or a file:// URI scheme, for example:
+///  * file:///usr/share/icons/my_icon.png
+///  * /usr/share/icons/my_icon.png
+class FilePathLinuxIcon extends LinuxNotificationIcon {
+  /// Constructs an instance of [FilePathLinuxIcon].
+  FilePathLinuxIcon(this.path);
+
+  @override
+  Object get content => path;
+
+  @override
+  LinuxIconType get type => LinuxIconType.filePath;
+
+  /// Path to the icon
+  final String path;
 }

--- a/flutter_local_notifications_linux/lib/src/notifications_manager.dart
+++ b/flutter_local_notifications_linux/lib/src/notifications_manager.dart
@@ -296,6 +296,8 @@ class LinuxNotificationManager {
         return null;
       case LinuxIconType.theme:
         return icon.content as String;
+      case LinuxIconType.filePath:
+        return icon.content as String;
     }
   }
 

--- a/flutter_local_notifications_linux/pubspec.yaml
+++ b/flutter_local_notifications_linux/pubspec.yaml
@@ -8,13 +8,13 @@ dependencies:
     sdk: flutter
   flutter_local_notifications_platform_interface: ^5.0.0
   dbus: ^0.7.1
-  path: ^1.8.0
+  path: ^1.8.1
   xdg_directories: ^0.2.0+1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mocktail: ^0.2.0
+  mocktail: ^0.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/flutter_local_notifications_linux/test/notifications_manager_test.dart
+++ b/flutter_local_notifications_linux/test/notifications_manager_test.dart
@@ -933,6 +933,40 @@ void main() {
 
         verifyNotifyMethod(values).called(1);
       });
+
+      test('File path details icon', () async {
+        final LinuxInitializationSettings initSettings =
+            LinuxInitializationSettings(
+          defaultActionName: kDefaultActionName,
+          defaultIcon: FilePathLinuxIcon('/foo/bar/icon.png'),
+        );
+
+        final LinuxNotificationDetails details = LinuxNotificationDetails(
+          icon: FilePathLinuxIcon('/foo/bar/icon.png'),
+        );
+
+        const LinuxNotificationInfo notify = LinuxNotificationInfo(
+          id: 0,
+          systemId: 1,
+        );
+
+        final List<DBusValue> values = buildNotifyMethodValues(
+          appIcon: '/foo/bar/icon.png'
+        );
+
+        mockNotifyMethod(notify.systemId);
+        when(
+          () => mockStorage.getById(notify.id),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockStorage.insert(notify),
+        ).thenAnswer((_) async => true);
+
+        await manager.initialize(initSettings);
+        await manager.show(notify.id, null, null, details: details);
+
+        verifyNotifyMethod(values).called(1);
+      });
     });
 
     test('Cancel', () async {

--- a/flutter_local_notifications_linux/test/notifications_manager_test.dart
+++ b/flutter_local_notifications_linux/test/notifications_manager_test.dart
@@ -191,7 +191,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -219,7 +219,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -294,7 +294,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -347,7 +347,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -381,7 +381,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -411,7 +411,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -442,7 +442,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -483,7 +483,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -519,7 +519,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -556,7 +556,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -589,7 +589,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -622,7 +622,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -655,7 +655,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -688,7 +688,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -720,7 +720,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -753,7 +753,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -787,7 +787,7 @@ void main() {
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -893,19 +893,19 @@ void main() {
               ],
             ),
             'bool-hint': const DBusBoolean(true),
-            'byte-hint': DBusByte(1),
+            'byte-hint': const DBusByte(1),
             'dict-hint': DBusDict(
               DBusSignature('y'),
               DBusSignature('s'),
               <DBusValue, DBusValue>{
-                DBusByte(1): const DBusString('1'),
-                DBusByte(2): const DBusString('2'),
+                const DBusByte(1): const DBusString('1'),
+                const DBusByte(2): const DBusString('2'),
               },
             ),
             'double-hint': const DBusDouble(1.1),
-            'int16-hint': DBusInt16(1),
-            'int32-hint': DBusInt32(1),
-            'int64-hint': DBusInt64(1),
+            'int16-hint': const DBusInt16(1),
+            'int32-hint': const DBusInt32(1),
+            'int64-hint': const DBusInt64(1),
             'string-hint': const DBusString('test'),
             'struct-hint': DBusStruct(
               <DBusValue>[
@@ -913,17 +913,17 @@ void main() {
                 const DBusBoolean(true),
               ],
             ),
-            'uint16-hint': DBusUint16(1),
-            'uint32-hint': DBusUint32(1),
+            'uint16-hint': const DBusUint16(1),
+            'uint32-hint': const DBusUint32(1),
             'uint64-hint': const DBusUint64(1),
-            'variant-hint': DBusVariant(DBusByte(1)),
+            'variant-hint': const DBusVariant(DBusByte(1)),
           },
         );
 
         mockNotifyMethod(notify.systemId);
         when(
           () => mockStorage.getById(notify.id),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => null);
         when(
           () => mockStorage.insert(notify),
         ).thenAnswer((_) async => true);
@@ -1044,7 +1044,7 @@ void main() {
               name: 'NotificationClosed',
               values: <DBusValue>[
                 DBusUint32(notify.systemId),
-                DBusUint32(1),
+                const DBusUint32(1),
               ],
             ),
           ).then((_) {


### PR DESCRIPTION
Adding the `FilePathLinuxIcon` class will allow the developer to specify a custom path in the file system to the icon, if other options, such as `AssetsLinuxIcon`, aren't suitable (for example, the assets path is different from the standard one).

Close #1565