### PR TITLE
[flutter_local_notifications] Add custom repeat interval - periodicallyShowWithDuration method

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [17.2.0]
+
+* [Android]][iOS][macOS] added `periodicallyShowWithDuration()` method that allows for having a notification periodically shown based on a specified duration. The duration will need to be at least a minute. Thanks to the PR from [Mateusz Łuczak](https://github.com/mateuszluczak1996)
+
 ## [17.1.2]
 
 * [Android] fixed issue [2318](https://github.com/MaikuB/flutter_local_notifications/issues/2318) where an exception could occur on calling the `getNotificationChannels()` method from the `AndroidFlutterLocalNotificationsPlugin` class. This happened when Android found that the audio attributes associated with the channel was null. The plugin will now coalesce the null value to indicate that the usage of the audio is for notifications as per https://developer.android.com/reference/android/media/AudioAttributes#USAGE_NOTIFICATION. On the Dart side, this would correspond to the [AudioAttributesUsage.notification](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/AudioAttributesUsage.html#notification) enum value

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -156,6 +156,7 @@ public class FlutterLocalNotificationsPlugin
   private static final String CANCEL_ALL_METHOD = "cancelAll";
   private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
   private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
+  private static final String PERIODICALLY_SHOW_WITH_DURATION = "periodicallyShowWithDuration";
   private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD =
       "getNotificationAppLaunchDetails";
   private static final String REQUEST_NOTIFICATIONS_PERMISSION_METHOD =
@@ -212,7 +213,7 @@ public class FlutterLocalNotificationsPlugin
     ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(context);
     for (NotificationDetails notificationDetails : scheduledNotifications) {
       try {
-        if (notificationDetails.repeatInterval != null) {
+        if (notificationDetails.repeatInterval != null || notificationDetails.repeatIntervalMilliseconds != null) {
           repeatNotification(context, notificationDetails, false);
         } else if (notificationDetails.timeZoneName != null) {
           zonedScheduleNotification(context, notificationDetails, false);
@@ -232,7 +233,7 @@ public class FlutterLocalNotificationsPlugin
         zonedScheduleNextNotification(context, notificationDetails);
       } else if (notificationDetails.matchDateTimeComponents != null) {
         zonedScheduleNextNotificationMatchingDateComponents(context, notificationDetails);
-      } else if (notificationDetails.repeatInterval != null) {
+      } else if (notificationDetails.repeatInterval != null || notificationDetails.repeatIntervalMilliseconds != null) {
         scheduleNextRepeatingNotification(context, notificationDetails);
       } else {
         removeNotificationFromCache(context, notificationDetails.id);
@@ -750,6 +751,12 @@ public class FlutterLocalNotificationsPlugin
 
   private static long calculateRepeatIntervalMilliseconds(NotificationDetails notificationDetails) {
     long repeatInterval = 0;
+
+    if (notificationDetails.repeatIntervalMilliseconds != null) {
+      repeatInterval = notificationDetails.repeatIntervalMilliseconds;
+      return repeatInterval;
+    }
+
     switch (notificationDetails.repeatInterval) {
       case EveryMinute:
         repeatInterval = 60000;
@@ -1433,6 +1440,9 @@ public class FlutterLocalNotificationsPlugin
             });
         break;
       case PERIODICALLY_SHOW_METHOD:
+        repeat(call, result);
+        break;
+      case PERIODICALLY_SHOW_WITH_DURATION:
         repeat(call, result);
         break;
       case CANCEL_METHOD:

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -30,6 +30,7 @@ public class NotificationDetails implements Serializable {
   private static final String MILLISECONDS_SINCE_EPOCH = "millisecondsSinceEpoch";
   private static final String CALLED_AT = "calledAt";
   private static final String REPEAT_INTERVAL = "repeatInterval";
+  private static final String REPEAT_INTERVAL_MILLISECONDS = "repeatIntervalMilliseconds";
   private static final String REPEAT_TIME = "repeatTime";
   private static final String PLATFORM_SPECIFICS = "platformSpecifics";
   private static final String AUTO_CANCEL = "autoCancel";
@@ -145,6 +146,7 @@ public class NotificationDetails implements Serializable {
   public NotificationStyle style;
   public StyleInformation styleInformation;
   public RepeatInterval repeatInterval;
+  public Integer repeatIntervalMilliseconds;
   public Time repeatTime;
   public Long millisecondsSinceEpoch;
   public Long calledAt;
@@ -225,6 +227,9 @@ public class NotificationDetails implements Serializable {
     if (arguments.containsKey(REPEAT_INTERVAL)) {
       notificationDetails.repeatInterval =
           RepeatInterval.values()[(Integer) arguments.get(REPEAT_INTERVAL)];
+    }
+    if (arguments.containsKey(REPEAT_INTERVAL_MILLISECONDS)) {
+      notificationDetails.repeatIntervalMilliseconds = (Integer) arguments.get(REPEAT_INTERVAL_MILLISECONDS);
     }
     if (arguments.containsKey(REPEAT_TIME)) {
       @SuppressWarnings("unchecked")

--- a/flutter_local_notifications/example/android/app/src/debug/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/debug/AndroidManifest.xml
@@ -4,7 +4,4 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 </manifest>

--- a/flutter_local_notifications/example/android/app/src/debug/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 </manifest>

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -424,7 +424,7 @@ class _HomePageState extends State<HomePage> {
                       },
                     ),
                     PaddedElevatedButton(
-                      buttonText: 'Repeat notification every 30 seconds',
+                      buttonText: 'Repeat notification every 5 minutes',
                       onPressed: () async {
                         await _repeatPeriodicallyWithDurationNotification();
                       },
@@ -1807,7 +1807,7 @@ class _HomePageState extends State<HomePage> {
       id++,
       'repeating period title',
       'repeating period body',
-      const Duration(seconds: 30),
+      const Duration(minutes: 5),
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
     );

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -424,6 +424,12 @@ class _HomePageState extends State<HomePage> {
                       },
                     ),
                     PaddedElevatedButton(
+                      buttonText: 'Repeat notification every 30 seconds',
+                      onPressed: () async {
+                        await _repeatPeriodicallyWithDurationNotification();
+                      },
+                    ),
+                    PaddedElevatedButton(
                       buttonText: 'Schedule daily 10:00:00 am notification in your '
                           'local time zone',
                       onPressed: () async {
@@ -1786,6 +1792,22 @@ class _HomePageState extends State<HomePage> {
       'repeating title',
       'repeating body',
       RepeatInterval.everyMinute,
+      notificationDetails,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+    );
+  }
+
+  Future<void> _repeatPeriodicallyWithDurationNotification() async {
+    const AndroidNotificationDetails androidNotificationDetails = AndroidNotificationDetails(
+        'repeating channel id', 'repeating channel name',
+        channelDescription: 'repeating description');
+    const NotificationDetails notificationDetails =
+    NotificationDetails(android: androidNotificationDetails);
+    await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
+      id++,
+      'repeating period title',
+      'repeating period body',
+      const Duration(seconds: 30),
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
     );

--- a/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m
@@ -22,6 +22,7 @@ NSString *const GET_CALLBACK_METHOD = @"getCallbackHandle";
 NSString *const SHOW_METHOD = @"show";
 NSString *const ZONED_SCHEDULE_METHOD = @"zonedSchedule";
 NSString *const PERIODICALLY_SHOW_METHOD = @"periodicallyShow";
+NSString *const PERIODICALLY_SHOW_WITH_DURATION_METHOD = @"periodicallyShowWithDuration";
 NSString *const CANCEL_METHOD = @"cancel";
 NSString *const CANCEL_ALL_METHOD = @"cancelAll";
 NSString *const PENDING_NOTIFICATIONS_REQUESTS_METHOD =
@@ -79,6 +80,7 @@ NSString *const PRESENT_LIST = @"presentList";
 NSString *const BADGE_NUMBER = @"badgeNumber";
 NSString *const MILLISECONDS_SINCE_EPOCH = @"millisecondsSinceEpoch";
 NSString *const REPEAT_INTERVAL = @"repeatInterval";
+NSString *const REPEAT_INTERVAL_MILLISECODNS = @"repeatIntervalMilliseconds";
 NSString *const SCHEDULED_DATE_TIME = @"scheduledDateTimeISO8601";
 NSString *const TIME_ZONE_NAME = @"timeZoneName";
 NSString *const MATCH_DATE_TIME_COMPONENTS = @"matchDateTimeComponents";
@@ -175,6 +177,8 @@ static FlutterError *getFlutterError(NSError *error) {
   } else if ([ZONED_SCHEDULE_METHOD isEqualToString:call.method]) {
     [self zonedSchedule:call.arguments result:result];
   } else if ([PERIODICALLY_SHOW_METHOD isEqualToString:call.method]) {
+    [self periodicallyShow:call.arguments result:result];
+  } else if ([PERIODICALLY_SHOW_WITH_DURATION_METHOD isEqualToString:call.method]) {
     [self periodicallyShow:call.arguments result:result];
   } else if ([REQUEST_PERMISSIONS_METHOD isEqualToString:call.method]) {
     [self requestPermissions:call.arguments result:result];
@@ -815,6 +819,11 @@ static FlutterError *getFlutterError(NSError *error) {
         [self buildStandardUILocalNotification:arguments];
 #pragma clang diagnostic pop
     NSTimeInterval timeInterval = 0;
+      if ([self containsKey:REPEAT_INTERVAL_MILLISECODNS forDictionary:arguments]) {
+          NSInteger repeatIntervalMilliseconds = [arguments[REPEAT_INTERVAL_MILLISECODNS] integerValue];
+          timeInterval = repeatIntervalMilliseconds / 1000.0;
+          notification.repeatInterval = NSCalendarUnitSecond;
+      }
     switch ([arguments[REPEAT_INTERVAL] integerValue]) {
     case EveryMinute:
       timeInterval = 60;
@@ -1096,6 +1105,12 @@ static FlutterError *getFlutterError(NSError *error) {
 
 - (UNTimeIntervalNotificationTrigger *)buildUserNotificationTimeIntervalTrigger:
     (id)arguments API_AVAILABLE(ios(10.0)) {
+    
+    if ([self containsKey:REPEAT_INTERVAL_MILLISECODNS forDictionary:arguments]) {
+        NSInteger repeatIntervalMilliseconds = [arguments[REPEAT_INTERVAL_MILLISECODNS] integerValue];
+        return [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:repeatIntervalMilliseconds / 1000.0
+                                                                  repeats:YES];
+    }
   switch ([arguments[REPEAT_INTERVAL] integerValue]) {
   case EveryMinute:
     return [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:60

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -340,7 +340,7 @@ class FlutterLocalNotificationsPlugin {
     required UILocalNotificationDateInterpretation
         uiLocalNotificationDateInterpretation,
     @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
-    bool androidAllowWhileIdle = false,
+        bool androidAllowWhileIdle = false,
     AndroidScheduleMode? androidScheduleMode,
     String? payload,
     DateTimeComponents? matchDateTimeComponents,
@@ -411,7 +411,7 @@ class FlutterLocalNotificationsPlugin {
     NotificationDetails notificationDetails, {
     String? payload,
     @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
-    bool androidAllowWhileIdle = false,
+        bool androidAllowWhileIdle = false,
     AndroidScheduleMode? androidScheduleMode,
   }) async {
     if (kIsWeb) {
@@ -448,18 +448,6 @@ class FlutterLocalNotificationsPlugin {
   /// the first time the notification will be an 5 minutes after the method
   /// has been called and then every 5 minutes after that.
   ///
-  /// If [androidAllowWhileIdle] is `false`, the Android `AlarmManager` APIs
-  /// are used to set a recurring inexact alarm that would present the
-  /// notification. This means that there may be delay in on when
-  /// notifications are displayed. If [androidAllowWhileIdle] is `true`, the
-  /// Android `AlarmManager` APIs are used to schedule a single notification
-  /// to be shown at the exact time even when the device is in a low-power idle
-  /// mode. After it is shown, the next one would be scheduled and this would
-  /// repeat. Note that this parameter has been deprecated and will removed in
-  /// future majorrelease in favour of the [androidScheduledMode] parameter that
-  /// provides the same functionality in addition to being able to schedule
-  /// notifications with inexact timings.
-  ///
   /// On Android, this will also require additional setup for the app,
   /// especially in the app's `AndroidManifest.xml` file. Please see check the
   /// readme for further details.
@@ -469,10 +457,8 @@ class FlutterLocalNotificationsPlugin {
     String? body,
     Duration repeatDurationInterval,
     NotificationDetails notificationDetails, {
+    AndroidScheduleMode androidScheduleMode = AndroidScheduleMode.exact,
     String? payload,
-    @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
-    bool androidAllowWhileIdle = false,
-    AndroidScheduleMode? androidScheduleMode,
   }) async {
     if (kIsWeb) {
       return;
@@ -484,8 +470,7 @@ class FlutterLocalNotificationsPlugin {
               id, title, body, repeatDurationInterval,
               notificationDetails: notificationDetails.android,
               payload: payload,
-              scheduleMode: _chooseScheduleMode(
-                  androidScheduleMode, androidAllowWhileIdle));
+              scheduleMode: androidScheduleMode);
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -441,7 +441,8 @@ class FlutterLocalNotificationsPlugin {
     }
   }
 
-  /// Periodically show a notification using the specified custom duration interval.
+  /// Periodically show a notification using the specified custom duration
+  /// interval.
   ///
   /// For example, specifying a 5 minutes repeat duration interval means
   /// the first time the notification will be an 5 minutes after the method
@@ -463,40 +464,44 @@ class FlutterLocalNotificationsPlugin {
   /// especially in the app's `AndroidManifest.xml` file. Please see check the
   /// readme for further details.
   Future<void> periodicallyShowWithDuration(
-      int id,
-      String? title,
-      String? body,
-      Duration repeatDurationInterval,
-      NotificationDetails notificationDetails, {
-        String? payload,
-        @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
-        bool androidAllowWhileIdle = false,
-        AndroidScheduleMode? androidScheduleMode,
-      }) async {
+    int id,
+    String? title,
+    String? body,
+    Duration repeatDurationInterval,
+    NotificationDetails notificationDetails, {
+    String? payload,
+    @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
+    bool androidAllowWhileIdle = false,
+    AndroidScheduleMode? androidScheduleMode,
+  }) async {
     if (kIsWeb) {
       return;
     }
     if (defaultTargetPlatform == TargetPlatform.android) {
       await resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>()
-          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
-          notificationDetails: notificationDetails.android,
-          payload: payload,
-          scheduleMode: _chooseScheduleMode(
-              androidScheduleMode, androidAllowWhileIdle));
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(
+              id, title, body, repeatDurationInterval,
+              notificationDetails: notificationDetails.android,
+              payload: payload,
+              scheduleMode: _chooseScheduleMode(
+                  androidScheduleMode, androidAllowWhileIdle));
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       await resolvePlatformSpecificImplementation<
-          IOSFlutterLocalNotificationsPlugin>()
-          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
-          notificationDetails: notificationDetails.iOS, payload: payload);
+              IOSFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(
+              id, title, body, repeatDurationInterval,
+              notificationDetails: notificationDetails.iOS, payload: payload);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       await resolvePlatformSpecificImplementation<
-          MacOSFlutterLocalNotificationsPlugin>()
-          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
-          notificationDetails: notificationDetails.macOS, payload: payload);
+              MacOSFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(
+              id, title, body, repeatDurationInterval,
+              notificationDetails: notificationDetails.macOS, payload: payload);
     } else {
       await FlutterLocalNotificationsPlatform.instance
-          .periodicallyShowWithDuration(id, title, body, repeatDurationInterval);
+          .periodicallyShowWithDuration(
+              id, title, body, repeatDurationInterval);
     }
   }
 

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -441,6 +441,65 @@ class FlutterLocalNotificationsPlugin {
     }
   }
 
+  /// Periodically show a notification using the specified interval.
+  ///
+  /// For example, specifying a hourly interval means the first time the
+  /// notification will be an hour after the method has been called and
+  /// then every hour after that.
+  ///
+  /// If [androidAllowWhileIdle] is `false`, the Android `AlarmManager` APIs
+  /// are used to set a recurring inexact alarm that would present the
+  /// notification. This means that there may be delay in on when
+  /// notifications are displayed. If [androidAllowWhileIdle] is `true`, the
+  /// Android `AlarmManager` APIs are used to schedule a single notification
+  /// to be shown at the exact time even when the device is in a low-power idle
+  /// mode. After it is shown, the next one would be scheduled and this would
+  /// repeat. Note that this parameter has been deprecated and will removed in
+  /// future majorrelease in favour of the [androidScheduledMode] parameter that
+  /// provides the same functionality in addition to being able to schedule
+  /// notifications with inexact timings.
+  ///
+  /// On Android, this will also require additional setup for the app,
+  /// especially in the app's `AndroidManifest.xml` file. Please see check the
+  /// readme for further details.
+  Future<void> periodicallyShowWithDuration(
+      int id,
+      String? title,
+      String? body,
+      Duration repeatDurationInterval,
+      NotificationDetails notificationDetails, {
+        String? payload,
+        @Deprecated('Deprecated in favor of the androidScheduleMode parameter')
+        bool androidAllowWhileIdle = false,
+        AndroidScheduleMode? androidScheduleMode,
+      }) async {
+    if (kIsWeb) {
+      return;
+    }
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      await resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
+          notificationDetails: notificationDetails.android,
+          payload: payload,
+          scheduleMode: _chooseScheduleMode(
+              androidScheduleMode, androidAllowWhileIdle));
+    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
+          notificationDetails: notificationDetails.iOS, payload: payload);
+    } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+      await resolvePlatformSpecificImplementation<
+          MacOSFlutterLocalNotificationsPlugin>()
+          ?.periodicallyShowWithDuration(id, title, body, repeatDurationInterval,
+          notificationDetails: notificationDetails.macOS, payload: payload);
+    } else {
+      await FlutterLocalNotificationsPlatform.instance
+          .periodicallyShowWithDuration(id, title, body, repeatDurationInterval);
+    }
+  }
+
   AndroidScheduleMode _chooseScheduleMode(
           AndroidScheduleMode? scheduleMode, bool allowWhileIdle) =>
       scheduleMode ??

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -441,11 +441,11 @@ class FlutterLocalNotificationsPlugin {
     }
   }
 
-  /// Periodically show a notification using the specified interval.
+  /// Periodically show a notification using the specified custom duration interval.
   ///
-  /// For example, specifying a hourly interval means the first time the
-  /// notification will be an hour after the method has been called and
-  /// then every hour after that.
+  /// For example, specifying a 5 minutes repeat duration interval means
+  /// the first time the notification will be an 5 minutes after the method
+  /// has been called and then every 5 minutes after that.
   ///
   /// If [androidAllowWhileIdle] is `false`, the Android `AlarmManager` APIs
   /// are used to set a recurring inexact alarm that would present the

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -346,6 +346,29 @@ class AndroidFlutterLocalNotificationsPlugin
     });
   }
 
+  @override
+  Future<void> periodicallyShowWithDuration(
+      int id,
+      String? title,
+      String? body,
+      Duration repeatDurationInterval, {
+        AndroidNotificationDetails? notificationDetails,
+        String? payload,
+        AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
+      }) async {
+    validateId(id);
+    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+      'id': id,
+      'title': title,
+      'body': body,
+      'calledAt': clock.now().millisecondsSinceEpoch,
+      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+      'platformSpecifics':
+      _buildPlatformSpecifics(notificationDetails, scheduleMode),
+      'payload': payload ?? '',
+    });
+  }
+
   Map<String, Object?> _buildPlatformSpecifics(
     AndroidNotificationDetails? notificationDetails,
     AndroidScheduleMode scheduleMode,
@@ -729,6 +752,27 @@ class IOSFlutterLocalNotificationsPlugin
     });
   }
 
+  @override
+  Future<void> periodicallyShowWithDuration(
+      int id,
+      String? title,
+      String? body,
+      Duration repeatDurationInterval, {
+        DarwinNotificationDetails? notificationDetails,
+        String? payload,
+      }) async {
+    validateId(id);
+    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+      'id': id,
+      'title': title,
+      'body': body,
+      'calledAt': clock.now().millisecondsSinceEpoch,
+      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+      'platformSpecifics': notificationDetails?.toMap(),
+      'payload': payload ?? ''
+    });
+  }
+
   Future<void> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case 'didReceiveNotificationResponse':
@@ -896,6 +940,27 @@ class MacOSFlutterLocalNotificationsPlugin
       'body': body,
       'calledAt': clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
+      'platformSpecifics': notificationDetails?.toMap(),
+      'payload': payload ?? ''
+    });
+  }
+
+  @override
+  Future<void> periodicallyShowWithDuration(
+      int id,
+      String? title,
+      String? body,
+      Duration repeatDurationInterval, {
+        DarwinNotificationDetails? notificationDetails,
+        String? payload,
+      }) async {
+    validateId(id);
+    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+      'id': id,
+      'title': title,
+      'body': body,
+      'calledAt': clock.now().millisecondsSinceEpoch,
+      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
     });

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -348,23 +348,24 @@ class AndroidFlutterLocalNotificationsPlugin
 
   @override
   Future<void> periodicallyShowWithDuration(
-      int id,
-      String? title,
-      String? body,
-      Duration repeatDurationInterval, {
-        AndroidNotificationDetails? notificationDetails,
-        String? payload,
-        AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
-      }) async {
+    int id,
+    String? title,
+    String? body,
+    Duration repeatDurationInterval, {
+    AndroidNotificationDetails? notificationDetails,
+    String? payload,
+    AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
+  }) async {
     validateId(id);
-    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+    await _channel
+        .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,
       'calledAt': clock.now().millisecondsSinceEpoch,
       'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics':
-      _buildPlatformSpecifics(notificationDetails, scheduleMode),
+          _buildPlatformSpecifics(notificationDetails, scheduleMode),
       'payload': payload ?? '',
     });
   }
@@ -754,15 +755,16 @@ class IOSFlutterLocalNotificationsPlugin
 
   @override
   Future<void> periodicallyShowWithDuration(
-      int id,
-      String? title,
-      String? body,
-      Duration repeatDurationInterval, {
-        DarwinNotificationDetails? notificationDetails,
-        String? payload,
-      }) async {
+    int id,
+    String? title,
+    String? body,
+    Duration repeatDurationInterval, {
+    DarwinNotificationDetails? notificationDetails,
+    String? payload,
+  }) async {
     validateId(id);
-    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+    await _channel
+        .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,
@@ -947,15 +949,16 @@ class MacOSFlutterLocalNotificationsPlugin
 
   @override
   Future<void> periodicallyShowWithDuration(
-      int id,
-      String? title,
-      String? body,
-      Duration repeatDurationInterval, {
-        DarwinNotificationDetails? notificationDetails,
-        String? payload,
-      }) async {
+    int id,
+    String? title,
+    String? body,
+    Duration repeatDurationInterval, {
+    DarwinNotificationDetails? notificationDetails,
+    String? payload,
+  }) async {
     validateId(id);
-    await _channel.invokeMethod('periodicallyShowWithDuration', <String, Object?>{
+    await _channel
+        .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -362,7 +362,7 @@ class AndroidFlutterLocalNotificationsPlugin
       'title': title,
       'body': body,
       'calledAt': clock.now().millisecondsSinceEpoch,
-      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+      'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics':
       _buildPlatformSpecifics(notificationDetails, scheduleMode),
       'payload': payload ?? '',
@@ -767,7 +767,7 @@ class IOSFlutterLocalNotificationsPlugin
       'title': title,
       'body': body,
       'calledAt': clock.now().millisecondsSinceEpoch,
-      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+      'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
     });
@@ -960,7 +960,7 @@ class MacOSFlutterLocalNotificationsPlugin
       'title': title,
       'body': body,
       'calledAt': clock.now().millisecondsSinceEpoch,
-      'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+      'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
     });

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -358,6 +358,7 @@ class AndroidFlutterLocalNotificationsPlugin
     AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
   }) async {
     validateId(id);
+    validateRepeatDurationInterval(repeatDurationInterval);
     await _channel
         .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,
@@ -769,6 +770,7 @@ class IOSFlutterLocalNotificationsPlugin
     String? payload,
   }) async {
     validateId(id);
+    validateRepeatDurationInterval(repeatDurationInterval);
     await _channel
         .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,
@@ -963,6 +965,7 @@ class MacOSFlutterLocalNotificationsPlugin
     String? payload,
   }) async {
     validateId(id);
+    validateRepeatDurationInterval(repeatDurationInterval);
     await _channel
         .invokeMethod('periodicallyShowWithDuration', <String, Object?>{
       'id': id,

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_local_notifications_linux: ^4.0.0
-  flutter_local_notifications_platform_interface: ^7.1.0
+  flutter_local_notifications_platform_interface: ^7.2.0
   timezone: ^0.9.0
 
 dev_dependencies:

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 17.1.2
+version: 17.2.0
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2068,7 +2068,7 @@ void main() {
                   'body': 'notification body',
                   'payload': '',
                   'calledAt': now.millisecondsSinceEpoch,
-                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
                   'platformSpecifics': <String, Object?>{
                     'scheduleMode': 'exact',
                     'icon': null,

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2029,10 +2029,9 @@ void main() {
       }
     });
 
-
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
-      final List<Duration> repeatDurationIntervals = [
+      final List<Duration> repeatDurationIntervals = <Duration>[
         const Duration(seconds: 30),
         const Duration(minutes: 15),
         const Duration(hours: 5),
@@ -2043,15 +2042,15 @@ void main() {
         test('$repeatDurationInterval', () async {
           await withClock(Clock.fixed(now), () async {
             const AndroidInitializationSettings androidInitializationSettings =
-            AndroidInitializationSettings('app_icon');
+                AndroidInitializationSettings('app_icon');
             const InitializationSettings initializationSettings =
-            InitializationSettings(android: androidInitializationSettings);
+                InitializationSettings(android: androidInitializationSettings);
             await flutterLocalNotificationsPlugin
                 .initialize(initializationSettings);
 
             const AndroidNotificationDetails androidNotificationDetails =
-            AndroidNotificationDetails('channelId', 'channelName',
-                channelDescription: 'channelDescription');
+                AndroidNotificationDetails('channelId', 'channelName',
+                    channelDescription: 'channelDescription');
             await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
               1,
               'notification title',
@@ -2062,72 +2061,74 @@ void main() {
 
             expect(
                 log.last,
-                isMethodCall('periodicallyShowWithDuration', arguments: <String, Object>{
-                  'id': 1,
-                  'title': 'notification title',
-                  'body': 'notification body',
-                  'payload': '',
-                  'calledAt': now.millisecondsSinceEpoch,
-                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
-                  'platformSpecifics': <String, Object?>{
-                    'scheduleMode': 'exact',
-                    'icon': null,
-                    'channelId': 'channelId',
-                    'channelName': 'channelName',
-                    'channelDescription': 'channelDescription',
-                    'channelShowBadge': true,
-                    'channelAction': AndroidNotificationChannelAction
-                        .createIfNotExists.index,
-                    'importance': Importance.defaultImportance.value,
-                    'priority': Priority.defaultPriority.value,
-                    'playSound': true,
-                    'enableVibration': true,
-                    'vibrationPattern': null,
-                    'groupKey': null,
-                    'setAsGroupSummary': false,
-                    'groupAlertBehavior': GroupAlertBehavior.all.index,
-                    'autoCancel': true,
-                    'ongoing': false,
-                    'silent': false,
-                    'colorAlpha': null,
-                    'colorRed': null,
-                    'colorGreen': null,
-                    'colorBlue': null,
-                    'onlyAlertOnce': false,
-                    'showWhen': true,
-                    'when': null,
-                    'usesChronometer': false,
-                    'chronometerCountDown': false,
-                    'showProgress': false,
-                    'maxProgress': 0,
-                    'progress': 0,
-                    'indeterminate': false,
-                    'enableLights': false,
-                    'ledColorAlpha': null,
-                    'ledColorRed': null,
-                    'ledColorGreen': null,
-                    'ledColorBlue': null,
-                    'ledOnMs': null,
-                    'ledOffMs': null,
-                    'ticker': null,
-                    'visibility': null,
-                    'timeoutAfter': null,
-                    'category': null,
-                    'additionalFlags': null,
-                    'fullScreenIntent': false,
-                    'shortcutId': null,
-                    'subText': null,
-                    'style': AndroidNotificationStyle.defaultStyle.index,
-                    'styleInformation': <String, Object>{
-                      'htmlFormatContent': false,
-                      'htmlFormatTitle': false,
-                    },
-                    'tag': null,
-                    'colorized': false,
-                    'number': null,
-                    'audioAttributesUsage': 5,
-                  },
-                }));
+                isMethodCall('periodicallyShowWithDuration',
+                    arguments: <String, Object>{
+                      'id': 1,
+                      'title': 'notification title',
+                      'body': 'notification body',
+                      'payload': '',
+                      'calledAt': now.millisecondsSinceEpoch,
+                      'repeatIntervalMilliseconds':
+                          repeatDurationInterval.inMilliseconds,
+                      'platformSpecifics': <String, Object?>{
+                        'scheduleMode': 'exact',
+                        'icon': null,
+                        'channelId': 'channelId',
+                        'channelName': 'channelName',
+                        'channelDescription': 'channelDescription',
+                        'channelShowBadge': true,
+                        'channelAction': AndroidNotificationChannelAction
+                            .createIfNotExists.index,
+                        'importance': Importance.defaultImportance.value,
+                        'priority': Priority.defaultPriority.value,
+                        'playSound': true,
+                        'enableVibration': true,
+                        'vibrationPattern': null,
+                        'groupKey': null,
+                        'setAsGroupSummary': false,
+                        'groupAlertBehavior': GroupAlertBehavior.all.index,
+                        'autoCancel': true,
+                        'ongoing': false,
+                        'silent': false,
+                        'colorAlpha': null,
+                        'colorRed': null,
+                        'colorGreen': null,
+                        'colorBlue': null,
+                        'onlyAlertOnce': false,
+                        'showWhen': true,
+                        'when': null,
+                        'usesChronometer': false,
+                        'chronometerCountDown': false,
+                        'showProgress': false,
+                        'maxProgress': 0,
+                        'progress': 0,
+                        'indeterminate': false,
+                        'enableLights': false,
+                        'ledColorAlpha': null,
+                        'ledColorRed': null,
+                        'ledColorGreen': null,
+                        'ledColorBlue': null,
+                        'ledOnMs': null,
+                        'ledOffMs': null,
+                        'ticker': null,
+                        'visibility': null,
+                        'timeoutAfter': null,
+                        'category': null,
+                        'additionalFlags': null,
+                        'fullScreenIntent': false,
+                        'shortcutId': null,
+                        'subText': null,
+                        'style': AndroidNotificationStyle.defaultStyle.index,
+                        'styleInformation': <String, Object>{
+                          'htmlFormatContent': false,
+                          'htmlFormatTitle': false,
+                        },
+                        'tag': null,
+                        'colorized': false,
+                        'number': null,
+                        'audioAttributesUsage': 5,
+                      },
+                    }));
           });
         });
       }

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2031,8 +2031,37 @@ void main() {
 
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
+
+      const Duration thirtySeconds = Duration(seconds: 30);
+      test('$thirtySeconds', () async {
+        await withClock(Clock.fixed(now), () async {
+          const AndroidInitializationSettings androidInitializationSettings =
+              AndroidInitializationSettings('app_icon');
+          const InitializationSettings initializationSettings =
+              InitializationSettings(android: androidInitializationSettings);
+          await flutterLocalNotificationsPlugin
+              .initialize(initializationSettings);
+
+          const AndroidNotificationDetails androidNotificationDetails =
+              AndroidNotificationDetails('channelId', 'channelName',
+                  channelDescription: 'channelDescription');
+
+          expect(
+              () async => await flutterLocalNotificationsPlugin
+                      .periodicallyShowWithDuration(
+                    1,
+                    'notification title',
+                    'notification body',
+                    thirtySeconds,
+                    const NotificationDetails(
+                        android: androidNotificationDetails),
+                  ),
+              throwsA(isA<ArgumentError>()));
+        });
+      });
+
       final List<Duration> repeatDurationIntervals = <Duration>[
-        const Duration(seconds: 30),
+        const Duration(minutes: 1),
         const Duration(minutes: 15),
         const Duration(hours: 5),
         const Duration(days: 30)

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2029,6 +2029,110 @@ void main() {
       }
     });
 
+
+    group('periodicallyShowWithDuration', () {
+      final DateTime now = DateTime(2023, 12, 29);
+      final List<Duration> repeatDurationIntervals = [
+        const Duration(seconds: 30),
+        const Duration(minutes: 15),
+        const Duration(hours: 5),
+        const Duration(days: 30)
+      ];
+
+      for (final Duration repeatDurationInterval in repeatDurationIntervals) {
+        test('$repeatDurationInterval', () async {
+          await withClock(Clock.fixed(now), () async {
+            const AndroidInitializationSettings androidInitializationSettings =
+            AndroidInitializationSettings('app_icon');
+            const InitializationSettings initializationSettings =
+            InitializationSettings(android: androidInitializationSettings);
+            await flutterLocalNotificationsPlugin
+                .initialize(initializationSettings);
+
+            const AndroidNotificationDetails androidNotificationDetails =
+            AndroidNotificationDetails('channelId', 'channelName',
+                channelDescription: 'channelDescription');
+            await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
+              1,
+              'notification title',
+              'notification body',
+              repeatDurationInterval,
+              const NotificationDetails(android: androidNotificationDetails),
+            );
+
+            expect(
+                log.last,
+                isMethodCall('periodicallyShowWithDuration', arguments: <String, Object>{
+                  'id': 1,
+                  'title': 'notification title',
+                  'body': 'notification body',
+                  'payload': '',
+                  'calledAt': now.millisecondsSinceEpoch,
+                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'platformSpecifics': <String, Object?>{
+                    'scheduleMode': 'exact',
+                    'icon': null,
+                    'channelId': 'channelId',
+                    'channelName': 'channelName',
+                    'channelDescription': 'channelDescription',
+                    'channelShowBadge': true,
+                    'channelAction': AndroidNotificationChannelAction
+                        .createIfNotExists.index,
+                    'importance': Importance.defaultImportance.value,
+                    'priority': Priority.defaultPriority.value,
+                    'playSound': true,
+                    'enableVibration': true,
+                    'vibrationPattern': null,
+                    'groupKey': null,
+                    'setAsGroupSummary': false,
+                    'groupAlertBehavior': GroupAlertBehavior.all.index,
+                    'autoCancel': true,
+                    'ongoing': false,
+                    'silent': false,
+                    'colorAlpha': null,
+                    'colorRed': null,
+                    'colorGreen': null,
+                    'colorBlue': null,
+                    'onlyAlertOnce': false,
+                    'showWhen': true,
+                    'when': null,
+                    'usesChronometer': false,
+                    'chronometerCountDown': false,
+                    'showProgress': false,
+                    'maxProgress': 0,
+                    'progress': 0,
+                    'indeterminate': false,
+                    'enableLights': false,
+                    'ledColorAlpha': null,
+                    'ledColorRed': null,
+                    'ledColorGreen': null,
+                    'ledColorBlue': null,
+                    'ledOnMs': null,
+                    'ledOffMs': null,
+                    'ticker': null,
+                    'visibility': null,
+                    'timeoutAfter': null,
+                    'category': null,
+                    'additionalFlags': null,
+                    'fullScreenIntent': false,
+                    'shortcutId': null,
+                    'subText': null,
+                    'style': AndroidNotificationStyle.defaultStyle.index,
+                    'styleInformation': <String, Object>{
+                      'htmlFormatContent': false,
+                      'htmlFormatTitle': false,
+                    },
+                    'tag': null,
+                    'colorized': false,
+                    'number': null,
+                    'audioAttributesUsage': 5,
+                  },
+                }));
+          });
+        });
+      }
+    });
+
     group('zonedSchedule', () {
       test('no repeat frequency', () async {
         const AndroidInitializationSettings androidInitializationSettings =

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -353,13 +353,54 @@ void main() {
 
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
+
+      const Duration thirtySeconds = Duration(seconds: 30);
+      test('$thirtySeconds', () async {
+        await withClock(Clock.fixed(now), () async {
+          const DarwinInitializationSettings iosInitializationSettings =
+              DarwinInitializationSettings();
+          const InitializationSettings initializationSettings =
+              InitializationSettings(iOS: iosInitializationSettings);
+          await flutterLocalNotificationsPlugin
+              .initialize(initializationSettings);
+
+          const NotificationDetails notificationDetails = NotificationDetails(
+            iOS: DarwinNotificationDetails(
+              presentAlert: true,
+              presentBadge: true,
+              presentSound: true,
+              presentBanner: true,
+              presentList: true,
+              sound: 'sound.mp3',
+              badgeNumber: 1,
+              attachments: <DarwinNotificationAttachment>[
+                DarwinNotificationAttachment(
+                  'video.mp4',
+                  identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                )
+              ],
+            ),
+          );
+
+          expect(
+              () async => await flutterLocalNotificationsPlugin
+                      .periodicallyShowWithDuration(
+                    1,
+                    'notification title',
+                    'notification body',
+                    thirtySeconds,
+                    notificationDetails,
+                  ),
+              throwsA(isA<ArgumentError>()));
+        });
+      });
+
       final List<Duration> repeatDurationIntervals = <Duration>[
-        const Duration(seconds: 30),
+        const Duration(minutes: 1),
         const Duration(minutes: 15),
         const Duration(hours: 5),
         const Duration(days: 30)
       ];
-
       for (final Duration repeatDurationInterval in repeatDurationIntervals) {
         test('$repeatDurationInterval', () async {
           await withClock(Clock.fixed(now), () async {

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -351,6 +351,91 @@ void main() {
       }
     });
 
+    group('periodicallyShowWithDuration', () {
+      final DateTime now = DateTime(2023, 12, 29);
+      final List<Duration> repeatDurationIntervals = [
+        const Duration(seconds: 30),
+        const Duration(minutes: 15),
+        const Duration(hours: 5),
+        const Duration(days: 30)
+      ];
+
+      for (final Duration repeatDurationInterval in repeatDurationIntervals) {
+        test('$repeatDurationInterval', () async {
+          await withClock(Clock.fixed(now), () async {
+            const DarwinInitializationSettings iosInitializationSettings =
+            DarwinInitializationSettings();
+            const InitializationSettings initializationSettings =
+            InitializationSettings(iOS: iosInitializationSettings);
+            await flutterLocalNotificationsPlugin
+                .initialize(initializationSettings);
+
+            const NotificationDetails notificationDetails = NotificationDetails(
+              iOS: DarwinNotificationDetails(
+                presentAlert: true,
+                presentBadge: true,
+                presentSound: true,
+                presentBanner: true,
+                presentList: true,
+                sound: 'sound.mp3',
+                badgeNumber: 1,
+                attachments: <DarwinNotificationAttachment>[
+                  DarwinNotificationAttachment(
+                    'video.mp4',
+                    identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                  )
+                ],
+              ),
+            );
+
+            await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
+              1,
+              'notification title',
+              'notification body',
+              repeatDurationInterval,
+              notificationDetails,
+            );
+
+            expect(
+              log.last,
+              isMethodCall(
+                'periodicallyShowWithDuration',
+                arguments: <String, Object>{
+                  'id': 1,
+                  'title': 'notification title',
+                  'body': 'notification body',
+                  'payload': '',
+                  'calledAt': now.millisecondsSinceEpoch,
+                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'platformSpecifics': <String, Object?>{
+                    'presentAlert': true,
+                    'presentBadge': true,
+                    'presentSound': true,
+                    'presentBanner': true,
+                    'presentList': true,
+                    'subtitle': null,
+                    'sound': 'sound.mp3',
+                    'badgeNumber': 1,
+                    'threadIdentifier': null,
+                    'attachments': <Map<String, Object?>>[
+                      <String, Object?>{
+                        'filePath': 'video.mp4',
+                        'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                        'hideThumbnail': null,
+                        'thumbnailClippingRect': null,
+                      }
+                    ],
+                    'categoryIdentifier': null,
+                    'interruptionLevel': null,
+                  },
+                },
+              ),
+            );
+          });
+        });
+      }
+    });
+
     group('zonedSchedule', () {
       test('no repeat frequency', () async {
         const DarwinInitializationSettings iosInitializationSettings =

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -406,7 +406,7 @@ void main() {
                   'body': 'notification body',
                   'payload': '',
                   'calledAt': now.millisecondsSinceEpoch,
-                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
                   'platformSpecifics': <String, Object?>{
                     'presentAlert': true,
                     'presentBadge': true,

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -353,7 +353,7 @@ void main() {
 
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
-      final List<Duration> repeatDurationIntervals = [
+      final List<Duration> repeatDurationIntervals = <Duration>[
         const Duration(seconds: 30),
         const Duration(minutes: 15),
         const Duration(hours: 5),
@@ -364,9 +364,9 @@ void main() {
         test('$repeatDurationInterval', () async {
           await withClock(Clock.fixed(now), () async {
             const DarwinInitializationSettings iosInitializationSettings =
-            DarwinInitializationSettings();
+                DarwinInitializationSettings();
             const InitializationSettings initializationSettings =
-            InitializationSettings(iOS: iosInitializationSettings);
+                InitializationSettings(iOS: iosInitializationSettings);
             await flutterLocalNotificationsPlugin
                 .initialize(initializationSettings);
 
@@ -406,7 +406,8 @@ void main() {
                   'body': 'notification body',
                   'payload': '',
                   'calledAt': now.millisecondsSinceEpoch,
-                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
+                  'repeatIntervalMilliseconds':
+                      repeatDurationInterval.inMilliseconds,
                   'platformSpecifics': <String, Object?>{
                     'presentAlert': true,
                     'presentBadge': true,

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -257,7 +257,7 @@ void main() {
 
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
-      final List<Duration> repeatDurationIntervals = [
+      final List<Duration> repeatDurationIntervals = <Duration>[
         const Duration(seconds: 30),
         const Duration(minutes: 15),
         const Duration(hours: 5),
@@ -268,9 +268,9 @@ void main() {
         test('$repeatDurationInterval', () async {
           await withClock(Clock.fixed(now), () async {
             const DarwinInitializationSettings macOSInitializationSettings =
-            DarwinInitializationSettings();
+                DarwinInitializationSettings();
             const InitializationSettings initializationSettings =
-            InitializationSettings(macOS: macOSInitializationSettings);
+                InitializationSettings(macOS: macOSInitializationSettings);
             await flutterLocalNotificationsPlugin
                 .initialize(initializationSettings);
 
@@ -302,35 +302,38 @@ void main() {
 
             expect(
                 log.last,
-                isMethodCall('periodicallyShowWithDuration', arguments: <String, Object>{
-                  'id': 1,
-                  'title': 'notification title',
-                  'body': 'notification body',
-                  'payload': '',
-                  'calledAt': now.millisecondsSinceEpoch,
-                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
-                  'platformSpecifics': <String, Object?>{
-                    'presentAlert': true,
-                    'presentBadge': true,
-                    'presentSound': true,
-                    'presentBanner': true,
-                    'presentList': true,
-                    'subtitle': null,
-                    'sound': 'sound.mp3',
-                    'badgeNumber': 1,
-                    'threadIdentifier': null,
-                    'attachments': <Map<String, Object?>>[
-                      <String, Object?>{
-                        'filePath': 'video.mp4',
-                        'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
-                        'hideThumbnail': null,
-                        'thumbnailClippingRect': null,
-                      }
-                    ],
-                    'categoryIdentifier': null,
-                    'interruptionLevel': null,
-                  },
-                }));
+                isMethodCall('periodicallyShowWithDuration',
+                    arguments: <String, Object>{
+                      'id': 1,
+                      'title': 'notification title',
+                      'body': 'notification body',
+                      'payload': '',
+                      'calledAt': now.millisecondsSinceEpoch,
+                      'repeatIntervalMilliseconds':
+                          repeatDurationInterval.inMilliseconds,
+                      'platformSpecifics': <String, Object?>{
+                        'presentAlert': true,
+                        'presentBadge': true,
+                        'presentSound': true,
+                        'presentBanner': true,
+                        'presentList': true,
+                        'subtitle': null,
+                        'sound': 'sound.mp3',
+                        'badgeNumber': 1,
+                        'threadIdentifier': null,
+                        'attachments': <Map<String, Object?>>[
+                          <String, Object?>{
+                            'filePath': 'video.mp4',
+                            'identifier':
+                                '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                            'hideThumbnail': null,
+                            'thumbnailClippingRect': null,
+                          }
+                        ],
+                        'categoryIdentifier': null,
+                        'interruptionLevel': null,
+                      },
+                    }));
           });
         });
       }

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -286,14 +286,6 @@ void main() {
             ),
           );
 
-          await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
-            1,
-            'notification title',
-            'notification body',
-            thirtySeconds,
-            notificationDetails,
-          );
-
           expect(
               () async => await flutterLocalNotificationsPlugin
                       .periodicallyShowWithDuration(

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -255,6 +255,87 @@ void main() {
       }
     });
 
+    group('periodicallyShowWithDuration', () {
+      final DateTime now = DateTime(2023, 12, 29);
+      final List<Duration> repeatDurationIntervals = [
+        const Duration(seconds: 30),
+        const Duration(minutes: 15),
+        const Duration(hours: 5),
+        const Duration(days: 30)
+      ];
+
+      for (final Duration repeatDurationInterval in repeatDurationIntervals) {
+        test('$repeatDurationInterval', () async {
+          await withClock(Clock.fixed(now), () async {
+            const DarwinInitializationSettings macOSInitializationSettings =
+            DarwinInitializationSettings();
+            const InitializationSettings initializationSettings =
+            InitializationSettings(macOS: macOSInitializationSettings);
+            await flutterLocalNotificationsPlugin
+                .initialize(initializationSettings);
+
+            const NotificationDetails notificationDetails = NotificationDetails(
+              macOS: DarwinNotificationDetails(
+                presentAlert: true,
+                presentBadge: true,
+                presentSound: true,
+                presentBanner: true,
+                presentList: true,
+                sound: 'sound.mp3',
+                badgeNumber: 1,
+                attachments: <DarwinNotificationAttachment>[
+                  DarwinNotificationAttachment(
+                    'video.mp4',
+                    identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                  )
+                ],
+              ),
+            );
+
+            await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
+              1,
+              'notification title',
+              'notification body',
+              repeatDurationInterval,
+              notificationDetails,
+            );
+
+            expect(
+                log.last,
+                isMethodCall('periodicallyShowWithDuration', arguments: <String, Object>{
+                  'id': 1,
+                  'title': 'notification title',
+                  'body': 'notification body',
+                  'payload': '',
+                  'calledAt': now.millisecondsSinceEpoch,
+                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'platformSpecifics': <String, Object?>{
+                    'presentAlert': true,
+                    'presentBadge': true,
+                    'presentSound': true,
+                    'presentBanner': true,
+                    'presentList': true,
+                    'subtitle': null,
+                    'sound': 'sound.mp3',
+                    'badgeNumber': 1,
+                    'threadIdentifier': null,
+                    'attachments': <Map<String, Object?>>[
+                      <String, Object?>{
+                        'filePath': 'video.mp4',
+                        'identifier': '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                        'hideThumbnail': null,
+                        'thumbnailClippingRect': null,
+                      }
+                    ],
+                    'categoryIdentifier': null,
+                    'interruptionLevel': null,
+                  },
+                }));
+          });
+        });
+      }
+    });
+
     group('zonedSchedule', () {
       test('no repeat frequency', () async {
         const DarwinInitializationSettings macOSInitializationSettings =

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -308,7 +308,7 @@ void main() {
                   'body': 'notification body',
                   'payload': '',
                   'calledAt': now.millisecondsSinceEpoch,
-                  'repeatDurationInterval': repeatDurationInterval.inMilliseconds,
+                  'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
                   'platformSpecifics': <String, Object?>{
                     'presentAlert': true,
                     'presentBadge': true,

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -257,8 +257,58 @@ void main() {
 
     group('periodicallyShowWithDuration', () {
       final DateTime now = DateTime(2023, 12, 29);
+
+      const Duration thirtySeconds = Duration(seconds: 30);
+      test('$thirtySeconds', () async {
+        await withClock(Clock.fixed(now), () async {
+          const DarwinInitializationSettings macOSInitializationSettings =
+              DarwinInitializationSettings();
+          const InitializationSettings initializationSettings =
+              InitializationSettings(macOS: macOSInitializationSettings);
+          await flutterLocalNotificationsPlugin
+              .initialize(initializationSettings);
+
+          const NotificationDetails notificationDetails = NotificationDetails(
+            macOS: DarwinNotificationDetails(
+              presentAlert: true,
+              presentBadge: true,
+              presentSound: true,
+              presentBanner: true,
+              presentList: true,
+              sound: 'sound.mp3',
+              badgeNumber: 1,
+              attachments: <DarwinNotificationAttachment>[
+                DarwinNotificationAttachment(
+                  'video.mp4',
+                  identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373',
+                )
+              ],
+            ),
+          );
+
+          await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
+            1,
+            'notification title',
+            'notification body',
+            thirtySeconds,
+            notificationDetails,
+          );
+
+          expect(
+              () async => await flutterLocalNotificationsPlugin
+                      .periodicallyShowWithDuration(
+                    1,
+                    'notification title',
+                    'notification body',
+                    thirtySeconds,
+                    notificationDetails,
+                  ),
+              throwsA(isA<ArgumentError>()));
+        });
+      });
+
       final List<Duration> repeatDurationIntervals = <Duration>[
-        const Duration(seconds: 30),
+        const Duration(minutes: 1),
         const Duration(minutes: 15),
         const Duration(hours: 5),
         const Duration(days: 30)

--- a/flutter_local_notifications_platform_interface/CHANGELOG.md
+++ b/flutter_local_notifications_platform_interface/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## [7.2.0]
+
+* Added `periodicallyShowWithDuration()` and corresponding `validateRepeatDurationInterval()` helper method to ensure duration is at least a minute
+
 ## [7.1.0]
 
 * [Android] `bigText` has added to `ActiveNotification` that allows getting information about the longer text associated with a notification displayed using the big text style. Thanks to the PR from [vulpeep](https://github.com/vulpeep)

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -50,6 +50,11 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('periodicallyShow() has not been implemented');
   }
 
+  Future<void> periodicallyShowWithDuration(
+      int id, String? title, String? body, Duration repeatDurationInterval) {
+    throw UnimplementedError('periodicallyShowWithDuration() has not been implemented');
+  }
+
   /// Cancel/remove the notification with the specified id.
   ///
   /// This applies to notifications that have been scheduled and those that

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -50,6 +50,10 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('periodicallyShow() has not been implemented');
   }
 
+  /// Periodically show a notification using the specified custom duration interval.
+  /// For example, specifying a 5 minutes repeat duration interval means
+  /// the first time the notification will be an 5 minutes after the method
+  /// has been called and then every 5 minutes after that.
   Future<void> periodicallyShowWithDuration(
       int id, String? title, String? body, Duration repeatDurationInterval) {
     throw UnimplementedError('periodicallyShowWithDuration() has not been implemented');

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -57,6 +57,8 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
   /// For example, specifying a 5 minutes repeat duration interval means
   /// the first time the notification will be an 5 minutes after the method
   /// has been called and then every 5 minutes after that.
+  ///
+  /// [repeatDurationInterval] must be at least one minute.
   Future<void> periodicallyShowWithDuration(
       int id, String? title, String? body, Duration repeatDurationInterval) {
     throw UnimplementedError(

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -42,6 +42,7 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
   }
 
   /// Periodically show a notification using the specified interval.
+  ///
   /// For example, specifying a hourly interval means the first time the
   /// notification will be an hour after the method has been called and then
   /// every hour after that.
@@ -50,16 +51,19 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('periodicallyShow() has not been implemented');
   }
 
-  /// Periodically show a notification using the specified custom duration interval.
+  /// Periodically show a notification using the specified custom duration
+  /// interval.
+  ///
   /// For example, specifying a 5 minutes repeat duration interval means
   /// the first time the notification will be an 5 minutes after the method
   /// has been called and then every 5 minutes after that.
   Future<void> periodicallyShowWithDuration(
       int id, String? title, String? body, Duration repeatDurationInterval) {
-    throw UnimplementedError('periodicallyShowWithDuration() has not been implemented');
+    throw UnimplementedError(
+        'periodicallyShowWithDuration() has not been implemented');
   }
 
-  /// Cancel/remove the notification with the specified id.
+  /// Cancels/removes the notification with the specified id.
   ///
   /// This applies to notifications that have been scheduled and those that
   /// have already been presented.

--- a/flutter_local_notifications_platform_interface/lib/src/helpers.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/helpers.dart
@@ -1,9 +1,22 @@
 /// Helper method for validating notification IDs.
+///
 /// Ensures IDs are valid 32-bit integers.
 void validateId(int id) {
   ArgumentError.checkNotNull(id, 'id');
   if (id > 0x7FFFFFFF || id < -0x80000000) {
     throw ArgumentError.value(id, 'id',
         'must fit within the size of a 32-bit integer i.e. in the range [-2^31, 2^31 - 1]'); // ignore: lines_longer_than_80_chars
+  }
+}
+
+/// Helper method for validation repeat interval duration used passed
+/// to periodicallyShowWithDuration().
+///
+/// Ensures the duration is at least one minute.
+void validateRepeatDurationInterval(Duration repeatDurationInterval) {
+  ArgumentError.checkNotNull(repeatDurationInterval, 'repeatDurationInterval');
+  if (repeatDurationInterval.inMinutes < 1) {
+    throw ArgumentError.value(repeatDurationInterval, 'repeatDurationInterval',
+        'must be at one minute or more');
   }
 }

--- a/flutter_local_notifications_platform_interface/pubspec.yaml
+++ b/flutter_local_notifications_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications_platform_interface
 description: A common platform interface for the flutter_local_notifications plugin.
-version: 7.1.0
+version: 7.2.0
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications_platform_interface
 
 environment:


### PR DESCRIPTION
Add an option to set custom time for periodically showed notifications.

The problem that I have encountered on iOS devices is that repeating interval must be set to 60 seconds minimum, but I don't think that is the problem for real use case scenarios.

**Sample usage:**
```
    await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
      1,
      'repeating period title',
      'repeating period body',
      const Duration(minutes: 5),
      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
    );
```
