### PR TITLE
[flutter_local_notifications]  Add audioAttributesUsage to NotificationDetails

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -972,7 +972,7 @@ public class FlutterLocalNotificationsPlugin
       notificationChannel.setGroup(notificationChannelDetails.groupId);
       if (notificationChannelDetails.playSound) {
         AudioAttributes audioAttributes =
-            new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION).build();
+            new AudioAttributes.Builder().setUsage(notificationChannelDetails.audioAttributesUsage).build();
         Uri uri =
             retrieveSoundResourceUri(
                 context, notificationChannelDetails.sound, notificationChannelDetails.soundSource);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -971,8 +971,11 @@ public class FlutterLocalNotificationsPlugin
       notificationChannel.setDescription(notificationChannelDetails.description);
       notificationChannel.setGroup(notificationChannelDetails.groupId);
       if (notificationChannelDetails.playSound) {
+        Integer audioAttributesUsage = notificationChannelDetails.audioAttributesUsage != null
+                ? notificationChannelDetails.audioAttributesUsage
+                : AudioAttributes.USAGE_NOTIFICATION;
         AudioAttributes audioAttributes =
-            new AudioAttributes.Builder().setUsage(notificationChannelDetails.audioAttributesUsage).build();
+                new AudioAttributes.Builder().setUsage(audioAttributesUsage).build();
         Uri uri =
             retrieveSoundResourceUri(
                 context, notificationChannelDetails.sound, notificationChannelDetails.soundSource);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationChannelDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationChannelDetails.java
@@ -26,6 +26,7 @@ public class NotificationChannelDetails implements Serializable {
   private static final String LED_COLOR_RED = "ledColorRed";
   private static final String LED_COLOR_GREEN = "ledColorGreen";
   private static final String LED_COLOR_BLUE = "ledColorBlue";
+  private static final String AUDIO_ATTRIBUTES_USAGE = "audioAttributesUsage";
 
   public String id;
   public String name;
@@ -41,6 +42,7 @@ public class NotificationChannelDetails implements Serializable {
   public NotificationChannelAction channelAction;
   public Boolean enableLights;
   public Integer ledColor;
+  public Integer audioAttributesUsage;
 
   public static NotificationChannelDetails from(Map<String, Object> arguments) {
     NotificationChannelDetails notificationChannel = new NotificationChannelDetails();
@@ -57,6 +59,7 @@ public class NotificationChannelDetails implements Serializable {
 
     notificationChannel.playSound = (Boolean) arguments.get(PLAY_SOUND);
     notificationChannel.sound = (String) arguments.get(SOUND);
+    notificationChannel.audioAttributesUsage = (Integer) arguments.get(AUDIO_ATTRIBUTES_USAGE);
     Integer soundSourceIndex = (Integer) arguments.get(SOUND_SOURCE);
     if (soundSourceIndex != null) {
       notificationChannel.soundSource = SoundSource.values()[soundSourceIndex];
@@ -92,6 +95,7 @@ public class NotificationChannelDetails implements Serializable {
     notificationChannel.playSound = notificationDetails.playSound;
     notificationChannel.sound = notificationDetails.sound;
     notificationChannel.soundSource = notificationDetails.soundSource;
+    notificationChannel.audioAttributesUsage = notificationDetails.audioAttributesUsage;
     notificationChannel.ledColor = notificationDetails.ledColor;
     notificationChannel.enableLights = notificationDetails.enableLights;
     return notificationChannel;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -120,6 +120,7 @@ public class NotificationDetails implements Serializable {
   private static final String SUB_TEXT = "subText";
   private static final String COLORIZED = "colorized";
   private static final String NUMBER = "number";
+  private static final String AUDIO_ATTRIBUTES_USAGE = "audioAttributesUsage";
 
   public Integer id;
   public String title;
@@ -181,6 +182,7 @@ public class NotificationDetails implements Serializable {
   public String tag;
   public Boolean colorized;
   public Integer number;
+  public Integer audioAttributesUsage;
 
   // Note: this is set on the Android to save details about the icon that should be used when
   // re-hydrating scheduled notifications when a device has been restarted.
@@ -268,6 +270,7 @@ public class NotificationDetails implements Serializable {
       notificationDetails.tag = (String) platformChannelSpecifics.get(TAG);
       notificationDetails.colorized = (Boolean) platformChannelSpecifics.get(COLORIZED);
       notificationDetails.number = (Integer) platformChannelSpecifics.get(NUMBER);
+      notificationDetails.audioAttributesUsage = (Integer) platformChannelSpecifics.get(AUDIO_ATTRIBUTES_USAGE);
     }
   }
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -618,6 +618,14 @@ class _HomePageState extends State<HomePage> {
                         },
                       ),
                       PaddedElevatedButton(
+                        buttonText:
+                            'Show notification with sound controlled by '
+                            'alarm volume',
+                        onPressed: () async {
+                          await _showNotificationWithAudioAttributeAlarm();
+                        },
+                      ),
+                      PaddedElevatedButton(
                         buttonText: 'Create grouped notification channels',
                         onPressed: () async {
                           await _createNotificationChannelGroup();
@@ -2306,6 +2314,26 @@ class _HomePageState extends State<HomePage> {
     await flutterLocalNotificationsPlugin.show(
         0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
         payload: 'item x');
+  }
+
+  Future<void> _showNotificationWithAudioAttributeAlarm() async {
+    const AndroidNotificationDetails androidPlatformChannelSpecifics =
+        AndroidNotificationDetails(
+      'your alarm channel id',
+      'your alarm channel name',
+      channelDescription: 'your alarm channel description',
+      importance: Importance.max,
+      priority: Priority.high,
+      audioAttributesUsage: AudioAttributesUsage.alarm,
+    );
+    const NotificationDetails platformChannelSpecifics =
+        NotificationDetails(android: androidPlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+      0,
+      'notification sound controlled by alarm volume',
+      'alarm notification sound body',
+      platformChannelSpecifics,
+    );
   }
 }
 

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -326,6 +326,7 @@ class AudioAttributesUsage {
         media,
         notification,
         notificationEvent,
+        notificationRingtone,
         unknown,
         voiceCommunication,
         voiceCommunicationSignalling,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -262,3 +262,82 @@ enum NotificationVisibility {
   /// Do not reveal any part of this notification on a secure lockscreen.
   secret,
 }
+
+/// The available audio attributes usages for an Android service.
+@immutable
+class AudioAttributesUsage {
+  /// Constructs an instance of [AudioAttributesUsage].
+  const AudioAttributesUsage._(this.value);
+
+  /// Corresponds to [`AudioAttributes.USAGE_ALARM`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_ALARM).
+  static const AudioAttributesUsage alarm = AudioAttributesUsage._(4);
+
+  /// Corresponds to [`AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_ASSISTANCE_ACCESSIBILITY).
+  static const AudioAttributesUsage assistanceAccessibility =
+      AudioAttributesUsage._(11);
+
+  /// Corresponds to [`AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_ASSISTANCE_NAVIGATION_GUIDANCE).
+  static const AudioAttributesUsage assistanceNavigationGuidance =
+      AudioAttributesUsage._(12);
+
+  /// Corresponds to [`AudioAttributes.USAGE_ASSISTANCE_SONIFICATION`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_ASSISTANCE_SONIFICATION).
+  static const AudioAttributesUsage assistanceSonification =
+      AudioAttributesUsage._(13);
+
+  /// Corresponds to [`AudioAttributes.USAGE_ASSISTANT`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_ASSISTANT).
+  static const AudioAttributesUsage assistant = AudioAttributesUsage._(16);
+
+  /// Corresponds to [`AudioAttributes.USAGE_GAME`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_GAME).
+  static const AudioAttributesUsage game = AudioAttributesUsage._(14);
+
+  /// Corresponds to [`AudioAttributes.USAGE_MEDIA`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_MEDIA).
+  static const AudioAttributesUsage media = AudioAttributesUsage._(1);
+
+  /// Corresponds to [`AudioAttributes.USAGE_NOTIFICATION`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_NOTIFICATION).
+  static const AudioAttributesUsage notification = AudioAttributesUsage._(5);
+
+  /// Corresponds to [`AudioAttributes.USAGE_NOTIFICATION_EVENT`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_NOTIFICATION_EVENT).
+  static const AudioAttributesUsage notificationEvent =
+      AudioAttributesUsage._(10);
+
+  /// Corresponds to [`AudioAttributes.USAGE_NOTIFICATION_RINGTONE`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_NOTIFICATION_RINGTONE).
+  static const AudioAttributesUsage notificationRingtone =
+      AudioAttributesUsage._(6);
+
+  /// Corresponds to [`AudioAttributes.USAGE_UNKNOWN`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_UNKNOWN).
+  static const AudioAttributesUsage unknown = AudioAttributesUsage._(0);
+
+  /// Corresponds to [`AudioAttributes.USAGE_VOICE_COMMUNICATION`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_VOICE_COMMUNICATION).
+  static const AudioAttributesUsage voiceCommunication =
+      AudioAttributesUsage._(2);
+
+  /// Corresponds to [`AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING`](https://developer.android.com/reference/android/media/AudioAttributes#USAGE_VOICE_COMMUNICATION_SIGNALLING).
+  static const AudioAttributesUsage voiceCommunicationSignalling =
+      AudioAttributesUsage._(3);
+
+  /// All the possible values for the [AudioAttributesUsage] enumeration.
+  static List<AudioAttributesUsage> get values => <AudioAttributesUsage>[
+        alarm,
+        assistanceAccessibility,
+        assistanceNavigationGuidance,
+        assistanceSonification,
+        assistant,
+        game,
+        media,
+        notification,
+        notificationEvent,
+        unknown,
+        voiceCommunication,
+        voiceCommunicationSignalling,
+      ];
+
+  /// The integer representation.
+  final int value;
+
+  @override
+  int get hashCode => value;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AudioAttributesUsage && other.value == value;
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -218,6 +218,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'tag': tag,
         'colorized': colorized,
         'number': number,
+        'audioAttributesUsage': audioAttributesUsage.value,
       }
         ..addAll(_convertStyleInformationToMap())
         ..addAll(_convertNotificationSoundToMap(sound))

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -53,6 +53,7 @@ class AndroidNotificationDetails {
     this.tag,
     this.colorized = false,
     this.number,
+    this.audioAttributesUsage = AudioAttributesUsage.notification,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -299,4 +300,9 @@ class AndroidNotificationDetails {
   /// If not supported, this value is ignored.
   /// See https://developer.android.com/training/notify-user/badges#set_custom_notification_count
   final int? number;
+
+  /// The attribute describing what is the intended use of the audio signal,
+  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int))
+  /// https://developer.android.com/reference/android/media/AudioAttributes
+  final AudioAttributesUsage audioAttributesUsage;
 }

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -148,6 +148,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -229,6 +230,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -311,6 +313,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -394,6 +397,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -481,6 +485,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -567,6 +572,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -652,6 +658,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -746,6 +753,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -850,6 +858,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -944,6 +953,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1048,6 +1058,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1139,6 +1150,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1237,6 +1249,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1320,6 +1333,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1406,6 +1420,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1517,6 +1532,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1641,6 +1657,7 @@ void main() {
               'tag': null,
               'colorized': false,
               'number': null,
+              'audioAttributesUsage': 5,
             },
           }));
     });
@@ -1731,6 +1748,7 @@ void main() {
                     'tag': null,
                     'colorized': false,
                     'number': null,
+                    'audioAttributesUsage': 5,
                   },
                 }));
           });
@@ -1825,6 +1843,7 @@ void main() {
                 'tag': null,
                 'colorized': false,
                 'number': null,
+                'audioAttributesUsage': 5,
               },
             }));
       });
@@ -1918,6 +1937,7 @@ void main() {
                 'tag': null,
                 'colorized': false,
                 'number': null,
+                'audioAttributesUsage': 5,
               },
             }));
       });
@@ -2012,6 +2032,7 @@ void main() {
                 'tag': null,
                 'colorized': false,
                 'number': null,
+                'audioAttributesUsage': 5,
               },
             }));
       });
@@ -2317,6 +2338,7 @@ void main() {
                   'tag': null,
                   'colorized': true,
                   'number': null,
+                  'audioAttributesUsage': 5,
                 },
               },
               'startType': AndroidServiceStartType.startSticky.value,


### PR DESCRIPTION
Allows users to change  AudioAttributes (https://developer.android.com/reference/android/media/AudioAttributes) to the notification sound

Closes: https://github.com/MaikuB/flutter_local_notifications/issues/1519
