### PR TITLE
[flutter_local_notifications] update readme to include details of a Flutter issue with desugaring enabled on foldable Android devices

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [11.0.1]
 
-* [Android] fixed crash when using notification actions with foreground service notification. Thanks to the PR from [Arnold Laishram](https://github.com/arnoldlaishram)
+* [Android] fixed crash when using notification actions with a foreground service. Thanks to the PR from [Arnold Laishram](https://github.com/arnoldlaishram)
 * Fixed typo in readme around Darwin (iOS/macOS) initialisation settings
 * Added a link to an issue with using Flutter apps with desugaring enabled where crashes could occur on foldable Android devices. Link to this is https://github.com/flutter/flutter/issues/110658 so those experience the problem can follow the issue and try out the solutions there as this isn't specific to the plugin
 

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [11.0.1]
+
+* [Android] fixed crash when using notification actions with foreground service notification. Thanks to the PR from [Arnold Laishram](https://github.com/arnoldlaishram)
+* Fixed typo in readme around Darwin (iOS/macOS) initialisation settings
+* Added a link to an issue with using Flutter apps with desugaring enabled where crashes could occur on foldable Android devices. Link to this is https://github.com/flutter/flutter/issues/110658 so those experience the problem can follow the issue and try out the solutions there as this isn't specific to the plugin
+
 # [11.0.0]
 
 * Bumped `timezone` dependency. To err on the safe when it comes to dependency version conflicts, this is being published as major release as the updated `timezone` package was published as a major release. Thanks to the PR from [Joachim Nohl](https://github.com/nohli)

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -209,7 +209,7 @@ buildscript {
     }
 ```
 
-The plugin also requires that the `compileSdkVersion` in their application's Gradle file  is set to 33
+There have been reports that enabling desugaring may result in a Flutter apps crashing on foldable devices. This would be an issue with Flutter itself, not the plugin. Please see [this link](https://github.com/flutter/flutter/issues/110658) for details to try out the solutions there. The plugin also requires that the `compileSdkVersion` in their application's Gradle file  is set to 33
 
 ```gradle
 android {

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 11.0.0
+version: 11.0.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Relates to #1713