### PR TITLE
[flutter_local_notifications] Implement options to hide or crop attachments in the thumbnail on iOS

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -826,9 +826,26 @@ class _HomePageState extends State<HomePage> {
                       },
                     ),
                     PaddedElevatedButton(
-                      buttonText: 'Show notification with attachment',
+                      buttonText:
+                          'Show notification with attachment (with thumbnail)',
                       onPressed: () async {
-                        await _showNotificationWithAttachment();
+                        await _showNotificationWithAttachment(
+                            hideThumbnail: false);
+                      },
+                    ),
+                    PaddedElevatedButton(
+                      buttonText:
+                          'Show notification with attachment (no thumbnail)',
+                      onPressed: () async {
+                        await _showNotificationWithAttachment(
+                            hideThumbnail: true);
+                      },
+                    ),
+                    PaddedElevatedButton(
+                      buttonText:
+                          'Show notification with attachment (clipped thumbnail)',
+                      onPressed: () async {
+                        await _showNotificationWithClippedThumbnailAttachment();
                       },
                     ),
                     PaddedElevatedButton(
@@ -2162,12 +2179,43 @@ class _HomePageState extends State<HomePage> {
         payload: 'item x');
   }
 
-  Future<void> _showNotificationWithAttachment() async {
+  Future<void> _showNotificationWithAttachment({
+    required bool hideThumbnail,
+  }) async {
     final String bigPicturePath = await _downloadAndSaveFile(
         'https://via.placeholder.com/600x200', 'bigPicture.jpg');
     final DarwinNotificationDetails darwinNotificationDetails =
         DarwinNotificationDetails(attachments: <DarwinNotificationAttachment>[
-      DarwinNotificationAttachment(bigPicturePath)
+      DarwinNotificationAttachment(
+        bigPicturePath,
+        hideThumbnail: hideThumbnail,
+      )
+    ]);
+    final NotificationDetails notificationDetails = NotificationDetails(
+        iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
+    await flutterLocalNotificationsPlugin.show(
+        id++,
+        'notification with attachment title',
+        'notification with attachment body',
+        notificationDetails);
+  }
+
+  Future<void> _showNotificationWithClippedThumbnailAttachment() async {
+    final String bigPicturePath = await _downloadAndSaveFile(
+        'https://via.placeholder.com/600x200', 'bigPicture.jpg');
+    final DarwinNotificationDetails darwinNotificationDetails =
+        DarwinNotificationDetails(attachments: <DarwinNotificationAttachment>[
+      DarwinNotificationAttachment(
+        bigPicturePath,
+        thumbnailClippingRect:
+            // lower right quadrant of the attachment
+            const DarwinNotificationAttachmentThumbnailClippingRect(
+          x: 0.5,
+          y: 0.5,
+          height: 0.5,
+          width: 0.5,
+        ),
+      )
     ]);
     final NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/mappers.dart
@@ -48,10 +48,21 @@ extension DarwinInitializationSettingsMapper on DarwinInitializationSettings {
       };
 }
 
-extension DarwinNotificationAttachmentMapper on DarwinNotificationAttachment {
+extension on DarwinNotificationAttachmentThumbnailClippingRect {
   Map<String, Object> toMap() => <String, Object>{
+    'x': x,
+    'y': y,
+    'width': width,
+    'height': height,
+  };
+}
+
+extension DarwinNotificationAttachmentMapper on DarwinNotificationAttachment {
+  Map<String, Object?> toMap() => <String, Object?>{
         'identifier': identifier ?? '',
         'filePath': filePath,
+        'hideThumbnail': hideThumbnail,
+        'thumbnailClippingRect': thumbnailClippingRect?.toMap(),
       };
 }
 

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_attachment.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_attachment.dart
@@ -5,6 +5,8 @@ class DarwinNotificationAttachment {
   const DarwinNotificationAttachment(
     this.filePath, {
     this.identifier,
+    this.hideThumbnail,
+    this.thumbnailClippingRect,
   });
 
   /// The local file path to the attachment.
@@ -18,4 +20,43 @@ class DarwinNotificationAttachment {
   /// When left empty, the platform's native APIs will generate a unique
   /// identifier
   final String? identifier;
+
+  /// Should the attachment be considered for the notification thumbnail?
+  final bool? hideThumbnail;
+
+  /// The clipping rectangle for the thumbnail image.
+  final DarwinNotificationAttachmentThumbnailClippingRect?
+      thumbnailClippingRect;
+}
+
+/// Represents the clipping rectangle used for the thumbnail image.
+class DarwinNotificationAttachmentThumbnailClippingRect {
+  /// Constructs an instance of
+  /// [DarwinNotificationAttachmentThumbnailClippingRect].
+  const DarwinNotificationAttachmentThumbnailClippingRect({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  /// Horizontal offset of the rectangle as proportion of the original image.
+  ///
+  /// Value in the range from 0.0 to 1.0.
+  final double x;
+
+  /// Vertical offset of the rectangle as proportion of the original image.
+  ///
+  /// Value in the range from 0.0 to 1.0.
+  final double y;
+
+  /// Width of the rectangle as proportion of the original image.
+  ///
+  /// Value in the range from 0.0 to 1.0.
+  final double width;
+
+  /// Height of the rectangle as proportion of the original image.
+  ///
+  /// Value in the range from 0.0 to 1.0.
+  final double height;
 }

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -35,6 +35,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         static let attachments = "attachments"
         static let identifier = "identifier"
         static let filePath = "filePath"
+        static let hideThumbnail = "hideThumbnail"
+        static let attachmentThumbnailClippingRect = "thumbnailClippingRect"
         static let threadIdentifier = "threadIdentifier"
         static let interruptionLevel = "interruptionLevel"
         static let actionId = "actionId"
@@ -517,7 +519,19 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 for attachment in attachments {
                     let identifier = attachment[MethodCallArguments.identifier] as! String
                     let filePath = attachment[MethodCallArguments.filePath] as! String
-                    let notificationAttachment = try UNNotificationAttachment.init(identifier: identifier, url: URL.init(fileURLWithPath: filePath))
+                    var options: [String: Any] = [:]
+                    if let hideThumbnail = attachment[MethodCallArguments.hideThumbnail] as? NSNumber {
+                        options[UNNotificationAttachmentOptionsThumbnailHiddenKey] = hideThumbnail
+                    }
+                    if let thumbnailClippingRect = attachment[MethodCallArguments.attachmentThumbnailClippingRect] as? [String: Any] {
+                        let rect = CGRect(x: thumbnailClippingRect["x"] as! Double, y: thumbnailClippingRect["y"] as! Double, width: thumbnailClippingRect["width"] as! Double, height: thumbnailClippingRect["height"] as! Double)
+                        options[UNNotificationAttachmentOptionsThumbnailClippingRectKey] = rect.dictionaryRepresentation
+                    }
+                    let notificationAttachment = try UNNotificationAttachment.init(
+                        identifier: identifier,
+                        url: URL.init(fileURLWithPath: filePath),
+                        options: options
+                    )
                     content.attachments.append(notificationAttachment)
                 }
             }

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -242,10 +242,12 @@ void main() {
               'sound': 'sound.mp3',
               'badgeNumber': 1,
               'threadIdentifier': null,
-              'attachments': <Map<String, Object>>[
-                <String, Object>{
+              'attachments': <Map<String, Object?>>[
+                <String, Object?>{
                   'filePath': 'video.mp4',
                   'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                  'hideThumbnail': null,
+                  'thumbnailClippingRect': null,
                 }
               ],
               'categoryIdentifier': 'category1',
@@ -309,10 +311,12 @@ void main() {
                     'sound': 'sound.mp3',
                     'badgeNumber': 1,
                     'threadIdentifier': null,
-                    'attachments': <Map<String, Object>>[
-                      <String, Object>{
+                    'attachments': <Map<String, Object?>>[
+                      <String, Object?>{
                         'filePath': 'video.mp4',
                         'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                        'hideThumbnail': null,
+                        'thumbnailClippingRect': null,
                       }
                     ],
                     'categoryIdentifier': null,
@@ -379,10 +383,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,
@@ -445,10 +451,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,
@@ -512,10 +520,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -152,10 +152,12 @@ void main() {
               'sound': 'sound.mp3',
               'badgeNumber': 1,
               'threadIdentifier': 'thread',
-              'attachments': <Map<String, Object>>[
-                <String, Object>{
+              'attachments': <Map<String, Object?>>[
+                <String, Object?>{
                   'filePath': 'video.mp4',
                   'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                  'hideThumbnail': null,
+                  'thumbnailClippingRect': null,
                 }
               ],
               'categoryIdentifier': 'category1',
@@ -219,10 +221,12 @@ void main() {
                     'sound': 'sound.mp3',
                     'badgeNumber': 1,
                     'threadIdentifier': null,
-                    'attachments': <Map<String, Object>>[
-                      <String, Object>{
+                    'attachments': <Map<String, Object?>>[
+                      <String, Object?>{
                         'filePath': 'video.mp4',
                         'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                        'hideThumbnail': null,
+                        'thumbnailClippingRect': null,
                       }
                     ],
                     'categoryIdentifier': null,
@@ -288,10 +292,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,
@@ -357,10 +363,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,
@@ -429,10 +437,12 @@ void main() {
                 'sound': 'sound.mp3',
                 'badgeNumber': 1,
                 'threadIdentifier': null,
-                'attachments': <Map<String, Object>>[
-                  <String, Object>{
+                'attachments': <Map<String, Object?>>[
+                  <String, Object?>{
                     'filePath': 'video.mp4',
                     'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                    'hideThumbnail': null,
+                    'thumbnailClippingRect': null,
                   }
                 ],
                 'categoryIdentifier': null,


### PR DESCRIPTION
This PR implements access to two platform-specific features for customizing attachments to notifications (c.f. https://developer.apple.com/documentation/usernotifications/unnotificationattachment?language=objc). Without them it's very hard to use image attachments at all, because by default the first attachment is used both for a tiny thumbnail (smaller than app logo) and a potentially full screen image on an expanded notification.