### PR TITLE
Bumped `timezone` dependency to 0.9.1

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [13.0.1]
+
+* Bumped `timezone` dependency to 0.9.1 to include time zone database updates 2022d, 2022e, 2022f, and 2022g.
+
 # [13.0.0]
 
 * [Android] Bumped Android Gradle plugin to 7.3.1. Thanks to the PR from [Rexios](https://github.com/Rexios80)

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications_linux: ^3.0.0
   flutter_local_notifications_platform_interface: ^6.0.0
-  timezone: ^0.9.0
+  timezone: ^0.9.1
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
Bumped `timezone` dependency to 0.9.1 to include time zone database updates 2022d, 2022e, 2022f, and 2022g.
