### PR TITLE
[flutter_local_notifications] fix crash occurring for notification actions that don't have a callback to handle them

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [12.0.1]
+
+* [Android][iOS] fixed issue [1721](https://github.com/MaikuB/flutter_local_notifications/issues/1721) where a crash occurs upon tapping on a notification action fbut the `onDidReceiveBackgroundNotificationResponse` optional callback hasn't been specified. 
+
 # [12.0.0]
 
 * Bumped `dbus` dependency via `flutter_local_notifications_linux`

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
@@ -71,6 +71,12 @@ public class ActionBroadcastReceiver extends BroadcastReceiver {
       return;
     }
 
+    FlutterCallbackInformation dispatcherHandle = preferences.lookupDispatcherHandle();
+    if (dispatcherHandle == null) {
+      Log.w(TAG, "Callback information could not be retrieved");
+      return;
+    }
+
     FlutterInjector injector = FlutterInjector.instance();
     FlutterLoader loader = injector.flutterLoader();
 
@@ -80,7 +86,6 @@ public class ActionBroadcastReceiver extends BroadcastReceiver {
     engine = new FlutterEngine(context);
     DartExecutor dartExecutor = engine.getDartExecutor();
 
-    FlutterCallbackInformation dispatcherHandle = preferences.lookupDispatcherHandle();
     initializeEventChannel(dartExecutor);
 
     String dartBundlePath = loader.findAppBundlePath();

--- a/flutter_local_notifications/ios/Classes/FlutterEngineManager.m
+++ b/flutter_local_notifications/ios/Classes/FlutterEngineManager.m
@@ -45,7 +45,6 @@ static FlutterEngine *backgroundEngine;
   NSNumber *dispatcherHandle =
       [_persistentState objectForKey:@"dispatcher_handle"];
 
-
   FlutterCallbackInformation *info = [FlutterCallbackCache
       lookupCallbackInformation:[dispatcherHandle longValue]];
 
@@ -58,10 +57,10 @@ static FlutterEngine *backgroundEngine;
   NSString *uri = info.callbackLibraryPath;
 
   backgroundEngine =
-    [[FlutterEngine alloc] initWithName:@"FlutterLocalNotificationsIsolate"
-                                project:nil
-                allowHeadlessExecution:true];
-                
+      [[FlutterEngine alloc] initWithName:@"FlutterLocalNotificationsIsolate"
+                                  project:nil
+                   allowHeadlessExecution:true];
+
   dispatch_async(dispatch_get_main_queue(), ^{
     FlutterEventChannel *channel = [FlutterEventChannel
         eventChannelWithName:

--- a/flutter_local_notifications/ios/Classes/FlutterEngineManager.m
+++ b/flutter_local_notifications/ios/Classes/FlutterEngineManager.m
@@ -45,22 +45,23 @@ static FlutterEngine *backgroundEngine;
   NSNumber *dispatcherHandle =
       [_persistentState objectForKey:@"dispatcher_handle"];
 
-  backgroundEngine =
-      [[FlutterEngine alloc] initWithName:@"FlutterLocalNotificationsIsolate"
-                                  project:nil
-                   allowHeadlessExecution:true];
 
   FlutterCallbackInformation *info = [FlutterCallbackCache
       lookupCallbackInformation:[dispatcherHandle longValue]];
 
   if (!info) {
-    NSLog(@"callback information could not be retrieved");
-    abort();
+    NSLog(@"Callback information could not be retrieved");
+    return;
   }
 
   NSString *entryPoint = info.callbackName;
   NSString *uri = info.callbackLibraryPath;
 
+  backgroundEngine =
+    [[FlutterEngine alloc] initWithName:@"FlutterLocalNotificationsIsolate"
+                                project:nil
+                allowHeadlessExecution:true];
+                
   dispatch_async(dispatch_get_main_queue(), ^{
     FlutterEventChannel *channel = [FlutterEventChannel
         eventChannelWithName:

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 12.0.0
+version: 12.0.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Closes #1721 