### PR TITLE
[flutter_local_notifications] fixed date parsing on iOS and macOS when specified time is when daylight savings occurs

### DIFF
--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import device_info_plus
 import flutter_local_notifications
 import flutter_timezone
-import path_provider_macos
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -81,7 +81,7 @@ NSString *const REPEAT_TIME = @"repeatTime";
 NSString *const HOUR = @"hour";
 NSString *const MINUTE = @"minute";
 NSString *const SECOND = @"second";
-NSString *const SCHEDULED_DATE_TIME = @"scheduledDateTime";
+NSString *const SCHEDULED_DATE_TIME = @"scheduledDateTimeISO8601";
 NSString *const TIME_ZONE_NAME = @"timeZoneName";
 NSString *const MATCH_DATE_TIME_COMPONENTS = @"matchDateTimeComponents";
 NSString *const UILOCALNOTIFICATION_DATE_INTERPRETATION =
@@ -1000,15 +1000,9 @@ static FlutterError *getFlutterError(NSError *error) {
   NSNumber *matchDateComponents = arguments[MATCH_DATE_TIME_COMPONENTS];
   NSCalendar *calendar = [NSCalendar currentCalendar];
   NSTimeZone *timezone = [NSTimeZone timeZoneWithName:timeZoneName];
-  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-
-  // Needed for some countries, when phone DateTime format is 12H
-  NSLocale *posix = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
-
-  [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
+  NSISO8601DateFormatter *dateFormatter =  [[NSISO8601DateFormatter alloc] init];
   [dateFormatter setTimeZone:timezone];
-  [dateFormatter setLocale:posix];
-
+  dateFormatter.formatOptions = NSISO8601DateFormatWithFractionalSeconds | NSISO8601DateFormatWithInternetDateTime;
   NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
 
   calendar.timeZone = timezone;

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -625,9 +625,9 @@ static FlutterError *getFlutterError(NSError *error) {
     NSNumber *uiLocalNotificationDateInterpretation =
         arguments[UILOCALNOTIFICATION_DATE_INTERPRETATION];
     NSTimeZone *timezone = [NSTimeZone timeZoneWithName:timeZoneName];
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
+    NSISO8601DateFormatter *dateFormatter =  [[NSISO8601DateFormatter alloc] init];
     [dateFormatter setTimeZone:timezone];
+    dateFormatter.formatOptions = NSISO8601DateFormatWithFractionalSeconds | NSISO8601DateFormatWithInternetDateTime;
     NSDate *date = [dateFormatter dateFromString:scheduledDateTime];
     notification.fireDate = date;
     if (uiLocalNotificationDateInterpretation != nil) {

--- a/flutter_local_notifications/lib/src/tz_datetime_mapper.dart
+++ b/flutter_local_notifications/lib/src/tz_datetime_mapper.dart
@@ -24,6 +24,7 @@ extension TZDateTimeMapper on TZDateTime {
     return <String, Object>{
       'timeZoneName': location.name,
       'scheduledDateTime': iso8601DateComponent,
+      'scheduledDateTimeISO8601': toIso8601String(),
     };
   }
 }

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -26,7 +26,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         static let subtitle = "subtitle"
         static let categoryIdentifier = "categoryIdentifier"
         static let body = "body"
-        static let scheduledDateTime = "scheduledDateTime"
+        static let scheduledDateTime = "scheduledDateTimeISO8601"
         static let timeZoneName = "timeZoneName"
         static let matchDateTimeComponents = "matchDateTimeComponents"
         static let platformSpecifics = "platformSpecifics"

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -412,8 +412,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
             let scheduledDateTime = arguments[MethodCallArguments.scheduledDateTime] as! String
             let timeZoneName = arguments[MethodCallArguments.timeZoneName] as! String
             let timeZone = TimeZone.init(identifier: timeZoneName)
-            let dateFormatter = DateFormatter.init()
-            dateFormatter.dateFormat = DateFormatStrings.isoFormat
+            let dateFormatter = ISO8601DateFormatter()
+            dateFormatter.formatOptions = [.withFractionalSeconds, .withInternetDateTime];
             let date = dateFormatter.date(from: scheduledDateTime)!
             notification.deliveryDate = date
             notification.deliveryTimeZone = timeZone
@@ -552,9 +552,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         let scheduledDateTime = arguments[MethodCallArguments.scheduledDateTime] as! String
         let timeZoneName = arguments[MethodCallArguments.timeZoneName] as! String
         let timeZone = TimeZone.init(identifier: timeZoneName)
-        let dateFormatter = DateFormatter.init()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = DateFormatStrings.isoFormat
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFractionalSeconds, .withInternetDateTime];
         dateFormatter.timeZone = timeZone
         let date = dateFormatter.date(from: scheduledDateTime)!
         var calendar = Calendar.current


### PR DESCRIPTION
fixes #1950 
