### PR TITLE
[flutter_local_notifications] Skip setMethodCallHandler() on null callback

### DIFF
--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -140,8 +140,10 @@ class AndroidFlutterLocalNotificationsPlugin
     DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) async {
-    _ondidReceiveNotificationResponse = onDidReceiveNotificationResponse;
-    _channel.setMethodCallHandler(_handleMethod);
+    if (onDidReceiveNotificationResponse != null) {
+      _ondidReceiveNotificationResponse = onDidReceiveNotificationResponse;
+      _channel.setMethodCallHandler(_handleMethod);
+    }
 
     final Map<String, Object> arguments = initializationSettings.toMap();
 


### PR DESCRIPTION
If the user didn't provide a onDidReceiveNotificationResponse callback, there's no point in listening to method calls coming from the platform.

This is useful when using the plugin from a separate Isolate. The setMethodCallHandler() call is overwriting the main Isolate's callback without this patch.

See discussion in https://github.com/MaikuB/flutter_local_notifications/issues/1730