### PR TITLE
[flutter_local_notifications] throw PlatformException to allow apps to deal with when Apple's APIs are given a date when daylight saving occurs and can't process it

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [14.0.0-dev.4]
 
 * [iOS][macOS] fixed issue [1950](https://github.com/MaikuB/flutter_local_notifications/issues/1950) where a crash occurs when calling `zonedSchedule` whilst specifying a date and time value when daylight savings occurs when time gets adjusted. A `PlatformException` will now be thrown when this happens with an error code of `invalid_date`. This allows apps to catch the exception and specify a date and time value after the adjustment has happened for Apple's APIs to work. For example, in the Africa/Cairo timezone, at 12:00AM on 28th of April 2023, the clock will move forward an hour to 1:00AM. If `zonedSchedule` is called specifying Africa/Cairo as the timezone and a date and time value of 12:00AM on 28th of April 2023, the plugin will throw the aforementioned exception. This allows apps to trap the exception and give the opportunity to specify 1:00AM instead
+* The minimum iOS version for the example app is now iOS 11 that aligns with the minimum iOS version supported by Flutter
 
 # [14.0.0-dev.3]
 

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [14.0.0-dev.4]
+
+* [iOS][macOS] fixed issue [1950](https://github.com/MaikuB/flutter_local_notifications/issues/1950) where a crash occurs when calling `zonedSchedule` whilst specifying a date and time value when daylight savings occurs when time gets adjusted. A `PlatformException` will now be thrown when this happens with an error code of `invalid_date`. This allows apps to catch the exception and specify a date and time value after the adjustment has happened for Apple's APIs to work. For example, in the Africa/Cairo timezone, at 12:00AM on 28th of April 2023, the clock will move forward an hour to 1:00AM. If `zonedSchedule` is called specifying Africa/Cairo as the timezone and a date and time value of 12:00AM on 28th of April 2023, the plugin will throw the aforementioned exception. This allows apps to trap the exception and give the opportunity to specify 1:00AM instead
+
 # [14.0.0-dev.3]
 
 * Align Dart SDK constraint with minimum Flutter version (i.e. 3.0)

--- a/flutter_local_notifications/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/flutter_local_notifications/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/flutter_local_notifications/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter_local_notifications/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -227,6 +227,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -241,6 +242,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -345,7 +347,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -423,7 +425,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -472,7 +474,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/flutter_local_notifications/example/ios/Runner/Info.plist
+++ b/flutter_local_notifications/example/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import device_info_plus
 import flutter_local_notifications
 import flutter_timezone
-import path_provider_macos
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))

--- a/flutter_local_notifications/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/flutter_local_notifications/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -205,7 +205,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -259,6 +259,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -407,7 +408,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -486,7 +487,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -533,7 +534,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/flutter_local_notifications/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/flutter_local_notifications/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -124,7 +124,12 @@ static FlutterError *getFlutterError(NSError *error) {
 }
 
 static FlutterError *getInvalidDateFlutterError(void) {
-   return [FlutterError errorWithCode:@"invalid_date" message:@"Apple's APIs cannot parse this date. Please check to see if daylight savings is taking on this time and adjust the date you want to specify accordingly." details:nil];
+  return [FlutterError
+      errorWithCode:@"invalid_date"
+            message:@"Apple's APIs cannot parse this date. Please check to see "
+                    @"if daylight savings is taking on this time and adjust "
+                    @"the date you want to specify accordingly."
+            details:nil];
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -613,8 +618,8 @@ static FlutterError *getInvalidDateFlutterError(void) {
     UNCalendarNotificationTrigger *trigger =
         [self buildUserNotificationCalendarTrigger:arguments];
     if (!trigger) {
-       result(getInvalidDateFlutterError());
-       return;
+      result(getInvalidDateFlutterError());
+      return;
     }
 
     [self addNotificationRequest:[self getIdentifier:arguments]
@@ -640,7 +645,7 @@ static FlutterError *getInvalidDateFlutterError(void) {
     NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
     if (!date) {
       result(getInvalidDateFlutterError());
-       return;
+      return;
     }
     notification.fireDate = date;
     if (uiLocalNotificationDateInterpretation != nil) {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -126,9 +126,10 @@ static FlutterError *getFlutterError(NSError *error) {
 static FlutterError *getInvalidDateFlutterError(void) {
   return [FlutterError
       errorWithCode:@"invalid_date"
-            message:@"Apple's APIs cannot parse this date. Please check to see "
-                    @"if daylight savings is taking place on this time and adjust "
-                    @"the date you want to specify accordingly."
+            message:
+                @"Apple's APIs cannot parse this date. Please check to see "
+                @"if daylight savings is taking place on this time and adjust "
+                @"the date you want to specify accordingly."
             details:nil];
 }
 

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -127,7 +127,7 @@ static FlutterError *getInvalidDateFlutterError(void) {
   return [FlutterError
       errorWithCode:@"invalid_date"
             message:@"Apple's APIs cannot parse this date. Please check to see "
-                    @"if daylight savings is taking on this time and adjust "
+                    @"if daylight savings is taking place on this time and adjust "
                     @"the date you want to specify accordingly."
             details:nil];
 }

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -334,8 +334,18 @@ class FlutterLocalNotificationsPlugin {
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
   ///
+  /// Throws a [PlatformException] with an error code of `invalid_date`
+  /// on iOS and macOS when Apple's API cannot handle the date and time.
+  /// In these situations, it's likely that daylight savings will take
+  /// effect that Apple requires the date and time value to be the value
+  /// after the transition. An example of this is 28th of April 2023
+  /// 12:00AM in the Africa/Cairo time zone where the time will be
+  /// moved forward one hour to 1:00AM. The plugin throw an exception
+  /// if the date and time value is 28th of April 2023 12:00AM but
+  /// will work if the date and time value is 28th of April 2023 1:00AM.
+  ///
   /// Note that to get the appropriate representation of the time at the native
-  /// level (i.e. Android/iOS), the plugin needs to pass the time over the
+  /// level (i.e. Android/iOS/macOS), the plugin needs to pass the time over the
   /// platform channel in yyyy-mm-dd hh:mm:ss format. Therefore, the precision
   /// is at the best to the second.
   ///

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -688,6 +688,16 @@ class IOSFlutterLocalNotificationsPlugin
   /// Schedules a notification to be shown at the specified time in the
   /// future in a specific time zone.
   ///
+  /// Throws a [PlatformException] with an error code of `invalid_date`
+  /// when Apple's API cannot handle the date and time.
+  /// In these situations, it's likely that daylight savings will take
+  /// effect that Apple requires the date and time value to be the value
+  /// after the transition. An example of this is 28th of April 2023
+  /// 12:00AM in the Africa/Cairo time zone where the time will be
+  /// moved forward one hour to 1:00AM. The plugin throw an exception
+  /// if the date and time value is 28th of April 2023 12:00AM but
+  /// will work if the date and time value is 28th of April 2023 1:00AM.
+  ///
   /// Due to the limited support for time zones provided the UILocalNotification
   /// APIs used on devices using iOS versions older than 10, the
   /// [uiLocalNotificationDateInterpretation] is needed to control how
@@ -904,6 +914,16 @@ class MacOSFlutterLocalNotificationsPlugin
 
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
+  ///
+  /// Throws a [PlatformException] with an error code of `invalid_date`
+  /// when Apple's API cannot handle the date and time.
+  /// In these situations, it's likely that daylight savings will take
+  /// effect that Apple requires the date and time value to be the value
+  /// after the transition. An example of this is 28th of April 2023
+  /// 12:00AM in the Africa/Cairo time zone where the time will be
+  /// moved forward one hour to 1:00AM. The plugin throw an exception
+  /// if the date and time value is 28th of April 2023 12:00AM but
+  /// will work if the date and time value is 28th of April 2023 1:00AM.
   Future<void> zonedSchedule(
     int id,
     String? title,

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -82,7 +82,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     var defaultPresentBadge = false
     var launchNotificationResponseDict: [String: Any?]?
     var launchingAppFromNotification = false
-    let invalidDateFlutterError = FlutterError.init(code: "invalid_date", message: "Apple's APIs cannot parse this date. Please check to see if daylight savings is taking on this time and adjust the date you want to specify accordingly", details: nil)
+    let invalidDateFlutterError = FlutterError.init(code: "invalid_date", message: "Apple's APIs cannot parse this date. Please check to see if daylight savings is taking place on this time and adjust the date you want to specify accordingly", details: nil)
 
     init(fromChannel channel: FlutterMethodChannel) {
         self.channel = channel

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -49,7 +49,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
 
     struct ErrorCodes {
         static let unsupportedOSVersion = "unsupported_os_version"
-        static let invalidDate = "invalid_date";
+        static let invalidDate = "invalid_date"
     }
 
     struct DateFormatStrings {
@@ -401,9 +401,9 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 let arguments = call.arguments as! [String: AnyObject]
                 let content = try buildUserNotificationContent(fromArguments: arguments)
                 let trigger = buildUserNotificationCalendarTrigger(fromArguments: arguments)
-                if (trigger == nil) {
+                if trigger == nil {
                     result(invalidDateFlutterError)
-                    return;
+                    return
                 }
                 let center = UNUserNotificationCenter.current()
                 let request = UNNotificationRequest(identifier: getIdentifier(fromArguments: arguments), content: content, trigger: trigger)
@@ -421,7 +421,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
             let dateFormatter = DateFormatter.init()
             dateFormatter.dateFormat = DateFormatStrings.isoFormat
             let date = dateFormatter.date(from: scheduledDateTime)
-            if (date == nil) {
+            if date == nil {
                 result(invalidDateFlutterError)
                 return
             }
@@ -567,7 +567,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         dateFormatter.dateFormat = DateFormatStrings.isoFormat
         dateFormatter.timeZone = timeZone
         let date = dateFormatter.date(from: scheduledDateTime)
-        if (date == nil) {
+        if date == nil {
             return nil
         }
         var calendar = Calendar.current

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 14.0.0-dev.3
+version: 14.0.0-dev.4
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Closes #1950 
