### PR TITLE
[flutter_local_notifications] add AndroidNotificationCategory to make Android categories more accessible

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1628,7 +1628,7 @@ class _HomePageState extends State<HomePage> {
     final AndroidNotificationDetails androidNotificationDetails =
         AndroidNotificationDetails('message channel id', 'message channel name',
             channelDescription: 'message channel description',
-            category: AndroidNotificationCategory.message(),
+            category: AndroidNotificationCategory.message,
             styleInformation: messagingStyle);
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1628,7 +1628,7 @@ class _HomePageState extends State<HomePage> {
     final AndroidNotificationDetails androidNotificationDetails =
         AndroidNotificationDetails('message channel id', 'message channel name',
             channelDescription: 'message channel description',
-            category: 'msg',
+            category: AndroidNotificationCategory.message(),
             styleInformation: messagingStyle);
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -16,6 +16,7 @@ export 'src/notification_details.dart';
 export 'src/platform_flutter_local_notifications.dart'
     hide MethodChannelFlutterLocalNotificationsPlugin;
 export 'src/platform_specifics/android/bitmap.dart';
+export 'src/platform_specifics/android/categories.dart';
 export 'src/platform_specifics/android/enums.dart'
     hide AndroidBitmapSource, AndroidIconSource, AndroidNotificationSoundSource;
 export 'src/platform_specifics/android/icon.dart' hide AndroidIcon;

--- a/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/foundation.dart';
+
+/// The available categories for Android notifications.
+@immutable
+class AndroidNotificationCategory {
+  /// Constructs an instance of [AndroidNotificationCategory]
+  /// with a given [name] of category.
+  const AndroidNotificationCategory(this.name);
+
+  /// Alarm or timer.
+  factory AndroidNotificationCategory.alarm() =>
+      const AndroidNotificationCategory('alarm');
+
+  /// Incoming call (voice or video) or similar 
+  /// synchronous communication request.
+  factory AndroidNotificationCategory.call() =>
+      const AndroidNotificationCategory('call');
+
+  /// Asynchronous bulk message (email).
+  factory AndroidNotificationCategory.email() =>
+      const AndroidNotificationCategory('email');
+
+  /// Error in background operation or authentication status.
+  factory AndroidNotificationCategory.error() =>
+      const AndroidNotificationCategory('err');
+
+  /// Calendar event.
+  factory AndroidNotificationCategory.event() =>
+      const AndroidNotificationCategory('event');
+
+  /// Temporarily sharing location.
+  factory AndroidNotificationCategory.locationSharing() =>
+      const AndroidNotificationCategory('location_sharing');
+
+  /// Incoming direct message like SMS and instant message.
+  factory AndroidNotificationCategory.message() =>
+      const AndroidNotificationCategory('msg');
+
+  /// Missed call.
+  factory AndroidNotificationCategory.missedCall() =>
+      const AndroidNotificationCategory('missed_call');
+
+  /// Map turn-by-turn navigation.
+  factory AndroidNotificationCategory.navigation() =>
+      const AndroidNotificationCategory('navigation');
+
+  /// Progress of a long-running background operation.
+  factory AndroidNotificationCategory.progress() =>
+      const AndroidNotificationCategory('progress');
+
+  /// Promotion or advertisement.
+  factory AndroidNotificationCategory.promo() =>
+      const AndroidNotificationCategory('promo');
+
+  /// A specific, timely recommendation for a single thing.
+  ///
+  /// For example, a news app might want to recommend a
+  /// news story it believes the user will want to read next.
+  factory AndroidNotificationCategory.recommendation() =>
+      const AndroidNotificationCategory('recommendation');
+
+  /// User-scheduled reminder.
+  factory AndroidNotificationCategory.reminder() =>
+      const AndroidNotificationCategory('reminder');
+
+  /// Indication of running background service.
+  factory AndroidNotificationCategory.service() =>
+      const AndroidNotificationCategory('service');
+
+  /// Social network or sharing update.
+  factory AndroidNotificationCategory.social() =>
+      const AndroidNotificationCategory('social');
+
+  /// Ongoing information about device or contextual status.
+  factory AndroidNotificationCategory.status() =>
+      const AndroidNotificationCategory('status');
+
+  /// Running stopwatch.
+  factory AndroidNotificationCategory.stopwatch() =>
+      const AndroidNotificationCategory('stopwatch');
+
+  /// System or device status update.
+  ///
+  /// Reserved for system use.
+  factory AndroidNotificationCategory.system() =>
+      const AndroidNotificationCategory('sys');
+
+  /// Media transport control for playback.
+  factory AndroidNotificationCategory.transport() =>
+      const AndroidNotificationCategory('transport');
+
+  /// Tracking a user's workout.
+  factory AndroidNotificationCategory.workout() =>
+      const AndroidNotificationCategory('workout');
+
+  /// Name of category.
+  final String name;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is AndroidNotificationCategory && other.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  String toString() => 'AndroidNotificationCategory(name: $name)';
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
@@ -6,49 +6,70 @@ class AndroidNotificationCategory {
   /// Constructs an instance of [AndroidNotificationCategory]
   /// with a given [name] of category.
   const AndroidNotificationCategory(this.name);
-
   /// Alarm or timer.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_ALARM`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_ALARM%28%29).
   static const AndroidNotificationCategory alarm =
       AndroidNotificationCategory('alarm');
 
   /// Incoming call (voice or video) or similar
   /// synchronous communication request.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_CALL`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_CALL%28%29).
   static const AndroidNotificationCategory call =
       AndroidNotificationCategory('call');
 
   /// Asynchronous bulk message (email).
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_EMAIL`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_EMAIL%28%29).
   static const AndroidNotificationCategory email =
       AndroidNotificationCategory('email');
 
   /// Error in background operation or authentication status.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_ERROR`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_ERROR%28%29).
   static const AndroidNotificationCategory error =
       AndroidNotificationCategory('err');
 
   /// Calendar event.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_EVENT`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_EVENT%28%29).
   static const AndroidNotificationCategory event =
       AndroidNotificationCategory('event');
 
   /// Temporarily sharing location.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_LOCATION_SHARING`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_LOCATION_SHARING%28%29).
   static const AndroidNotificationCategory locationSharing =
       AndroidNotificationCategory('location_sharing');
 
   /// Incoming direct message like SMS and instant message.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_MESSAGE`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_MESSAGE%28%29).
   static const AndroidNotificationCategory message =
       AndroidNotificationCategory('msg');
 
   /// Missed call.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_MISSED_CALL`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_MISSED_CALL%28%29).
   static const AndroidNotificationCategory missedCall =
       AndroidNotificationCategory('missed_call');
 
   /// Map turn-by-turn navigation.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_NAVIGATION`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_NAVIGATION%28%29).
   static const AndroidNotificationCategory navigation =
       AndroidNotificationCategory('navigation');
 
   /// Progress of a long-running background operation.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_PROGRESS`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_PROGRESS%28%29).
   static const AndroidNotificationCategory progress =
       AndroidNotificationCategory('progress');
 
   /// Promotion or advertisement.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_PROMO`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_PROMO%28%29).
   static const AndroidNotificationCategory promo =
       AndroidNotificationCategory('promo');
 
@@ -56,40 +77,58 @@ class AndroidNotificationCategory {
   ///
   /// For example, a news app might want to recommend a
   /// news story it believes the user will want to read next.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_RECOMMENDATION`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_RECOMMENDATION%28%29).
   static const AndroidNotificationCategory recommendation =
       AndroidNotificationCategory('recommendation');
 
   /// User-scheduled reminder.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_REMINDER`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_REMINDER%28%29).
   static const AndroidNotificationCategory reminder =
       AndroidNotificationCategory('reminder');
 
   /// Indication of running background service.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_SERVICE`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_SERVICE%28%29).
   static const AndroidNotificationCategory service =
       AndroidNotificationCategory('service');
 
   /// Social network or sharing update.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_SOCIAL`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_SOCIAL%28%29).
   static const AndroidNotificationCategory social =
       AndroidNotificationCategory('social');
 
   /// Ongoing information about device or contextual status.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_STATUS`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_STATUS%28%29).
   static const AndroidNotificationCategory status =
       AndroidNotificationCategory('status');
 
   /// Running stopwatch.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_STOPWATCH`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_STOPWATCH%28%29).
   static const AndroidNotificationCategory stopwatch =
       AndroidNotificationCategory('stopwatch');
 
   /// System or device status update.
   ///
   /// Reserved for system use.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_SYSTEM`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_SYSTEM%28%29).
   static const AndroidNotificationCategory system =
       AndroidNotificationCategory('sys');
 
   /// Media transport control for playback.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_TRANSPORT`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_TRANSPORT%28%29).
   static const AndroidNotificationCategory transport =
       AndroidNotificationCategory('transport');
 
   /// Tracking a user's workout.
+  ///
+  /// Corresponds to [`NotificationCompat.CATEGORY_WORKOUT`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_WORKOUT%28%29).
   static const AndroidNotificationCategory workout =
       AndroidNotificationCategory('workout');
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
@@ -6,6 +6,7 @@ class AndroidNotificationCategory {
   /// Constructs an instance of [AndroidNotificationCategory]
   /// with a given [name] of category.
   const AndroidNotificationCategory(this.name);
+
   /// Alarm or timer.
   ///
   /// Corresponds to [`NotificationCompat.CATEGORY_ALARM`](https://developer.android.com/reference/androidx/core/app/NotificationCompat#CATEGORY_ALARM%28%29).

--- a/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/categories.dart
@@ -8,90 +8,90 @@ class AndroidNotificationCategory {
   const AndroidNotificationCategory(this.name);
 
   /// Alarm or timer.
-  factory AndroidNotificationCategory.alarm() =>
-      const AndroidNotificationCategory('alarm');
+  static const AndroidNotificationCategory alarm =
+      AndroidNotificationCategory('alarm');
 
-  /// Incoming call (voice or video) or similar 
+  /// Incoming call (voice or video) or similar
   /// synchronous communication request.
-  factory AndroidNotificationCategory.call() =>
-      const AndroidNotificationCategory('call');
+  static const AndroidNotificationCategory call =
+      AndroidNotificationCategory('call');
 
   /// Asynchronous bulk message (email).
-  factory AndroidNotificationCategory.email() =>
-      const AndroidNotificationCategory('email');
+  static const AndroidNotificationCategory email =
+      AndroidNotificationCategory('email');
 
   /// Error in background operation or authentication status.
-  factory AndroidNotificationCategory.error() =>
-      const AndroidNotificationCategory('err');
+  static const AndroidNotificationCategory error =
+      AndroidNotificationCategory('err');
 
   /// Calendar event.
-  factory AndroidNotificationCategory.event() =>
-      const AndroidNotificationCategory('event');
+  static const AndroidNotificationCategory event =
+      AndroidNotificationCategory('event');
 
   /// Temporarily sharing location.
-  factory AndroidNotificationCategory.locationSharing() =>
-      const AndroidNotificationCategory('location_sharing');
+  static const AndroidNotificationCategory locationSharing =
+      AndroidNotificationCategory('location_sharing');
 
   /// Incoming direct message like SMS and instant message.
-  factory AndroidNotificationCategory.message() =>
-      const AndroidNotificationCategory('msg');
+  static const AndroidNotificationCategory message =
+      AndroidNotificationCategory('msg');
 
   /// Missed call.
-  factory AndroidNotificationCategory.missedCall() =>
-      const AndroidNotificationCategory('missed_call');
+  static const AndroidNotificationCategory missedCall =
+      AndroidNotificationCategory('missed_call');
 
   /// Map turn-by-turn navigation.
-  factory AndroidNotificationCategory.navigation() =>
-      const AndroidNotificationCategory('navigation');
+  static const AndroidNotificationCategory navigation =
+      AndroidNotificationCategory('navigation');
 
   /// Progress of a long-running background operation.
-  factory AndroidNotificationCategory.progress() =>
-      const AndroidNotificationCategory('progress');
+  static const AndroidNotificationCategory progress =
+      AndroidNotificationCategory('progress');
 
   /// Promotion or advertisement.
-  factory AndroidNotificationCategory.promo() =>
-      const AndroidNotificationCategory('promo');
+  static const AndroidNotificationCategory promo =
+      AndroidNotificationCategory('promo');
 
   /// A specific, timely recommendation for a single thing.
   ///
   /// For example, a news app might want to recommend a
   /// news story it believes the user will want to read next.
-  factory AndroidNotificationCategory.recommendation() =>
-      const AndroidNotificationCategory('recommendation');
+  static const AndroidNotificationCategory recommendation =
+      AndroidNotificationCategory('recommendation');
 
   /// User-scheduled reminder.
-  factory AndroidNotificationCategory.reminder() =>
-      const AndroidNotificationCategory('reminder');
+  static const AndroidNotificationCategory reminder =
+      AndroidNotificationCategory('reminder');
 
   /// Indication of running background service.
-  factory AndroidNotificationCategory.service() =>
-      const AndroidNotificationCategory('service');
+  static const AndroidNotificationCategory service =
+      AndroidNotificationCategory('service');
 
   /// Social network or sharing update.
-  factory AndroidNotificationCategory.social() =>
-      const AndroidNotificationCategory('social');
+  static const AndroidNotificationCategory social =
+      AndroidNotificationCategory('social');
 
   /// Ongoing information about device or contextual status.
-  factory AndroidNotificationCategory.status() =>
-      const AndroidNotificationCategory('status');
+  static const AndroidNotificationCategory status =
+      AndroidNotificationCategory('status');
 
   /// Running stopwatch.
-  factory AndroidNotificationCategory.stopwatch() =>
-      const AndroidNotificationCategory('stopwatch');
+  static const AndroidNotificationCategory stopwatch =
+      AndroidNotificationCategory('stopwatch');
 
   /// System or device status update.
   ///
   /// Reserved for system use.
-  factory AndroidNotificationCategory.system() =>
-      const AndroidNotificationCategory('sys');
+  static const AndroidNotificationCategory system =
+      AndroidNotificationCategory('sys');
 
   /// Media transport control for playback.
-  factory AndroidNotificationCategory.transport() =>
-      const AndroidNotificationCategory('transport');
+  static const AndroidNotificationCategory transport =
+      AndroidNotificationCategory('transport');
 
   /// Tracking a user's workout.
-  factory AndroidNotificationCategory.workout() =>
-      const AndroidNotificationCategory('workout');
+  static const AndroidNotificationCategory workout =
+      AndroidNotificationCategory('workout');
 
   /// Name of category.
   final String name;

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -210,7 +210,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'ticker': ticker,
         'visibility': visibility?.index,
         'timeoutAfter': timeoutAfter,
-        'category': category,
+        'category': category?.name,
         'fullScreenIntent': fullScreenIntent,
         'shortcutId': shortcutId,
         'additionalFlags': additionalFlags,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'bitmap.dart';
+import 'categories.dart';
 import 'enums.dart';
 import 'notification_sound.dart';
 import 'styles/style_information.dart';
@@ -316,9 +317,7 @@ class AndroidNotificationDetails {
   final int? timeoutAfter;
 
   /// The notification category.
-  ///
-  /// Refer to Android notification API documentation at https://developer.android.com/reference/androidx/core/app/NotificationCompat.html#constants_2 for the available categories
-  final String? category;
+  final AndroidNotificationCategory? category;
 
   /// Specifies whether the notification should launch a full-screen intent as
   /// soon as it triggers.


### PR DESCRIPTION
Add all the Android categories values with documentation in AndroidNotificationCategory class from https://developer.android.com/reference/androidx/core/app/NotificationCompat.html#constants_2. 

The goal is make this property more accessible for the users. It results in a little breaking change since the current `category` property is of `String` type. However, I believe it’s worth using it. 

Also, I tried to make it just like LinuxNotificationCategory of Linux package to keep a pattern. 