### PR TITLE
[flutter_local_notifications] setupAlarm method: handle ScheduleMode.useAllowWhileIdle() called on null

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -598,7 +598,7 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(context);
     if (notificationDetails.scheduleMode == null) {
       // This is to account for notifications created in older versions prior to allowWhileIdle
-      // being added so the deserialiser.
+      // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/4b723e750d1371206520b10a122a444c4bba7475/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L569C37-L569C37
       notificationDetails.scheduleMode = ScheduleMode.exactAllowWhileIdle;
@@ -676,7 +676,7 @@ public class FlutterLocalNotificationsPlugin
 
     if (notificationDetails.scheduleMode == null) {
       // This is to account for notifications created in older versions prior to allowWhileIdle
-      // being added so the deserialiser.
+      // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/4b723e750d1371206520b10a122a444c4bba7475/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L642
       notificationDetails.scheduleMode = ScheduleMode.inexact;
@@ -703,7 +703,7 @@ public class FlutterLocalNotificationsPlugin
 
     if (notificationDetails.scheduleMode == null) {
       // This is to account for notifications created in older versions prior to allowWhileIdle
-      // being added so the deserialiser.
+      // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L735
       notificationDetails.scheduleMode = ScheduleMode.exact;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -706,7 +706,7 @@ public class FlutterLocalNotificationsPlugin
       // being added so the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L735
-      notificationDetails.scheduleMode = ScheduleMode.exact
+      notificationDetails.scheduleMode = ScheduleMode.exact;
     }
 
     if (notificationDetails.scheduleMode.useAllowWhileIdle()) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -702,9 +702,11 @@ public class FlutterLocalNotificationsPlugin
       PendingIntent pendingIntent) {
 
     if (notificationDetails.scheduleMode == null) {
-      // Handle ScheduleMode.useAllowWhileIdle() called on a null object reference
-      // Issue reference: https://github.com/MaikuB/flutter_local_notifications/issues/2136
-      notificationDetails.scheduleMode = ScheduleMode.inexact;
+      // This is to account for notifications created in older versions prior to allowWhileIdle
+      // being added so the deserialiser.
+      // Reference to old behaviour:
+      // https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L735
+      notificationDetails.scheduleMode = ScheduleMode.exact
     }
 
     if (notificationDetails.scheduleMode.useAllowWhileIdle()) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -700,6 +700,13 @@ public class FlutterLocalNotificationsPlugin
       AlarmManager alarmManager,
       long epochMilli,
       PendingIntent pendingIntent) {
+
+    if (notificationDetails.scheduleMode == null) {
+      // Handle ScheduleMode.useAllowWhileIdle() called on a null object reference
+      // Issue reference: https://github.com/MaikuB/flutter_local_notifications/issues/2136
+      notificationDetails.scheduleMode = ScheduleMode.inexact;
+    }
+
     if (notificationDetails.scheduleMode.useAllowWhileIdle()) {
       setupAllowWhileIdleAlarm(notificationDetails, alarmManager, epochMilli, pendingIntent);
     } else {


### PR DESCRIPTION
…ence

As this repository hosts multiple packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). Should the PR more than one package than please prefix the title of the PR with [various] The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
