### PR TITLE
[flutter_local_notifications] solves the expected behavior for 'didNotificationLaunchApp'

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -133,6 +133,7 @@ public class FlutterLocalNotificationsPlugin
   private static final String SELECT_FOREGROUND_NOTIFICATION_ACTION =
       "SELECT_FOREGROUND_NOTIFICATION";
   private static final String SCHEDULED_NOTIFICATIONS = "scheduled_notifications";
+  private static final String LAUNCHED_FROM_NOTIFICATION = "LAUNCHED_FROM_NOTIFICATION";
   private static final String INITIALIZE_METHOD = "initialize";
   private static final String GET_CALLBACK_HANDLE_METHOD = "getCallbackHandle";
   private static final String ARE_NOTIFICATIONS_ENABLED_METHOD = "areNotificationsEnabled";
@@ -1580,19 +1581,36 @@ public class FlutterLocalNotificationsPlugin
     Boolean notificationLaunchedApp = false;
     if (mainActivity != null) {
       Intent launchIntent = mainActivity.getIntent();
+
       notificationLaunchedApp =
-          launchIntent != null
-              && (SELECT_NOTIFICATION.equals(launchIntent.getAction())
-                  || SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(launchIntent.getAction()))
-              && !launchedActivityFromHistory(launchIntent);
+              isNotificationLaunchedApp(launchIntent);
+
       if (notificationLaunchedApp) {
         notificationAppLaunchDetails.put(
             "notificationResponse", extractNotificationResponseMap(launchIntent));
+        launchIntent.putExtra(LAUNCHED_FROM_NOTIFICATION, true);
+        mainActivity.setIntent(launchIntent);
       }
-    }
 
+    }
     notificationAppLaunchDetails.put(NOTIFICATION_LAUNCHED_APP, notificationLaunchedApp);
     result.success(notificationAppLaunchDetails);
+  }
+
+  private boolean isNotificationLaunchedApp(Intent launchIntent) {
+    Boolean isAlreadyLaunched = isAlreadyLaunched(launchIntent);
+    return launchIntent != null
+            && (SELECT_NOTIFICATION.equals(launchIntent.getAction())
+            || SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(launchIntent.getAction()))
+            && !launchedActivityFromHistory(launchIntent)
+            && !isAlreadyLaunched;
+  }
+
+  private Boolean isAlreadyLaunched(Intent intent) {
+    if(intent != null && intent.hasExtra(LAUNCHED_FROM_NOTIFICATION)) {
+      return intent.getBooleanExtra(LAUNCHED_FROM_NOTIFICATION, false);
+    }
+    return false;
   }
 
   private void initialize(MethodCall call, Result result) {


### PR DESCRIPTION
Condition added to avoid 'didNotificationLaunchApp=true' when opening app from recent apps list in Android.
Related to #1926
