### PR TITLE
[flutter_local_notifications] fixed issue importance level was mapped incorrectly when calling getNotificationChannels()

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [16.0.0-dev.3]
+
+* [Android] fixed issue [2106](https://github.com/MaikuB/flutter_local_notifications/issues/2106) where calling `getNotificationChannels()` reports the wrong importance level or result in an exception if the importance level was unspecified
+
 # [16.0.0-dev.2]
 
 * [Android] fixed issue an issue similar to [2033](https://github.com/MaikuB/flutter_local_notifications/issues/2033) that was addressed in 15.0.1 where notifications on scheduled using older version of the plugin via the `periodicallyShow()` method would fail to have the next subsequent ones scheduled. This issue started occuring in 14.0 where support for inexact notifications was added using the `ScheduleMode` enum that was added and resulted in the deprecation of `androidAllowWhileIdle`. A mechanism was added to help "migrate" old notifications that had `androidAllowWhileIdle` specified but didn't account for how there are recurring notifications that were scheduled using older versions of the plugin prior to `androidAllowWhile` being added

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [16.0.0-dev.3]
 
 * [Android] fixed issue [2106](https://github.com/MaikuB/flutter_local_notifications/issues/2106) where calling `getNotificationChannels()` reports the wrong importance level or result in an exception if the importance level was unspecified
+* Fixed example code shown at the "Handling notifications whilst the app is in the foreground" section of the readme. Thanks to the PR from [Tinh Huynh](https://github.com/TinhHuynh)
 
 # [16.0.0-dev.2]
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -483,7 +483,9 @@ class AndroidFlutterLocalNotificationsPlugin
               description: a['description'],
               groupId: a['groupId'],
               showBadge: a['showBadge'],
-              importance: Importance.values[a['importance']],
+              importance: Importance.values
+                  // ignore: always_specify_types
+                  .firstWhere((i) => i.value == a['importance']),
               playSound: a['playSound'],
               sound: _getNotificationChannelSound(a),
               enableLights: a['enableLights'],

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 16.0.0-dev.2
+version: 16.0.0-dev.3
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Fixes #2106 