### PR TITLE
[flutter_local_notifications] Add useAlarmClock variable [Android only]

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -392,7 +392,11 @@ public class FlutterLocalNotificationsPlugin
         getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
 
     AlarmManager alarmManager = getAlarmManager(context);
-    if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
+    if(BooleanUtils.getValue(notificationDetails.useAlarmClock)) {
+      AlarmManagerCompat.setAlarmClock(alarmManager, notificationDetails.millisecondsSinceEpoch,
+              pendingIntent,
+              pendingIntent);
+    } else if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
       AlarmManagerCompat.setExactAndAllowWhileIdle(
           alarmManager,
           AlarmManager.RTC_WAKEUP,
@@ -434,7 +438,11 @@ public class FlutterLocalNotificationsPlugin
                     org.threeten.bp.ZoneId.of(notificationDetails.timeZoneName))
                 .toInstant()
                 .toEpochMilli();
-    if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
+    if (BooleanUtils.getValue(notificationDetails.useAlarmClock)) {
+      AlarmManagerCompat.setAlarmClock(alarmManager, epochMilli,
+              pendingIntent,
+              pendingIntent);
+    } else if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
       AlarmManagerCompat.setExactAndAllowWhileIdle(
           alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
     } else {
@@ -510,7 +518,11 @@ public class FlutterLocalNotificationsPlugin
         getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
 
-    if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
+    if (BooleanUtils.getValue(notificationDetails.useAlarmClock)) {
+      AlarmManagerCompat.setAlarmClock(alarmManager, notificationTriggerTime,
+              pendingIntent,
+              pendingIntent);
+    }else if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
       AlarmManagerCompat.setExactAndAllowWhileIdle(
           alarmManager, AlarmManager.RTC_WAKEUP, notificationTriggerTime, pendingIntent);
     } else {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -102,6 +102,7 @@ public class NotificationDetails implements Serializable {
 
   private static final String TICKER = "ticker";
   private static final String ALLOW_WHILE_IDLE = "allowWhileIdle";
+  private static final String USE_ALARM_CLOCK = "useAlarmClock";
   private static final String CATEGORY = "category";
   private static final String TIMEOUT_AFTER = "timeoutAfter";
   private static final String SHOW_WHEN = "showWhen";
@@ -165,6 +166,7 @@ public class NotificationDetails implements Serializable {
   public String ticker;
   public Integer visibility;
   public Boolean allowWhileIdle;
+  public Boolean useAlarmClock;
   public Long timeoutAfter;
   public String category;
   public int[] additionalFlags;
@@ -258,6 +260,7 @@ public class NotificationDetails implements Serializable {
       notificationDetails.ticker = (String) platformChannelSpecifics.get(TICKER);
       notificationDetails.visibility = (Integer) platformChannelSpecifics.get(VISIBILITY);
       notificationDetails.allowWhileIdle = (Boolean) platformChannelSpecifics.get(ALLOW_WHILE_IDLE);
+      notificationDetails.useAlarmClock = (Boolean) platformChannelSpecifics.get(USE_ALARM_CLOCK);
       notificationDetails.timeoutAfter = parseLong(platformChannelSpecifics.get(TIMEOUT_AFTER));
       notificationDetails.category = (String) platformChannelSpecifics.get(CATEGORY);
       notificationDetails.fullScreenIntent =


### PR DESCRIPTION

_Changes required on existing code ?_
Non, By default it is false, and code will behave like current one.

_Why do we need it sometimes ?_
The reason why I added this is that I was never able to get the alarm fired on many android devices, and since my app idea was relying on the alarm idea, I found AlarmClock solution to work the best for me.

_Why not to use always?_
Setting alarm with `AlarmManagerCompat.setAlarmClock` will show alarm icon on the status bar, and it won't disappear until you cancel all alarms set with `AlarmManagerCompat.setAlarmClock`

The alarm icon is show in the screenshot:
![alarm icon](https://user-images.githubusercontent.com/735154/183303587-55d953d9-6ddb-42ad-8f50-b480030b3ccc.png)

On Android, I couldn't have the alarm fired exactly on time set in any other way!