### PR TITLE
[flutter_local_notifications] fix zonedSchedule error on macOS when matching using dayOfMonthAndTime or dateAndTime

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [9.6.1]
+
+* [macOS] fixed issue [1623](https://github.com/MaikuB/flutter_local_notifications/issues/1623) where calling `zonedSchedule` with `matchDateTimeComponents` set to `dayOfMonthAndTime` or `dateAndTime` led to an error
+
 # [9.6.0]
 
 * [Linux] Bumped dependency on `flutter_local_notifications_linux` to `^0.5.0+1` where support for icons to be specified via a file path was added by [Yaroslav Pronin](https://github.com/proninyaroslav)

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -47,6 +47,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     enum DateTimeComponents: Int {
         case time
         case dayOfWeekAndTime
+        case dayOfMonthAndTime
+        case dateAndTime
     }
 
     enum RepeatInterval: Int {
@@ -298,6 +300,10 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                     notification.deliveryRepeatInterval = DateComponents.init(day: 1)
                 case .dayOfWeekAndTime:
                     notification.deliveryRepeatInterval = DateComponents.init(weekOfYear: 1)
+                case .dayOfMonthAndTime:
+                    notification.deliveryRepeatInterval = DateComponents.init(month: 1)
+                case .dateAndTime:
+                    notification.deliveryRepeatInterval = DateComponents.init(year: 1)
                 }
             }
             NSUserNotificationCenter.default.scheduleNotification(notification)
@@ -417,6 +423,12 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 return UNCalendarNotificationTrigger.init(dateMatching: dateComponents, repeats: true)
             case .dayOfWeekAndTime:
                 let dateComponents = calendar.dateComponents([ .weekday, .hour, .minute, .second, .timeZone], from: date)
+                return UNCalendarNotificationTrigger.init(dateMatching: dateComponents, repeats: true)
+            case .dayOfMonthAndTime:
+                let dateComponents = calendar.dateComponents([ .day, .hour, .minute, .second, .timeZone], from: date)
+                return UNCalendarNotificationTrigger.init(dateMatching: dateComponents, repeats: true)
+            case .dateAndTime:
+                let dateComponents = calendar.dateComponents([ .day, .month, .hour, .minute, .second, .timeZone], from: date)
                 return UNCalendarNotificationTrigger.init(dateMatching: dateComponents, repeats: true)
             }
         }

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 9.6.0
+version: 9.6.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 
 dependencies:


### PR DESCRIPTION
Closes #1623 