### PR TITLE
Crash fix when notification actions is used for foreground service 

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationAction.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationAction.java
@@ -4,6 +4,7 @@ import android.graphics.Color;
 
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -11,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 @Keep
-public class NotificationAction {
-  public static class NotificationActionInput {
+public class NotificationAction implements Serializable {
+  public static class NotificationActionInput implements Serializable {
 
     public NotificationActionInput(
         @Nullable List<String> choices,


### PR DESCRIPTION
**Issue -** 
When NotificationAction is used for foreground service, getting the below error.
```
Failed to handle method call
Unhandled Exception: PlatformException(error, Parcelable encountered IOException writing serializable 
object (name = com.dexterous.flutterlocalnotifications.ForegroundServiceStartParameter), null, java.lang.RuntimeException: Parcelable encountered IOException writing serializable 
object (name = com.dexterous.flutterlocalnotifications.ForegroundServiceStartParameter
```

Upon debugging I found that NotificationAction was not implementing Serializable.


**Fix -** 

Making NotificationAction Serializable to support  notification actions when notification is started as foreground service
