### PR TITLE
[flutter_local_notifications] Upgraded Android Gradle Plugin to fix Android build

### DIFF
--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/flutter_local_notifications/example/analysis_options.yaml
+++ b/flutter_local_notifications/example/analysis_options.yaml
@@ -71,7 +71,7 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
-    - lines_longer_than_80_chars
+    # - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings

--- a/flutter_local_notifications/example/android/app/build.gradle
+++ b/flutter_local_notifications/example/android/app/build.gradle
@@ -55,6 +55,8 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    // Temporary workaround as per https://issuetracker.google.com/issues/158060799
     lint {
         checkReleaseBuilds false
     }
@@ -63,8 +65,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-    // Temporary workaround as per https://issuetracker.google.com/issues/158060799
 }
 
 flutter {

--- a/flutter_local_notifications/example/android/app/build.gradle
+++ b/flutter_local_notifications/example/android/app/build.gradle
@@ -55,6 +55,9 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+    lint {
+        checkReleaseBuilds false
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -62,9 +65,6 @@ android {
     }
 
     // Temporary workaround as per https://issuetracker.google.com/issues/158060799
-    lintOptions {
-        checkReleaseBuilds false
-    }
 }
 
 flutter {

--- a/flutter_local_notifications/example/android/app/build.gradle
+++ b/flutter_local_notifications/example/android/app/build.gradle
@@ -56,11 +56,6 @@ android {
         }
     }
 
-    // Temporary workaround as per https://issuetracker.google.com/issues/158060799
-    lint {
-        checkReleaseBuilds false
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/flutter_local_notifications/example/android/build.gradle
+++ b/flutter_local_notifications/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/flutter_local_notifications/example/android/gradle.properties
+++ b/flutter_local_notifications/example/android/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
 # https://github.com/robolectric/robolectric/issues/6521
-android.jetifier.blacklist=bcprov
+android.jetifier.ignorelist=bcprov

--- a/flutter_local_notifications/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_local_notifications/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat May 14 14:15:09 AEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/cupertino.dart';
@@ -9,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+// import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as image;
 import 'package:path_provider/path_provider.dart';
@@ -209,8 +208,8 @@ Future<void> _configureLocalTimeZone() async {
     return;
   }
   tz.initializeTimeZones();
-  final String? timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
-  tz.setLocalLocation(tz.getLocation(timeZoneName!));
+  // final String? timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+  // tz.setLocalLocation(tz.getLocation(timeZoneName!));
 }
 
 class PaddedElevatedButton extends StatelessWidget {
@@ -2392,7 +2391,7 @@ class _HomePageState extends State<HomePage> {
     if (Platform.isAndroid) {
       final DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
       final AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
-      if (androidInfo.version.sdkInt! < 23) {
+      if (androidInfo.version.sdkInt < 23) {
         return const Text(
           '"getActiveNotifications" is available only for Android 6.0 or newer',
         );

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-// import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as image;
 import 'package:path_provider/path_provider.dart';
@@ -208,8 +208,8 @@ Future<void> _configureLocalTimeZone() async {
     return;
   }
   tz.initializeTimeZones();
-  // final String? timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
-  // tz.setLocalLocation(tz.getLocation(timeZoneName!));
+  final String? timeZoneName = await FlutterTimezone.getLocalTimezone();
+  tz.setLocalLocation(tz.getLocation(timeZoneName!));
 }
 
 class PaddedElevatedButton extends StatelessWidget {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as image;
 import 'package:path_provider/path_provider.dart';
@@ -208,7 +208,7 @@ Future<void> _configureLocalTimeZone() async {
     return;
   }
   tz.initializeTimeZones();
-  final String? timeZoneName = await FlutterTimezone.getLocalTimezone();
+  final String? timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
   tz.setLocalLocation(tz.getLocation(timeZoneName!));
 }
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:http/http.dart' as http;
 import 'package:image/image.dart' as image;
 import 'package:path_provider/path_provider.dart';
@@ -208,7 +208,7 @@ Future<void> _configureLocalTimeZone() async {
     return;
   }
   tz.initializeTimeZones();
-  final String? timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+  final String? timeZoneName = await FlutterTimezone.getLocalTimezone();
   tz.setLocalLocation(tz.getLocation(timeZoneName!));
 }
 

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,12 @@ import Foundation
 
 import device_info_plus
 import flutter_local_notifications
-import flutter_native_timezone
+import flutter_timezone
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
-  FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,12 @@ import Foundation
 
 import device_info_plus
 import flutter_local_notifications
-import flutter_timezone
+import flutter_native_timezone
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
-  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
+  FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,12 @@ import Foundation
 
 import device_info_plus
 import flutter_local_notifications
+import flutter_timezone
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,14 +5,12 @@
 import FlutterMacOS
 import Foundation
 
-import device_info_plus_macos
+import device_info_plus
 import flutter_local_notifications
-import flutter_native_timezone
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
-  FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications:
     path: ../
-  flutter_timezone: ^1.0.4
+  flutter_native_timezone: ^2.0.0
   http: ^0.13.4
   image: ^3.0.8
   path_provider: ^2.0.0

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -4,12 +4,12 @@ publish_to: none
 
 dependencies:
   cupertino_icons: ^1.0.2
-  device_info_plus: ^4.1.3
+  device_info_plus: ^8.0.0
   flutter:
     sdk: flutter
   flutter_local_notifications:
     path: ../
-  flutter_native_timezone: ^2.0.0
+  # flutter_native_timezone: ^2.0.0
   http: ^0.13.4
   image: ^3.0.8
   path_provider: ^2.0.0

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications:
     path: ../
-  flutter_native_timezone: ^2.0.0
+  flutter_timezone: ^1.0.4
   http: ^0.13.4
   image: ^3.0.8
   path_provider: ^2.0.0

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications:
     path: ../
-  # flutter_native_timezone: ^2.0.0
+  flutter_timezone: ^1.0.4
   http: ^0.13.4
   image: ^3.0.8
   path_provider: ^2.0.0

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -37,4 +37,4 @@ flutter:
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.8.0"
+  flutter: ">=3.0.0"

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -163,7 +163,6 @@ void main() {
               requestAlertPermission: false,
               requestBadgePermission: false,
               requestSoundPermission: false,
-              requestCriticalPermission: false,
               defaultPresentAlert: false,
               defaultPresentBadge: false,
               defaultPresentSound: false);

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -62,7 +62,6 @@ void main() {
         requestAlertPermission: false,
         requestBadgePermission: false,
         requestSoundPermission: false,
-        requestCriticalPermission: false,
         defaultPresentAlert: false,
         defaultPresentBadge: false,
         defaultPresentSound: false,


### PR DESCRIPTION
Fixes:

```console

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/rexios/.pub-cache/hosted/pub.dartlang.org/flutter_local_notifications-12.0.3/android/build.gradle'

* What went wrong:
Could not compile build file '/Users/rexios/.pub-cache/hosted/pub.dartlang.org/flutter_local_notifications-12.0.3/android/build.gradle'.
> startup failed:
  General error during conversion: Unsupported class file major version 63

  java.lang.IllegalArgumentException: Unsupported class file major version 63
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:199)
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:180)
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:166)
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:287)
  	at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:81)
  	at org.codehaus.groovy.control.ClassNodeResolver.findDecompiled(ClassNodeResolver.java:251)

  	at org.codehaus.groovy.control.ClassNodeResolver.tryAsLoaderClassOrScript(ClassNodeResolver.java:189)
  	at org.codehaus.groovy.control.ClassNodeResolver.findClassNode(ClassNodeResolver.java:169)
  	at org.codehaus.groovy.control.ClassNodeResolver.resolveName(ClassNodeResolver.java:125)
  	at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClassNullable(AsmReferenceResolver.java:57)
  	at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClass(AsmReferenceResolver.java:44)
  	at org.codehaus.groovy.ast.decompiled.TypeSignatureParser.visitEnd(TypeSignatureParser.java:110)
  	at groovyjarjarasm.asm.signature.SignatureReader.parseType(SignatureReader.java:206)
  	at groovyjarjarasm.asm.signature.SignatureReader.accept(SignatureReader.java:124)
  	at org.codehaus.groovy.ast.decompiled.ClassSignatureParser.parseClassSignature(ClassSignatureParser.java:74)
  	at org.codehaus.groovy.ast.decompiled.ClassSignatureParser.configureClass(ClassSignatureParser.java:32)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lazyInitSupers(DecompiledClassNode.java:185)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.isUsingGenerics(DecompiledClassNode.java:86)
  	at org.codehaus.groovy.ast.tools.GenericsUtils.nonGeneric(GenericsUtils.java:275)
  	at org.codehaus.groovy.ast.decompiled.MemberSignatureParser.createMethodNode(MemberSignatureParser.java:101)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lambda$createMethodNode$1(DecompiledClassNode.java:230)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.createMethodNode(DecompiledClassNode.java:236)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lazyInitMembers(DecompiledClassNode.java:203)
  	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.getDeclaredMethods(DecompiledClassNode.java:122)
  	at org.codehaus.groovy.ast.ClassNode.tryFindPossibleMethod(ClassNode.java:1283)
  	at org.codehaus.groovy.control.StaticImportVisitor.transformMethodCallExpression(StaticImportVisitor.java:251)
  	at org.codehaus.groovy.control.StaticImportVisitor.transform(StaticImportVisitor.java:133)
  	at org.codehaus.groovy.ast.ClassCodeExpressionTransformer.visitExpressionStatement(ClassCodeExpressionTransformer.java:108)
  	at org.codehaus.groovy.ast.stmt.ExpressionStatement.visit(ExpressionStatement.java:40)
  	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClassCodeContainer(ClassCodeVisitorSupport.java:138)
  	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitConstructorOrMethod(ClassCodeVisitorSupport.java:111)
  	at org.codehaus.groovy.ast.ClassCodeExpressionTransformer.visitConstructorOrMethod(ClassCodeExpressionTransformer.java:66)
  	at org.codehaus.groovy.control.StaticImportVisitor.visitConstructorOrMethod(StaticImportVisitor.java:108)
  	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitConstructor(ClassCodeVisitorSupport.java:101)
  	at org.codehaus.groovy.ast.ClassNode.visitContents(ClassNode.java:1089)
  	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClass(ClassCodeVisitorSupport.java:52)
  	at org.codehaus.groovy.control.CompilationUnit.lambda$addPhaseOperations$3(CompilationUnit.java:209)
  	at org.codehaus.groovy.control.CompilationUnit$IPrimaryClassNodeOperation.doPhaseOperation(CompilationUnit.java:942)
  	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:671)
  	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:635)
  	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:389)
  	at groovy.lang.GroovyClassLoader.lambda$parseClass$3(GroovyClassLoader.java:332)
  	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.compute(StampedCommonCache.java:163)
  	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.getAndPut(StampedCommonCache.java:154)
  	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:330)
  	at org.gradle.groovy.scripts.internal.DefaultScriptCompilationHandler.compileScript(DefaultScriptCompilationHandler.java:139)
...
```