### PR TITLE
[flutter_local_notifications] Fix docs for Android notification permission

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -268,7 +268,7 @@ From Android 13 (API level 33) onwards, apps now have the ability to display a p
 FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
         FlutterLocalNotificationsPlugin();
 flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-    AndroidFlutterLocalNotificationsPlugin>().requestPermission();
+    AndroidFlutterLocalNotificationsPlugin>().requestNotificationsPermission();
 ```
 
 ### Custom notification icons and sounds


### PR DESCRIPTION
Based on the latest breaking changes, the name for he request permission for notifications on Android is wrong.

Current description:
AndroidFlutterLocalNotificationsPlugin>().requestPermission();

New description:
AndroidFlutterLocalNotificationsPlugin>().requestNotificationsPermission();
