### PR TITLE
[flutter_local_notifications] Adding calledAt parameter to periodicallyShow method

### DIFF
--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -395,6 +395,7 @@ class FlutterLocalNotificationsPlugin {
     String? body,
     RepeatInterval repeatInterval,
     NotificationDetails notificationDetails, {
+    int? calledAt,
     String? payload,
     bool androidAllowWhileIdle = false,
   }) async {
@@ -404,7 +405,8 @@ class FlutterLocalNotificationsPlugin {
     if (defaultTargetPlatform == TargetPlatform.android) {
       await resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()
-          ?.periodicallyShow(id, title, body, repeatInterval,
+          ?.periodicallyShow(id, title, body, repeatInterval, 
+              calledAt: calledAt,
               notificationDetails: notificationDetails.android,
               payload: payload,
               androidAllowWhileIdle: androidAllowWhileIdle);
@@ -412,11 +414,13 @@ class FlutterLocalNotificationsPlugin {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
+              calledAt: calledAt,
               notificationDetails: notificationDetails.iOS, payload: payload);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       await resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
+              calledAt: calledAt,
               notificationDetails: notificationDetails.macOS, payload: payload);
     } else {
       await FlutterLocalNotificationsPlatform.instance

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -324,6 +324,7 @@ class AndroidFlutterLocalNotificationsPlugin
     String? title,
     String? body,
     RepeatInterval repeatInterval, {
+    int? calledAt,
     AndroidNotificationDetails? notificationDetails,
     String? payload,
     bool androidAllowWhileIdle = false,
@@ -336,7 +337,7 @@ class AndroidFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': calledAt ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': serializedPlatformSpecifics,
       'payload': payload ?? '',
@@ -731,6 +732,7 @@ class IOSFlutterLocalNotificationsPlugin
     String? title,
     String? body,
     RepeatInterval repeatInterval, {
+    int? calledAt,
     IOSNotificationDetails? notificationDetails,
     String? payload,
   }) async {
@@ -739,7 +741,7 @@ class IOSFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': calledAt ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
@@ -870,6 +872,7 @@ class MacOSFlutterLocalNotificationsPlugin
     String? title,
     String? body,
     RepeatInterval repeatInterval, {
+    int? calledAt,
     MacOSNotificationDetails? notificationDetails,
     String? payload,
   }) async {
@@ -878,7 +881,7 @@ class MacOSFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': calledAt ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''


### PR DESCRIPTION
When setting periodically scheduled notification, we may need to specify when start to call it. For example, Today is Monday but I want to set the periodically notification on Sunday to repeat on every Sunday.