### PR TITLE
[flutter_local_notifications] Fixes #1769 : Updates readme for iOS Setup

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -360,6 +360,10 @@ Adjust `AppDelegate.m` and set the plugin registrant callback:
 
 If you're using Objective-C, add this function anywhere in AppDelegate.m:
 ``` objc
+// This is required for calling FlutterLocalNotificationsPlugin.setPluginRegistrantCallback method.
+#import <FlutterLocalNotificationsPlugin.h>
+...
+...
 void registerPlugins(NSObject<FlutterPluginRegistry>* registry) {
     [GeneratedPluginRegistrant registerWithRegistry:registry];
 }
@@ -380,6 +384,12 @@ For Swift, open the `AppDelegate.swift` and update the `didFinishLaunchingWithOp
 where the commented code indicates the code to add in and why
 
 ```swift
+import UIKit
+import Flutter
+// This is required for calling FlutterLocalNotificationsPlugin.setPluginRegistrantCallback method.
+import flutter_local_notifications
+
+@UIApplicationMain
 override func application(
   _ application: UIApplication,
   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?


### PR DESCRIPTION
Fixes #1769 
Adds the import statement required for AppDelegate.swift and AppDelegate.m to use FlutterLocalNotificationsPlugin's setPluginRegistrantCallback function.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
