### PR TITLE
[flutter_local_notifications_linux] Bump xdg_directories dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 version: 2
+enable-beta-ecosystems: true
+
 updates:
   - package-ecosystem: "pub"
     directory: "/flutter_local_notifications_platform_interface"

--- a/flutter_local_notifications_linux/pubspec.yaml
+++ b/flutter_local_notifications_linux/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_local_notifications_platform_interface: ^6.0.0
   path: ^1.8.0
-  xdg_directories: ^0.2.0+1
+  xdg_directories: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Also, I noticed that dependabot seems to not have run in while? Tried to add `enable-beta-ecosystems` to see if it improves the situation.