### PR TITLE
[flutter_local_notifications] Update pub.dev links

### DIFF
--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -3,7 +3,7 @@ description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
 version: 9.9.1
-homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
+repository: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 
 dependencies:

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -4,6 +4,7 @@ description: A cross platform plugin for displaying and scheduling local
   platform.
 version: 9.9.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
+issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 
 dependencies:
   clock: ^1.1.0


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).