### PR TITLE
[flutter_local_notifications] Fix conflict with other plugins (onActivityResult)

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -2128,7 +2128,9 @@ public class FlutterLocalNotificationsPlugin
       return false;
     }
 
-    if (requestCode == EXACT_ALARM_PERMISSION_REQUEST_CODE && VERSION.SDK_INT >= VERSION_CODES.S) {
+    if (permissionRequestProgress == PermissionRequestProgress.RequestingExactAlarmsPermission 
+        && requestCode == EXACT_ALARM_PERMISSION_REQUEST_CODE 
+        && VERSION.SDK_INT >= VERSION_CODES.S) {
       AlarmManager alarmManager = getAlarmManager(applicationContext);
       this.callback.complete(alarmManager.canScheduleExactAlarms());
       permissionRequestProgress = PermissionRequestProgress.None;


### PR DESCRIPTION
Hello,

Thanks for your package. 

There is a conflict with the latest version 16.0.0+1 of flutter_local_notifications. I use another package which also implements `onActivityResult`, so there is a conflict when this package starts `startActivityForResult` with a request code == 2. The flutter_local_notifications package falsely intercepts and processes the request code, resulting in an application crash.

Could you merge this PR to fix the issue please?

Thanks.
 
Here is the log:
```
E/AndroidRuntime( 3382): Caused by: java.lang.NullPointerException: Attempt to invoke interface method 'void com.dexterous.flutterlocalnotifications.PermissionRequestListener.complete(boolean)' on a null object reference
E/AndroidRuntime( 3382): 	at com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin.onActivityResult(FlutterLocalNotificationsPlugin.java:2133)
E/AndroidRuntime( 3382): 	at io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEngineConnectionRegistry.java:813)
E/AndroidRuntime( 3382): 	at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.onActivityResult(FlutterEngineConnectionRegistry.java:432)
E/AndroidRuntime( 3382): 	at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onActivityResult(FlutterActivityAndFragmentDelegate.java:853)
E/AndroidRuntime( 3382): 	at io.flutter.embedding.android.FlutterActivity.onActivityResult(FlutterActivity.java:884)
E/AndroidRuntime( 3382): 	at android.app.Activity.dispatchActivityResult(Activity.java:8613)
E/AndroidRuntime( 3382): 	at android.app.ActivityThread.deliverResults(ActivityThread.java:5340)
```

And if I use `requestNotificationsPermission()`, I get this error:
```
E/AndroidRuntime(27739): Caused by: java.lang.IllegalStateException: Reply already submitted
E/AndroidRuntime(27739): 	at s4.c$g.a(SourceFile:36)
E/AndroidRuntime(27739): 	at io.flutter.plugin.common.MethodChannel$a$a.success(SourceFile:15)
E/AndroidRuntime(27739): 	at com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin$b.b(SourceFile:7)
E/AndroidRuntime(27739): 	at com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin.onActivityResult(SourceFile:29)
E/AndroidRuntime(27739): 	at r4.b$c.g(SourceFile:26)
E/AndroidRuntime(27739): 	at r4.b.onActivityResult(SourceFile:14)
E/AndroidRuntime(27739): 	at q4.i.p(SourceFile:52)
E/AndroidRuntime(27739): 	at q4.h.onActivityResult(SourceFile:11)
E/AndroidRuntime(27739): 	at android.app.Activity.dispatchActivityResult(Activity.java:8613)
E/AndroidRuntime(27739): 	at android.app.ActivityThread.deliverResults(ActivityThread.java:5340)
```
