### PR TITLE
[flutter_local_notifications] Rename Converters - conflict with another libraries

### DIFF
--- a/flutter_local_notifications/darwin/Classes/NotificationParser.h
+++ b/flutter_local_notifications/darwin/Classes/NotificationParser.h
@@ -1,5 +1,5 @@
 //
-//  Converters.h
+//  NotificationParser.h
 //  flutter_local_notifications
 //
 
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Converters : NSObject
+@interface NotificationParser : NSObject
 
 + (UNNotificationCategoryOptions)parseNotificationCategoryOptions:
     (NSArray *)options API_AVAILABLE(ios(10.0), macosx(10.14));

--- a/flutter_local_notifications/darwin/Classes/NotificationParser.m
+++ b/flutter_local_notifications/darwin/Classes/NotificationParser.m
@@ -1,6 +1,6 @@
-#import "Converters.h"
+#import "NotificationParser.h"
 
-@implementation Converters
+@implementation NotificationParser
 
 + (UNNotificationCategoryOptions)parseNotificationCategoryOptions:
     (NSArray *)options {

--- a/flutter_local_notifications/ios/Classes/Converters.h
+++ b/flutter_local_notifications/ios/Classes/Converters.h
@@ -1,1 +1,0 @@
-../../darwin/Classes/Converters.h

--- a/flutter_local_notifications/ios/Classes/Converters.m
+++ b/flutter_local_notifications/ios/Classes/Converters.m
@@ -1,1 +1,0 @@
-../../darwin/Classes/Converters.m

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -1,6 +1,6 @@
 #import "FlutterLocalNotificationsPlugin.h"
 #import "ActionEventSink.h"
-#import "Converters.h"
+#import "NotificationParser.h"
 #import "FlutterEngineManager.h"
 
 @implementation FlutterLocalNotificationsPlugin {
@@ -316,7 +316,7 @@ static FlutterError *getFlutterError(NSError *error) {
           NSString *identifier = action[@"identifier"];
           NSString *title = action[@"title"];
           UNNotificationActionOptions options =
-              [Converters parseNotificationActionOptions:action[@"options"]];
+              [NotificationParser parseNotificationActionOptions:action[@"options"]];
 
           if ((options & UNNotificationActionOptionForeground) != 0) {
             [foregroundActionIdentifiers addObject:identifier];
@@ -343,7 +343,7 @@ static FlutterError *getFlutterError(NSError *error) {
             categoryWithIdentifier:category[@"identifier"]
                            actions:newActions
                  intentIdentifiers:@[]
-                           options:[Converters parseNotificationCategoryOptions:
+                           options:[NotificationParser parseNotificationCategoryOptions:
                                                    category[@"options"]]];
 
         [notificationCategories addObject:notificationCategory];

--- a/flutter_local_notifications/ios/Classes/NotificationParser.h
+++ b/flutter_local_notifications/ios/Classes/NotificationParser.h
@@ -1,0 +1,1 @@
+../../darwin/Classes/NotificationParser.h

--- a/flutter_local_notifications/ios/Classes/NotificationParser.m
+++ b/flutter_local_notifications/ios/Classes/NotificationParser.m
@@ -1,0 +1,1 @@
+../../darwin/Classes/NotificationParser.m

--- a/flutter_local_notifications/macos/Classes/Converters.m
+++ b/flutter_local_notifications/macos/Classes/Converters.m
@@ -1,1 +1,0 @@
-../../darwin/Classes/Converters.m

--- a/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/Classes/FlutterLocalNotificationsPlugin.swift
@@ -266,7 +266,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                                 newActions.append(UNNotificationAction(
                                     identifier: identifier,
                                     title: title,
-                                    options: Converters.parseNotificationActionOptions(options)
+                                    options: NotificationParser.parseNotificationActionOptions(options)
                                 ))
                             } else if type == "text" {
                                 let buttonTitle = action["buttonTitle"] as! String
@@ -274,7 +274,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                                 newActions.append(UNTextInputNotificationAction(
                                     identifier: identifier,
                                     title: title,
-                                    options: Converters.parseNotificationActionOptions(options),
+                                    options: NotificationParser.parseNotificationActionOptions(options),
                                     textInputButtonTitle: buttonTitle,
                                     textInputPlaceholder: placeholder
                                 ))
@@ -288,7 +288,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                         intentIdentifiers: [],
                         hiddenPreviewsBodyPlaceholder: nil,
                         categorySummaryFormat: nil,
-                        options: Converters.parseNotificationCategoryOptions(category["options"] as! [NSNumber])
+                        options: NotificationParser.parseNotificationCategoryOptions(category["options"] as! [NSNumber])
                     )
 
                     notificationCategories.insert(notificationCategory)

--- a/flutter_local_notifications/macos/Classes/NotificationParser.h
+++ b/flutter_local_notifications/macos/Classes/NotificationParser.h
@@ -1,5 +1,5 @@
 //
-//  Converters.h
+//  NotificationParser.h
 //  flutter_local_notifications
 //
 
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Converters : NSObject
+@interface NotificationParser : NSObject
 
 + (UNNotificationCategoryOptions)parseNotificationCategoryOptions:
     (NSArray *)options API_AVAILABLE(ios(10.0), macos(10.14));

--- a/flutter_local_notifications/macos/Classes/NotificationParser.m
+++ b/flutter_local_notifications/macos/Classes/NotificationParser.m
@@ -1,0 +1,1 @@
+../../darwin/Classes/NotificationParser.m


### PR DESCRIPTION
Fix: https://github.com/MaikuB/flutter_local_notifications/issues/2160