### PR TITLE
[flutter_local_notifications] register android broadcast in init meth…

### DIFF
--- a/flutter_local_notifications/android/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/android/src/main/AndroidManifest.xml
@@ -6,15 +6,5 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application>
-        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
-        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
-        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
-                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
-            </intent-filter>
-        </receiver>
     </application>
 </manifest>

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -11,6 +11,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.AssetFileDescriptor;
@@ -1556,6 +1557,15 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private void initialize(MethodCall call, Result result) {
+    applicationContext.registerReceiver(new ActionBroadcastReceiver(),new IntentFilter());
+    applicationContext.registerReceiver(new ScheduledNotificationReceiver(),new IntentFilter());
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(Intent.ACTION_BOOT_COMPLETED);
+    filter.addAction(Intent.ACTION_MY_PACKAGE_REPLACED);
+    filter.addAction("android.intent.action.QUICKBOOT_POWERON");
+    filter.addAction("com.htc.intent.action.QUICKBOOT_POWERON");
+    applicationContext.registerReceiver(new ScheduledNotificationBootReceiver(),filter);
+
     Map<String, Object> arguments = call.arguments();
     String defaultIcon = (String) arguments.get(DEFAULT_ICON);
     if (!isValidDrawableResource(


### PR DESCRIPTION
register android broadcast in init function,  to fix #1996  and it is no need init in xml because export is false.

As this repository hosts multiple packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). Should the PR more than one package than please prefix the title of the PR with [various] The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
