### PR TITLE
[flutter_local_notifications] textstyle of theme changed in example

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -887,7 +887,7 @@ class _HomePageState extends State<HomePage> {
                                   'Capabilities of the current system:',
                                   style: Theme.of(context)
                                       .textTheme
-                                      .subtitle1!
+                                      .titleMedium!
                                       .copyWith(fontWeight: FontWeight.bold),
                                 ),
                                 const SizedBox(height: 8),


### PR DESCRIPTION
'subtitle1' is deprecated and shouldn't be used. 'titleMedium' is used instead.
