### PR TITLE
[flutter_local_notifications] Fix showMessagingNotification in example

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1684,7 +1684,7 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'message title', 'message body', notificationDetails);
+        id, 'message title', 'message body', notificationDetails);
 
     // wait 10 seconds and add another message to simulate another response
     await Future<void>.delayed(const Duration(seconds: 10), () async {


### PR DESCRIPTION
The notification ID was being incremented after creating the notification, which meant that trying to append a message 10 seconds later created an entirely new notification rather than just being added to the conversation.