### PR TITLE
[flutter_local_notifications] Update README.md to fix compile error

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -452,9 +452,9 @@ On iOS/macOS, notification actions need to be configured before the app is start
 final DarwinInitializationSettings initializationSettingsDarwin = DarwinInitializationSettings(
     // ...
     notificationCategories: [
-    const DarwinNotificationCategory(
+      DarwinNotificationCategory(
         'demoCategory',
-        <DarwinNotificationAction>[
+        actions: <DarwinNotificationAction>[
             DarwinNotificationAction.plain('id_1', 'Action 1'),
             DarwinNotificationAction.plain(
             'id_2',


### PR DESCRIPTION
Environment:
_Dart **3.2.0-42.1.beta** 
Flutter **3.14.0-0.1.pre**
flutter_local_notifications: ^15.1.2_

Convert to named arguments and remove const from constructor invocation as getting compilation error
<img width="820" alt="Screenshot 2023-10-06 at 3 43 05 PM" src="https://github.com/MaikuB/flutter_local_notifications/assets/11186863/391dfe52-ab4c-4182-be54-09061cd4df8d">
