### PR TITLE
[flutter_local_notifications] Check permissionRequestInProgress in onRequestPermissionsResult

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1574,7 +1574,7 @@ public class FlutterLocalNotificationsPlugin
   @Override
   public boolean onRequestPermissionsResult(
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
+    if (permissionRequestInProgress && requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
       boolean granted =
           grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
       callback.complete(granted);


### PR DESCRIPTION
Other flutter plugins permissions requests can end up triggering onRequestPermissionsResult, so only handle callbacks when we're expecting one to be outstanding.

This fixes a `java.lang.IllegalStateException: Reply already submitted` crash that can occur when other flutter plugins request access to permissions on Android.