### PR TITLE
[flutter_local_notifications] Check permissions for iOS and macOS

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -95,6 +95,7 @@ A cross platform plugin for displaying local notifications.
 * [Android] Ability to check if notifications are enabled
 * [iOS (all supported versions) & macOS 10.14+] Request notification permissions and customise the permissions being requested around displaying notifications
 * [iOS 10 or newer and macOS 10.14 or newer] Display notifications with attachments
+* [iOS and macOS 10.14 or newer] Ability to check if notifications are enabled with specific type check
 * [Linux] Ability to to use themed/Flutter Assets icons and sound
 * [Linux] Ability to to set the category
 * [Linux] Configuring the urgency

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2484,30 +2484,38 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _checkNotificationsOnCupertino() async {
     final bool? areEnabled = await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            IOSFlutterLocalNotificationsPlugin>()
-        ?.checkPermissions(
-          sound: true,
-          alert: true,
-          badge: true,
-        );
+            .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin>()
+            ?.checkPermissions(
+              sound: true,
+              alert: true,
+              badge: true,
+            ) ??
+        await flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<
+                MacOSFlutterLocalNotificationsPlugin>()
+            ?.checkPermissions(
+              sound: true,
+              alert: true,
+              badge: true,
+            );
     await showDialog<void>(
         context: context,
         builder: (BuildContext context) => AlertDialog(
-          content: Text(areEnabled == null
-              ? 'ERROR: received null'
-              : (areEnabled
-              ? 'Notifications are enabled'
-              : 'Notifications are NOT enabled')),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: const Text('OK'),
-            ),
-          ],
-        ));
+              content: Text(areEnabled == null
+                  ? 'ERROR: received null'
+                  : (areEnabled
+                      ? 'Notifications are enabled'
+                      : 'Notifications are NOT enabled')),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('OK'),
+                ),
+              ],
+            ));
   }
 
   Future<void> _deleteNotificationChannel() async {
@@ -2874,7 +2882,8 @@ Future<void> _showLinuxNotificationWithByteDataIcon() async {
         data: iconBytes,
         width: iconData.width,
         height: iconData.height,
-        channels: 4, // The icon has an alpha channel
+        channels: 4,
+        // The icon has an alpha channel
         hasAlpha: true,
       ),
     ),

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -821,6 +821,10 @@ class _HomePageState extends State<HomePage> {
                       style: TextStyle(fontWeight: FontWeight.bold),
                     ),
                     PaddedElevatedButton(
+                      buttonText: 'Check permissions',
+                      onPressed: _checkNotificationsOnCupertino,
+                    ),
+                    PaddedElevatedButton(
                       buttonText: 'Request permission',
                       onPressed: _requestPermissions,
                     ),
@@ -2476,6 +2480,34 @@ class _HomePageState extends State<HomePage> {
                 ),
               ],
             ));
+  }
+
+  Future<void> _checkNotificationsOnCupertino() async {
+    final bool? areEnabled = await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.checkPermissions(
+          sound: true,
+          alert: true,
+          badge: true,
+        );
+    await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          content: Text(areEnabled == null
+              ? 'ERROR: received null'
+              : (areEnabled
+              ? 'Notifications are enabled'
+              : 'Notifications are NOT enabled')),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        ));
   }
 
   Future<void> _deleteNotificationChannel() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2483,30 +2483,29 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _checkNotificationsOnCupertino() async {
-    final bool? areEnabled = await flutterLocalNotificationsPlugin
-            .resolvePlatformSpecificImplementation<
-                IOSFlutterLocalNotificationsPlugin>()
-            ?.checkPermissions(
-              sound: true,
-              alert: true,
-              badge: true,
-            ) ??
+    final NotificationsEnabledOptions? isEnabled =
         await flutterLocalNotificationsPlugin
-            .resolvePlatformSpecificImplementation<
-                MacOSFlutterLocalNotificationsPlugin>()
-            ?.checkPermissions(
-              sound: true,
-              alert: true,
-              badge: true,
-            );
+                .resolvePlatformSpecificImplementation<
+                    IOSFlutterLocalNotificationsPlugin>()
+                ?.checkPermissions() ??
+            await flutterLocalNotificationsPlugin
+                .resolvePlatformSpecificImplementation<
+                    MacOSFlutterLocalNotificationsPlugin>()
+                ?.checkPermissions();
+    final String isEnabledString = isEnabled == null
+        ? 'ERROR: received null'
+        : '''
+    isEnabled: ${isEnabled.isEnabled}
+    isSoundEnabled: ${isEnabled.isSoundEnabled}
+    isAlertEnabled: ${isEnabled.isAlertEnabled}
+    isBadgeEnabled: ${isEnabled.isBadgeEnabled}
+    isProvisionalEnabled: ${isEnabled.isProvisionalEnabled}
+    isCriticalEnabled: ${isEnabled.isCriticalEnabled}
+    ''';
     await showDialog<void>(
         context: context,
         builder: (BuildContext context) => AlertDialog(
-              content: Text(areEnabled == null
-                  ? 'ERROR: received null'
-                  : (areEnabled
-                      ? 'Notifications are enabled'
-                      : 'Notifications are NOT enabled')),
+              content: Text(isEnabledString),
               actions: <Widget>[
                 TextButton(
                   onPressed: () {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -592,6 +592,12 @@ static FlutterError *getFlutterError(NSError *error) {
         [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
             BOOL isEnabled = settings.authorizationStatus == UNAuthorizationStatusAuthorized;
             
+            if(@available(iOS 12.0, *)) {
+                if(provisionalPermission) {
+                    isEnabled = settings.authorizationStatus == UNAuthorizationStatusProvisional;
+                }
+            }
+            
             if(soundPermission) {
                 isEnabled = isEnabled && settings.soundSetting == UNNotificationSettingEnabled;
             }
@@ -602,15 +608,10 @@ static FlutterError *getFlutterError(NSError *error) {
                 isEnabled = isEnabled && settings.badgeSetting == UNNotificationSettingEnabled;
             }
             if(@available(iOS 12.0, *)) {
-                if(provisionalPermission) {
-                    isEnabled = isEnabled && settings.authorizationStatus == UNAuthorizationOptionProvisional;
-                }
-                
                 if(criticalPermission) {
                     isEnabled = isEnabled && settings.criticalAlertSetting == UNNotificationSettingEnabled;
                 }
             }
-            
             result(@(isEnabled));
         }];
     } else {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -97,12 +97,12 @@ NSString *const GET_ACTIVE_NOTIFICATIONS_ERROR_MESSAGE =
 NSString *const PRESENTATION_OPTIONS_USER_DEFAULTS =
     @"flutter_local_notifications_presentation_options";
 
-NSString *const CHECK_ENABLED = @"isEnabled";
-NSString *const CHECK_SOUND_ENABLED = @"isSoundEnabled";
-NSString *const CHECK_ALERT_ENABLED = @"isAlertEnabled";
-NSString *const CHECK_BADGE_ENABLED = @"isBadgeEnabled";
-NSString *const CHECK_PROVISIONAL_ENABLED = @"isProvisionalEnabled";
-NSString *const CHECK_CRITICAL_ENABLED = @"isCriticalEnabled";
+NSString *const IS_NOTIFICATIONS_ENABLED = @"isEnabled";
+NSString *const IS_SOUND_ENABLED = @"isSoundEnabled";
+NSString *const IS_ALERT_ENABLED = @"isAlertEnabled";
+NSString *const IS_BADGE_ENABLED = @"isBadgeEnabled";
+NSString *const IS_PROVISIONAL_ENABLED = @"isProvisionalEnabled";
+NSString *const IS_CRITICAL_ENABLED = @"isCriticalEnabled";
 
 typedef NS_ENUM(NSInteger, RepeatInterval) {
   EveryMinute,
@@ -576,12 +576,12 @@ static FlutterError *getFlutterError(NSError *error) {
             }
             
             NSDictionary *dict = @{
-                CHECK_ENABLED: @(isEnabled),
-                CHECK_SOUND_ENABLED: @(isSoundEnabled),
-                CHECK_ALERT_ENABLED: @(isAlertEnabled),
-                CHECK_BADGE_ENABLED: @(isBadgeEnabled),
-                CHECK_PROVISIONAL_ENABLED: @(isProvisionalEnabled),
-                CHECK_CRITICAL_ENABLED: @(isCriticalEnabled),
+                IS_NOTIFICATIONS_ENABLED: @(isEnabled),
+                IS_SOUND_ENABLED: @(isSoundEnabled),
+                IS_ALERT_ENABLED: @(isAlertEnabled),
+                IS_BADGE_ENABLED: @(isBadgeEnabled),
+                IS_PROVISIONAL_ENABLED: @(isProvisionalEnabled),
+                IS_CRITICAL_ENABLED: @(isCriticalEnabled),
             };
             
             result(dict);
@@ -593,12 +593,12 @@ static FlutterError *getFlutterError(NSError *error) {
         
         if(settings == nil) {
             result(@{
-                CHECK_ENABLED: @NO,
-                CHECK_SOUND_ENABLED: @NO,
-                CHECK_ALERT_ENABLED: @NO,
-                CHECK_BADGE_ENABLED: @NO,
-                CHECK_PROVISIONAL_ENABLED: @NO,
-                CHECK_CRITICAL_ENABLED: @NO,
+                IS_NOTIFICATIONS_ENABLED: @NO,
+                IS_SOUND_ENABLED: @NO,
+                IS_ALERT_ENABLED: @NO,
+                IS_BADGE_ENABLED: @NO,
+                IS_PROVISIONAL_ENABLED: @NO,
+                IS_CRITICAL_ENABLED: @NO,
             });
             return;
         }
@@ -611,12 +611,12 @@ static FlutterError *getFlutterError(NSError *error) {
         BOOL isBadgeEnabled = types & UIUserNotificationTypeBadge;
         
         NSDictionary *dict = @{
-            CHECK_ENABLED: @(isEnabled),
-            CHECK_SOUND_ENABLED: @(isSoundEnabled),
-            CHECK_ALERT_ENABLED: @(isAlertEnabled),
-            CHECK_BADGE_ENABLED: @(isBadgeEnabled),
-            CHECK_PROVISIONAL_ENABLED: @NO,
-            CHECK_CRITICAL_ENABLED: @NO,
+            IS_NOTIFICATIONS_ENABLED: @(isEnabled),
+            IS_SOUND_ENABLED: @(isSoundEnabled),
+            IS_ALERT_ENABLED: @(isAlertEnabled),
+            IS_BADGE_ENABLED: @(isBadgeEnabled),
+            IS_PROVISIONAL_ENABLED: @NO,
+            IS_CRITICAL_ENABLED: @NO,
         };
         
         result(dict);

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -35,6 +35,7 @@ NSString *const CALLBACK_CHANNEL =
 NSString *const ON_NOTIFICATION_METHOD = @"onNotification";
 NSString *const DID_RECEIVE_LOCAL_NOTIFICATION = @"didReceiveLocalNotification";
 NSString *const REQUEST_PERMISSIONS_METHOD = @"requestPermissions";
+NSString *const CHECK_PERMISSIONS_METHOD = @"checkPermissions";
 
 NSString *const DAY = @"day";
 
@@ -170,6 +171,8 @@ static FlutterError *getFlutterError(NSError *error) {
     [self periodicallyShow:call.arguments result:result];
   } else if ([REQUEST_PERMISSIONS_METHOD isEqualToString:call.method]) {
     [self requestPermissions:call.arguments result:result];
+  } else if ([CHECK_PERMISSIONS_METHOD isEqualToString:call.method]) {
+    [self checkPermissions:call.arguments result:result];
   } else if ([CANCEL_METHOD isEqualToString:call.method]) {
     [self cancel:((NSNumber *)call.arguments) result:result];
   } else if ([CANCEL_ALL_METHOD isEqualToString:call.method]) {

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -614,6 +614,31 @@ static FlutterError *getFlutterError(NSError *error) {
             result(@(isEnabled));
         }];
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        UIUserNotificationSettings *settings = UIApplication.sharedApplication.currentUserNotificationSettings;
+        
+        if(settings == nil) {
+            result(@NO);
+            return;
+        }
+        
+        UIUserNotificationType types = settings.types;
+        
+        BOOL isEnabled = types != UIUserNotificationTypeNone;
+        
+        if(soundPermission) {
+            isEnabled = isEnabled && (types & UIUserNotificationTypeSound);
+        }
+        if(alertPermission) {
+            isEnabled = isEnabled && (types & UIUserNotificationTypeAlert);
+        }
+        if(badgePermission) {
+            isEnabled = isEnabled && (types & UIUserNotificationTypeBadge);
+        }
+        
+        result(@(isEnabled));
+#pragma clang diagnostic pop
     }
 }
 

--- a/flutter_local_notifications/lib/flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/flutter_local_notifications.dart
@@ -42,6 +42,7 @@ export 'src/platform_specifics/darwin/notification_attachment.dart';
 export 'src/platform_specifics/darwin/notification_category.dart';
 export 'src/platform_specifics/darwin/notification_category_option.dart';
 export 'src/platform_specifics/darwin/notification_details.dart';
+export 'src/platform_specifics/darwin/notification_enabled_options.dart';
 export 'src/platform_specifics/ios/enums.dart';
 export 'src/typedefs.dart';
 export 'src/types.dart';

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -617,20 +617,26 @@ class IOSFlutterLocalNotificationsPlugin
         'critical': critical,
       });
 
-  /// Returns whether the app can post notifications.
+  /// Returns whether the app can post notifications and what kind of.
   ///
-  /// Arguments can be used for check specific notifications type.
-  Future<NotificationsEnabledOptions> checkPermissions() =>
+  /// See [NotificationsEnabledOptions] for more info.
+  Future<NotificationsEnabledOptions?> checkPermissions() =>
       _channel.invokeMethod<Map<dynamic, dynamic>?>('checkPermissions').then(
-            (Map<dynamic, dynamic>? dict) => NotificationsEnabledOptions(
-              isEnabled: dict?['isEnabled'] ?? false,
-              isAlertEnabled: dict?['isAlertEnabled'] ?? false,
-              isBadgeEnabled: dict?['isBadgeEnabled'] ?? false,
-              isSoundEnabled: dict?['isSoundEnabled'] ?? false,
-              isProvisionalEnabled: dict?['isProvisionalEnabled'] ?? false,
-              isCriticalEnabled: dict?['isCriticalEnabled'] ?? false,
-            ),
+        (Map<dynamic, dynamic>? dict) {
+          if (dict == null) {
+            return null;
+          }
+
+          return NotificationsEnabledOptions(
+            isEnabled: dict['isEnabled'] ?? false,
+            isAlertEnabled: dict['isAlertEnabled'] ?? false,
+            isBadgeEnabled: dict['isBadgeEnabled'] ?? false,
+            isSoundEnabled: dict['isSoundEnabled'] ?? false,
+            isProvisionalEnabled: dict['isProvisionalEnabled'] ?? false,
+            isCriticalEnabled: dict['isCriticalEnabled'] ?? false,
           );
+        },
+      );
 
   /// Schedules a notification to be shown at the specified time in the
   /// future in a specific time zone.
@@ -801,22 +807,24 @@ class MacOSFlutterLocalNotificationsPlugin
         'critical': critical,
       });
 
-  /// Returns whether the app can post notifications.
+  /// Returns whether the app can post notifications and what kind of.
   ///
-  /// Arguments can be used for check specific notifications type.
-  Future<bool?> checkPermissions({
-    bool sound = false,
-    bool alert = false,
-    bool badge = false,
-    bool provisional = false,
-    bool critical = false,
-  }) =>
-      _channel.invokeMethod<bool?>('checkPermissions', <String, bool>{
-        'sound': sound,
-        'alert': alert,
-        'badge': badge,
-        'provisional': provisional,
-        'critical': critical,
+  /// See [NotificationsEnabledOptions] for more info.
+  Future<NotificationsEnabledOptions?> checkPermissions() => _channel
+          .invokeMethod<Map<dynamic, dynamic>>('checkPermissions')
+          .then((Map<dynamic, dynamic>? dict) {
+        if (dict == null) {
+          return null;
+        }
+
+        return NotificationsEnabledOptions(
+          isEnabled: dict['isEnabled'] ?? false,
+          isAlertEnabled: dict['isAlertEnabled'] ?? false,
+          isBadgeEnabled: dict['isBadgeEnabled'] ?? false,
+          isSoundEnabled: dict['isSoundEnabled'] ?? false,
+          isProvisionalEnabled: dict['isProvisionalEnabled'] ?? false,
+          isCriticalEnabled: dict['isCriticalEnabled'] ?? false,
+        );
       });
 
   /// Schedules a notification to be shown at the specified date and time

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -803,6 +803,24 @@ class MacOSFlutterLocalNotificationsPlugin
         'critical': critical,
       });
 
+  /// Returns whether the app can post notifications.
+  ///
+  /// Arguments can be used for check specific notifications type.
+  Future<bool?> checkPermissions({
+    bool sound = false,
+    bool alert = false,
+    bool badge = false,
+    bool provisional = false,
+    bool critical = false,
+  }) =>
+      _channel.invokeMethod<bool?>('checkPermissions', <String, bool>{
+        'sound': sound,
+        'alert': alert,
+        'badge': badge,
+        'provisional': provisional,
+        'critical': critical,
+      });
+
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
   Future<void> zonedSchedule(

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -616,6 +616,24 @@ class IOSFlutterLocalNotificationsPlugin
         'critical': critical,
       });
 
+  /// Returns whether the app can post notifications.
+  ///
+  /// Arguments can be used for check specific notifications type.
+  Future<bool?> checkPermissions({
+    bool sound = false,
+    bool alert = false,
+    bool badge = false,
+    bool provisional = false,
+    bool critical = false,
+  }) =>
+      _channel.invokeMethod<bool?>('checkPermissions', <String, bool>{
+        'sound': sound,
+        'alert': alert,
+        'badge': badge,
+        'provisional': provisional,
+        'critical': critical,
+      });
+
   /// Schedules a notification to be shown at the specified time in the
   /// future in a specific time zone.
   ///

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -23,6 +23,7 @@ import 'platform_specifics/android/styles/messaging_style_information.dart';
 import 'platform_specifics/darwin/initialization_settings.dart';
 import 'platform_specifics/darwin/mappers.dart';
 import 'platform_specifics/darwin/notification_details.dart';
+import 'platform_specifics/darwin/notification_enabled_options.dart';
 import 'platform_specifics/ios/enums.dart';
 import 'typedefs.dart';
 import 'types.dart';
@@ -619,20 +620,17 @@ class IOSFlutterLocalNotificationsPlugin
   /// Returns whether the app can post notifications.
   ///
   /// Arguments can be used for check specific notifications type.
-  Future<bool?> checkPermissions({
-    bool sound = false,
-    bool alert = false,
-    bool badge = false,
-    bool provisional = false,
-    bool critical = false,
-  }) =>
-      _channel.invokeMethod<bool?>('checkPermissions', <String, bool>{
-        'sound': sound,
-        'alert': alert,
-        'badge': badge,
-        'provisional': provisional,
-        'critical': critical,
-      });
+  Future<NotificationsEnabledOptions> checkPermissions() =>
+      _channel.invokeMethod<Map<dynamic, dynamic>?>('checkPermissions').then(
+            (Map<dynamic, dynamic>? dict) => NotificationsEnabledOptions(
+              isEnabled: dict?['isEnabled'] ?? false,
+              isAlertEnabled: dict?['isAlertEnabled'] ?? false,
+              isBadgeEnabled: dict?['isBadgeEnabled'] ?? false,
+              isSoundEnabled: dict?['isSoundEnabled'] ?? false,
+              isProvisionalEnabled: dict?['isProvisionalEnabled'] ?? false,
+              isCriticalEnabled: dict?['isCriticalEnabled'] ?? false,
+            ),
+          );
 
   /// Schedules a notification to be shown at the specified time in the
   /// future in a specific time zone.

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_enabled_options.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_enabled_options.dart
@@ -1,0 +1,17 @@
+class NotificationsEnabledOptions {
+  const NotificationsEnabledOptions({
+    required this.isEnabled,
+    required this.isSoundEnabled,
+    required this.isAlertEnabled,
+    required this.isBadgeEnabled,
+    required this.isProvisionalEnabled,
+    required this.isCriticalEnabled,
+  });
+
+  final bool isEnabled;
+  final bool isSoundEnabled;
+  final bool isAlertEnabled;
+  final bool isBadgeEnabled;
+  final bool isProvisionalEnabled;
+  final bool isCriticalEnabled;
+}

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_enabled_options.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_enabled_options.dart
@@ -1,4 +1,8 @@
+/// Data class that represent current state of notification options.
+///
+/// Used for Darwin systems, like iOS and macOS.
 class NotificationsEnabledOptions {
+  /// Constructs an instance of [NotificationsEnabledOptions]
   const NotificationsEnabledOptions({
     required this.isEnabled,
     required this.isSoundEnabled,
@@ -8,10 +12,25 @@ class NotificationsEnabledOptions {
     required this.isCriticalEnabled,
   });
 
+  /// Whenever notifications are enabled.
+  ///
+  /// Can be either [isEnabled] or [isProvisionalEnabled].
   final bool isEnabled;
+
+  /// Whenever sound notifications are enabled.
   final bool isSoundEnabled;
+
+  /// Whenever alert notifications are enabled.
   final bool isAlertEnabled;
+
+  /// Whenever badge notifications are enabled.
   final bool isBadgeEnabled;
+
+  /// Whenever provisional notifications are enabled.
+  ///
+  /// Can be either [isEnabled] or [isProvisionalEnabled].
   final bool isProvisionalEnabled;
+
+  /// Whenever critical notifications are enabled.
   final bool isCriticalEnabled;
 }

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -47,12 +47,12 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         static let interruptionLevel = "interruptionLevel"
         static let actionId = "actionId"
         static let notificationResponseType = "notificationResponseType"
-        static let checkEnabled = "isEnabled"
-        static let checkSoundEnabled = "isSoundEnabled"
-        static let checkAlertEnabled = "isAlertEnabled"
-        static let checkBadgeEnabled = "isBadgeEnabled"
-        static let checkProvisionalEnabled = "isProvisionalEnabled"
-        static let checkCriticalEnabled = "isCriticalEnabled"
+        static let isNotificationsEnabled = "isEnabled"
+        static let isSoundEnabled = "isSoundEnabled"
+        static let isAlertEnabled = "isAlertEnabled"
+        static let isBadgeEnabled = "isBadgeEnabled"
+        static let isProvisionalEnabled = "isProvisionalEnabled"
+        static let isCriticalEnabled = "isCriticalEnabled"
     }
 
     struct ErrorMessages {
@@ -678,12 +678,12 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         if #available(macOS 10.14, *) {
             UNUserNotificationCenter.current().getNotificationSettings { settings in
                 let dict = [
-                    MethodCallArguments.checkEnabled: settings.authorizationStatus == .authorized,
-                    MethodCallArguments.checkSoundEnabled: settings.soundSetting == .enabled,
-                    MethodCallArguments.checkAlertEnabled: settings.alertSetting == .enabled,
-                    MethodCallArguments.checkBadgeEnabled: settings.badgeSetting == .enabled,
-                    MethodCallArguments.checkProvisionalEnabled: settings.authorizationStatus == .provisional,
-                    MethodCallArguments.checkCriticalEnabled: settings.criticalAlertSetting == .enabled,
+                    MethodCallArguments.isNotificationsEnabled: settings.authorizationStatus == .authorized,
+                    MethodCallArguments.isSoundEnabled: settings.soundSetting == .enabled,
+                    MethodCallArguments.isAlertEnabled: settings.alertSetting == .enabled,
+                    MethodCallArguments.isBadgeEnabled: settings.badgeSetting == .enabled,
+                    MethodCallArguments.isProvisionalEnabled: settings.authorizationStatus == .provisional,
+                    MethodCallArguments.isCriticalEnabled: settings.criticalAlertSetting == .enabled,
                 ]
 
                 result(dict)

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -686,7 +686,9 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     @available(macOS 10.14, *)
     func checkPermissionsImpl(soundPermission: Bool, alertPermission: Bool, badgePermission: Bool, provisionalPermission: Bool, criticalPermission: Bool, result: @escaping FlutterResult) {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
-            var isEnabled: Bool = settings.authorizationStatus == .authorized
+            var isEnabled: Bool = provisionalPermission ? settings.authorizationStatus == .provisional : settings.authorizationStatus == .authorized
+            
+            print(isEnabled)
             
             if(soundPermission) {
                 isEnabled = isEnabled && settings.soundSetting == .enabled;
@@ -699,9 +701,6 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
             }
             if(criticalPermission) {
                 isEnabled = isEnabled && settings.criticalAlertSetting == .enabled;
-            }
-            if(provisionalPermission) {
-                isEnabled = isEnabled && settings.authorizationStatus == .provisional;
             }
             
             result(isEnabled)

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -606,6 +606,45 @@ void main() {
         })
       ]);
     });
+
+    test('checkPermissions with default settings', () async {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin>()!
+          .checkPermissions();
+      expect(log, <Matcher>[
+        isMethodCall('checkPermissions', arguments: <String, Object?>{
+          'sound': false,
+          'badge': false,
+          'alert': false,
+          'provisional': false,
+          'critical': false,
+        })
+      ]);
+    });
+
+    test('checkPermissions with all settings requested', () async {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin>()!
+          .checkPermissions(
+        sound: true,
+        badge: true,
+        alert: true,
+        provisional: true,
+        critical: true,
+      );
+      expect(log, <Matcher>[
+        isMethodCall('checkPermissions', arguments: <String, Object>{
+          'sound': true,
+          'badge': true,
+          'alert': true,
+          'provisional': true,
+          'critical': true,
+        })
+      ]);
+    });
+
     test('cancel', () async {
       await flutterLocalNotificationsPlugin.cancel(1);
       expect(log, <Matcher>[isMethodCall('cancel', arguments: 1)]);

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -20,7 +20,7 @@ void main() {
     setUp(() {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
         log.add(methodCall);
         if (methodCall.method == 'pendingNotificationRequests') {
@@ -607,42 +607,12 @@ void main() {
       ]);
     });
 
-    test('checkPermissions with default settings', () async {
+    test('checkPermissions', () async {
       await flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
-          IOSFlutterLocalNotificationsPlugin>()!
+              IOSFlutterLocalNotificationsPlugin>()!
           .checkPermissions();
-      expect(log, <Matcher>[
-        isMethodCall('checkPermissions', arguments: <String, Object?>{
-          'sound': false,
-          'badge': false,
-          'alert': false,
-          'provisional': false,
-          'critical': false,
-        })
-      ]);
-    });
-
-    test('checkPermissions with all settings requested', () async {
-      await flutterLocalNotificationsPlugin
-          .resolvePlatformSpecificImplementation<
-          IOSFlutterLocalNotificationsPlugin>()!
-          .checkPermissions(
-        sound: true,
-        badge: true,
-        alert: true,
-        provisional: true,
-        critical: true,
-      );
-      expect(log, <Matcher>[
-        isMethodCall('checkPermissions', arguments: <String, Object>{
-          'sound': true,
-          'badge': true,
-          'alert': true,
-          'provisional': true,
-          'critical': true,
-        })
-      ]);
+      expect(log, <Matcher>[isMethodCall('checkPermissions', arguments: null)]);
     });
 
     test('cancel', () async {

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -19,7 +19,7 @@ void main() {
     setUp(() {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
         log.add(methodCall);
         if (methodCall.method == 'pendingNotificationRequests') {
@@ -523,41 +523,13 @@ void main() {
       ]);
     });
 
-    test('checkPermissions with default settings', () async {
+    test('checkPermissions', () async {
       await flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
           MacOSFlutterLocalNotificationsPlugin>()!
           .checkPermissions();
       expect(log, <Matcher>[
-        isMethodCall('checkPermissions', arguments: <String, Object?>{
-          'sound': false,
-          'badge': false,
-          'alert': false,
-          'provisional': false,
-          'critical': false,
-        })
-      ]);
-    });
-
-    test('checkPermissions with all settings requested', () async {
-      await flutterLocalNotificationsPlugin
-          .resolvePlatformSpecificImplementation<
-          MacOSFlutterLocalNotificationsPlugin>()!
-          .checkPermissions(
-        sound: true,
-        badge: true,
-        alert: true,
-        provisional: true,
-        critical: true,
-      );
-      expect(log, <Matcher>[
-        isMethodCall('checkPermissions', arguments: <String, Object>{
-          'sound': true,
-          'badge': true,
-          'alert': true,
-          'provisional': true,
-          'critical': true,
-        })
+        isMethodCall('checkPermissions', arguments: null)
       ]);
     });
 

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -522,6 +522,45 @@ void main() {
         })
       ]);
     });
+
+    test('checkPermissions with default settings', () async {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+          MacOSFlutterLocalNotificationsPlugin>()!
+          .checkPermissions();
+      expect(log, <Matcher>[
+        isMethodCall('checkPermissions', arguments: <String, Object?>{
+          'sound': false,
+          'badge': false,
+          'alert': false,
+          'provisional': false,
+          'critical': false,
+        })
+      ]);
+    });
+
+    test('checkPermissions with all settings requested', () async {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+          MacOSFlutterLocalNotificationsPlugin>()!
+          .checkPermissions(
+        sound: true,
+        badge: true,
+        alert: true,
+        provisional: true,
+        critical: true,
+      );
+      expect(log, <Matcher>[
+        isMethodCall('checkPermissions', arguments: <String, Object>{
+          'sound': true,
+          'badge': true,
+          'alert': true,
+          'provisional': true,
+          'critical': true,
+        })
+      ]);
+    });
+
     test('cancel', () async {
       await flutterLocalNotificationsPlugin.cancel(1);
       expect(log, <Matcher>[isMethodCall('cancel', arguments: 1)]);


### PR DESCRIPTION
With this PR we add ability to check notification permissions for both iOS and macOS.
We can check if notifications is just enabled or if there is some specific type is enabled (like alert, badge, etc).

---

For iOS we use `UNUserNotificationCenter` for version 10 or above and `UIApplication.sharedApplication.currentUserNotificationSettings` for 9 and less (with ignore of critical and provisional).

Both version was tested with iOS simulator.

---

For macOS we just use `UNUserNotificationCenter`.

---

In both OS we separately check for provisional, because there can be either authorized status or provisional.