### PR TITLE
 [flutter_local_notifications] Add docs that desugaring is required for Android less than SDK 26

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -180,7 +180,7 @@ Before proceeding, please make sure you are using the latest version of the plug
 
 ### Gradle setup
 
-Version 10+ on the plugin now relies on [desugaring](https://developer.android.com/studio/releases/gradle-plugin#j8-library-desugaring) to support scheduled notifications with backwards compatibility on older versions of Android. Developers will need to update their application's Gradle file at `android/app/build.gradle`. Please see the link on desugaring for details but the main parts needed in this Gradle file would be
+Version 10+ on the plugin now relies on [desugaring](https://developer.android.com/studio/releases/gradle-plugin#j8-library-desugaring) to support scheduled notifications with backwards compatibility on older versions of Android less than Android 8 SDK 26. Developers will need to update their application's Gradle file at `android/app/build.gradle`. Please see the link on desugaring for details but the main parts needed in this Gradle file would be
 
 ```gradle
 android {


### PR DESCRIPTION
Add docs that the desugaring step is required for Android less than Android 8 SDK 26 so the users can use Gradle 8 without any issues and new Java versions

Android 8 is used by 93% 
https://www.composables.com/tools/distribution-chart
![image](https://github.com/MaikuB/flutter_local_notifications/assets/149420647/5cda2d01-b176-4dec-806f-2cf307e52af3)
