### PR TITLE
Adds Android namespace

### DIFF
--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+namespace 'com.dexterous.flutterlocalnotifications'
     compileSdkVersion 33
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-namespace 'com.dexterous.flutterlocalnotifications'
+    namespace 'com.dexterous.flutterlocalnotifications'
     compileSdkVersion 33
     compileOptions {
         coreLibraryDesugaringEnabled true


### PR DESCRIPTION
Add a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b