### PR TITLE
[flutter_local_notifications] android Initialization defaultIcon can null

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -303,10 +303,13 @@ public class FlutterLocalNotificationsPlugin
           context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
       String defaultIcon = sharedPreferences.getString(DEFAULT_ICON, null);
       if (StringUtils.isNullOrEmpty(defaultIcon)) {
-        // for backwards compatibility: this is for handling the old way references to the icon used
-        // to be kept but should be removed in future
-        builder.setSmallIcon(notificationDetails.iconResourceId);
-
+        if (notificationDetails.iconResourceId == null || notificationDetails.iconResourceId == 0) {
+          builder.setSmallIcon(context.getApplicationInfo().icon);
+        } else {
+          // for backwards compatibility: this is for handling the old way references to the icon used
+          // to be kept but should be removed in future
+          builder.setSmallIcon(notificationDetails.iconResourceId);
+        }
       } else {
         builder.setSmallIcon(getDrawableResourceId(context, defaultIcon));
       }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/initialization_settings.dart
@@ -1,8 +1,8 @@
 /// Plugin initialization settings for Android.
 class AndroidInitializationSettings {
   /// Constructs an instance of [AndroidInitializationSettings].
-  const AndroidInitializationSettings(this.defaultIcon);
+  const AndroidInitializationSettings([this.defaultIcon]);
 
   /// Specifies the default icon for notifications.
-  final String defaultIcon;
+  final String? defaultIcon;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -15,7 +15,7 @@ import 'styles/messaging_style_information.dart';
 
 // ignore_for_file: avoid_as, public_member_api_docs
 extension AndroidInitializationSettingsMapper on AndroidInitializationSettings {
-  Map<String, Object> toMap() => <String, Object>{'defaultIcon': defaultIcon};
+  Map<String, Object?> toMap() => <String, Object?>{'defaultIcon': defaultIcon};
 }
 
 extension MessageMapper on Message {


### PR DESCRIPTION
if defaultIcon is null, uses`getApplicationInfo().icon`

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
