### PR TITLE
[flutter_local_notifications_platform_interface] Make ID nullable to prevent exception for active firebase notifications on iOS

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -41,7 +41,7 @@ A cross platform plugin for displaying local notifications.
    - [Scheduling a notification](#scheduling-a-notification)
    - [Periodically show a notification with a specified interval](#periodically-show-a-notification-with-a-specified-interval)
    - [Retrieving pending notification requests](#retrieving-pending-notification-requests)
-   - [[Android only] Retrieving active notifications](#android-only-retrieving-active-notifications)
+   - [[Selected OS versions] Retrieving active notifications](#android-only-retrieving-active-notifications)
    - [Grouping notifications](#grouping-notifications)
    - [Cancelling/deleting a notification](#cancellingdeleting-a-notification)
    - [Cancelling/deleting all notifications](#cancellingdeleting-all-notifications)
@@ -723,15 +723,20 @@ final List<PendingNotificationRequest> pendingNotificationRequests =
     await flutterLocalNotificationsPlugin.pendingNotificationRequests();
 ```
 
-### [Android only] Retrieving active notifications
+### Retrieving active notifications
+
+
+
 
 ```dart
 final List<ActiveNotification> activeNotifications =
-    await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
-        ?.getActiveNotifications();
+    await flutterLocalNotificationsPlugin.getActiveNotifications();
 ```
+
+**Note**: The API only works for the following operating systems and versions
+- Android 6.0 or newer
+- iOS 10.0 or newer
+- macOS 10.14 or newer
 
 ### Grouping notifications
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2507,14 +2507,16 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _getActiveNotificationMessagingStyle(int? id, String? tag) async {
+  Future<void> _getActiveNotificationMessagingStyle(
+      int? id, String? tag) async {
     Widget dialogContent;
     try {
+      // On Android, the id cannot be null, so we can safely apply a null check
       final MessagingStyleInformation? messagingStyle =
           await flutterLocalNotificationsPlugin
               .resolvePlatformSpecificImplementation<
                   AndroidFlutterLocalNotificationsPlugin>()!
-              .getActiveNotificationMessagingStyle(id: id, tag: tag);
+              .getActiveNotificationMessagingStyle(id!, tag: tag);
       if (messagingStyle == null) {
         dialogContent = const Text('No messaging style');
       } else {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2486,13 +2486,14 @@ class _HomePageState extends State<HomePage> {
                     'title: ${activeNotification.title}\n'
                     'body: ${activeNotification.body}',
                   ),
-                  TextButton(
-                    child: const Text('Get messaging style'),
-                    onPressed: () {
-                      _getActiveNotificationMessagingStyle(
-                          activeNotification.id, activeNotification.tag);
-                    },
-                  ),
+                  if (Platform.isAndroid && activeNotification.id != null)
+                    TextButton(
+                      child: const Text('Get messaging style'),
+                      onPressed: () {
+                        _getActiveNotificationMessagingStyle(
+                            activeNotification.id!, activeNotification.tag);
+                      },
+                    ),
                   const Divider(color: Colors.black),
                 ],
               ),
@@ -2507,15 +2508,14 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _getActiveNotificationMessagingStyle(int? id, String? tag) async {
+  Future<void> _getActiveNotificationMessagingStyle(int id, String? tag) async {
     Widget dialogContent;
     try {
-      // On Android, the id cannot be null, so we can safely apply a null check
       final MessagingStyleInformation? messagingStyle =
           await flutterLocalNotificationsPlugin
               .resolvePlatformSpecificImplementation<
                   AndroidFlutterLocalNotificationsPlugin>()!
-              .getActiveNotificationMessagingStyle(id!, tag: tag);
+              .getActiveNotificationMessagingStyle(id, tag: tag);
       if (messagingStyle == null) {
         dialogContent = const Text('No messaging style');
       } else {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2507,8 +2507,7 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _getActiveNotificationMessagingStyle(
-      int? id, String? tag) async {
+  Future<void> _getActiveNotificationMessagingStyle(int? id, String? tag) async {
     Widget dialogContent;
     try {
       // On Android, the id cannot be null, so we can safely apply a null check

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2507,14 +2507,14 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _getActiveNotificationMessagingStyle(int id, String? tag) async {
+  Future<void> _getActiveNotificationMessagingStyle(int? id, String? tag) async {
     Widget dialogContent;
     try {
       final MessagingStyleInformation? messagingStyle =
           await flutterLocalNotificationsPlugin
               .resolvePlatformSpecificImplementation<
                   AndroidFlutterLocalNotificationsPlugin>()!
-              .getActiveNotificationMessagingStyle(id, tag: tag);
+              .getActiveNotificationMessagingStyle(id: id, tag: tag);
       if (messagingStyle == null) {
         dialogContent = const Text('No messaging style');
       } else {

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -543,7 +543,15 @@ class FlutterLocalNotificationsPlugin {
   Future<List<PendingNotificationRequest>> pendingNotificationRequests() =>
       FlutterLocalNotificationsPlatform.instance.pendingNotificationRequests();
 
-  /// Returns a list of notifications that are already delivered/shown.
+  /// Returns the list of active notifications shown by the application that
+  /// haven't been dismissed/removed.
+  ///
+  /// The supported OS versions are
+  /// - Android: Android 6.0 or newer
+  /// - iOS: iOS 10.0 or newer
+  /// - macOS: macOS 10.14 or newer
+  ///
+  /// On Linux it will throw an [UnimplementedError].
   Future<List<ActiveNotification>> getActiveNotifications() =>
       FlutterLocalNotificationsPlatform.instance.getActiveNotifications();
 }

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -84,16 +84,6 @@ class MethodChannelFlutterLocalNotificationsPlugin
         <PendingNotificationRequest>[];
   }
 
-  /// Returns the list of active notifications shown by the application that
-  /// haven't been dismissed/removed.
-  ///
-  /// The supported OS versions are
-  /// - Android: Android 6.0 or newer
-  /// - iOS: iOS 10.0 or newer
-  /// - macOS: macOS 10.14 or newer
-  ///
-  /// Throws a [PlatformException] with an `unsupported_os_version` error code
-  /// on older OS versions. On Linux it will throw an [UnimplementedError].
   @override
   Future<List<ActiveNotification>> getActiveNotifications() async {
     final List<Map<dynamic, dynamic>>? activeNotifications =

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -101,7 +101,7 @@ class MethodChannelFlutterLocalNotificationsPlugin
     return activeNotifications
             // ignore: always_specify_types
             ?.map((p) => ActiveNotification(
-                  id: p['id'] ?? -1,
+                  id: p['id'],
                   channelId: p['channelId'],
                   groupKey: p['groupKey'],
                   tag: p['tag'],

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -473,7 +473,7 @@ class AndroidFlutterLocalNotificationsPlugin
   /// Only [DrawableResourceAndroidIcon] and [ContentUriAndroidIcon] are
   /// supported for [AndroidIcon] fields.
   Future<MessagingStyleInformation?> getActiveNotificationMessagingStyle(
-  {int? id,
+    int id, {
     String? tag,
   }) async {
     final Map<dynamic, dynamic>? m = await _channel

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -101,7 +101,7 @@ class MethodChannelFlutterLocalNotificationsPlugin
     return activeNotifications
             // ignore: always_specify_types
             ?.map((p) => ActiveNotification(
-                  id: p['id'],
+                  id: p['id'] ?? -1,
                   channelId: p['channelId'],
                   groupKey: p['groupKey'],
                   tag: p['tag'],

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -473,7 +473,7 @@ class AndroidFlutterLocalNotificationsPlugin
   /// Only [DrawableResourceAndroidIcon] and [ContentUriAndroidIcon] are
   /// supported for [AndroidIcon] fields.
   Future<MessagingStyleInformation?> getActiveNotificationMessagingStyle(
-    int id, {
+  {int? id,
     String? tag,
   }) async {
     final Map<dynamic, dynamic>? m = await _channel

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -69,7 +69,13 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
         'pendingNotificationRequest() has not been implemented');
   }
 
-  /// Returns a list of notifications already delivered
+  /// Returns the list of active notifications shown by the application that
+  /// haven't been dismissed/removed.
+  ///
+  /// Throws a [PlatformException] with an `unsupported_os_version` error code
+  /// when the OS version is older than what is supported to have results
+  /// returned. On platforms that don't support the method at all,
+  /// it will throw an [UnimplementedError].
   Future<List<ActiveNotification>> getActiveNotifications() {
     throw UnimplementedError(
         'getActiveNotifications() has not been implemented');

--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -36,7 +36,7 @@ class PendingNotificationRequest {
 class ActiveNotification {
   /// Constructs an instance of [ActiveNotification].
   const ActiveNotification({
-    required this.id,
+    this.id,
     this.groupKey,
     this.channelId,
     this.title,
@@ -46,7 +46,7 @@ class ActiveNotification {
   });
 
   /// The notification's id.
-  final int id;
+  final int? id;
 
   /// The notification's channel id.
   ///

--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -46,6 +46,9 @@ class ActiveNotification {
   });
 
   /// The notification's id.
+  ///
+  /// This will be null if the notification was outsided of the plugin's
+  /// control e.g. on iOS and via Firebase Cloud Messaging.
   final int? id;
 
   /// The notification's channel id.
@@ -70,6 +73,7 @@ class ActiveNotification {
   final String? payload;
 
   /// The notification's tag.
+  ///
   /// Returned only on Android.
   final String? tag;
 }


### PR DESCRIPTION
A similar issue is already discussed in #1869.

When calling `getActiveNotifications()` on iOS, with Firebase notifications present, `null` is passed as the required `id` parameter of the `ActiveNotification` class. 

I initially proposed to use `-1` as a default value, so that no exception is thrown, and all notifications can be retrieved on both Android and iOS.

As discussed in the linked issue, there is an identifier in the iOS notification, but as this  is not numerical, it's not trivial to use it. I was aware that `-1` is a magic number, but at least this allows users to get the active notifications on iOS even with Firebase notifications present. 

Instead, the alternative approach is now chosen, we say that the `id` is not a `required` parameter, as it does not exist on every platform.

