### PR TITLE
[flutter_local_notifications] suppress getParcelableExtra deprecation warning

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,8 +1,10 @@
 # [11.0.1]
 
 * [Android] fixed crash when using notification actions with a foreground service. Thanks to the PR from [Arnold Laishram](https://github.com/arnoldlaishram)
+* [Android] Suppressed deprecation warning on calling the [`getParcelableExtra`](https://developer.android.com/reference/android/content/Intent#getParcelableExtra(java.lang.String)) Intent API
 * Fixed typo in readme around Darwin (iOS/macOS) initialisation settings
 * Added a link to an issue with using Flutter apps with desugaring enabled where crashes could occur on foldable Android devices. Link to this is https://github.com/flutter/flutter/issues/110658 so those experience the problem can follow the issue and try out the solutions there as this isn't specific to the plugin
+
 
 # [11.0.0]
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ScheduledNotificationReceiver.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 public class ScheduledNotificationReceiver extends BroadcastReceiver {
 
   @Override
+  @SuppressWarnings("deprecation")
   public void onReceive(final Context context, Intent intent) {
     String notificationDetailsJson =
         intent.getStringExtra(FlutterLocalNotificationsPlugin.NOTIFICATION_DETAILS);


### PR DESCRIPTION
Relates to #1702