### PR TITLE
[flutter_local_notifications] Handle onDetachedFromEngine in Android

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1260,7 +1260,11 @@ public class FlutterLocalNotificationsPlugin
   }
 
   @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    this.channel.setMethodCallHandler(null);
+    this.channel = null;
+    this.applicationContext = null;
+  }
 
   @Override
   public void onAttachedToActivity(ActivityPluginBinding binding) {


### PR DESCRIPTION
Do not leave behind a stale channel or application context. Undo what onnAttachedToEngine does.