### PR TITLE
[flutter_local_notifications] open the alarm settings screen specific to using app

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1793,7 +1793,9 @@ public class FlutterLocalNotificationsPlugin
       if (!permissionGranted) {
         permissionRequestProgress = PermissionRequestProgress.RequestingExactAlarmsPermission;
         mainActivity.startActivityForResult(
-            new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM), EXACT_ALARM_PERMISSION_REQUEST_CODE);
+            new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                    Uri.parse("package:" + applicationContext.getPackageName())),
+                EXACT_ALARM_PERMISSION_REQUEST_CODE);
       } else {
         this.callback.complete(true);
         permissionRequestProgress = PermissionRequestProgress.None;


### PR DESCRIPTION
`requestExactAlarmsPermission` opened the app list screen for alarm and reminder settings.
Fixed to open the alarm setting screen of the application.

ACTION_REQUEST_SCHEDULE_EXACT_ALARM's Document
https://developer.android.com/reference/android/provider/Settings#ACTION_REQUEST_SCHEDULE_EXACT_ALARM