### PR TITLE
[flutter_local_notifications] Added AudioAttributesUsage for AndroidNotificationChannel

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -2079,6 +2079,7 @@ public class FlutterLocalNotificationsPlugin
       channelPayload.put("vibrationPattern", channel.getVibrationPattern());
       channelPayload.put("enableLights", channel.shouldShowLights());
       channelPayload.put("ledColor", channel.getLightColor());
+      channelPayload.put("audioAttributesUsage", channel.getAudioAttributes().getUsage());
     }
     return channelPayload;
   }

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2814,7 +2814,8 @@ class _HomePageState extends State<HomePage> {
                         'vibrationPattern: ${channel.vibrationPattern}\n'
                         'showBadge: ${channel.showBadge}\n'
                         'enableLights: ${channel.enableLights}\n'
-                        'ledColor: ${channel.ledColor}\n'),
+                        'ledColor: ${channel.ledColor}\n'
+                        'audioAttributesUsage: ${channel.audioAttributesUsage}\n'),
                     const Divider(color: Colors.black),
                   ],
                 ),

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -493,6 +493,11 @@ class AndroidFlutterLocalNotificationsPlugin
               enableVibration: a['enableVibration'],
               vibrationPattern: a['vibrationPattern'],
               ledColor: Color(a['ledColor']),
+              audioAttributesUsage: AudioAttributesUsage.values.firstWhere(
+                // ignore: always_specify_types
+                (e) => e.value == a['audioAttributesUsage'],
+                orElse: () => AudioAttributesUsage.notification,
+              ),
             ))
         .toList();
   }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -53,6 +53,7 @@ extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
         'ledColorRed': ledColor?.red,
         'ledColorGreen': ledColor?.green,
         'ledColorBlue': ledColor?.blue,
+        'audioAttributesUsage': audioAttributesUsage.value,
         'channelAction':
             AndroidNotificationChannelAction.createIfNotExists.index,
       }..addAll(_convertNotificationSoundToMap(sound));

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
@@ -20,6 +20,7 @@ class AndroidNotificationChannel {
     this.showBadge = true,
     this.enableLights = false,
     this.ledColor,
+    this.audioAttributesUsage = AudioAttributesUsage.notification,
   });
 
   /// The channel's id.
@@ -80,4 +81,9 @@ class AndroidNotificationChannel {
   /// Whether notifications posted to this channel can appear as application
   /// icon badges in a Launcher
   final bool showBadge;
+
+  /// The attribute describing what is the intended use of the audio signal,
+  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int))
+  /// https://developer.android.com/reference/android/media/AudioAttributes
+  final AudioAttributesUsage audioAttributesUsage;
 }

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2359,13 +2359,15 @@ void main() {
           .resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>()!
           .createNotificationChannel(const AndroidNotificationChannel(
-              'channelId', 'channelName',
-              description: 'channelDescription'));
+            'channelId',
+            'channelName',
+            description: 'channelDescriptions',
+          ));
       expect(log, <Matcher>[
         isMethodCall('createNotificationChannel', arguments: <String, Object?>{
           'id': 'channelId',
           'name': 'channelName',
-          'description': 'channelDescription',
+          'description': 'channelDescriptions',
           'groupId': null,
           'showBadge': true,
           'importance': Importance.defaultImportance.value,
@@ -2377,6 +2379,7 @@ void main() {
           'ledColorRed': null,
           'ledColorGreen': null,
           'ledColorBlue': null,
+          'audioAttributesUsage': AudioAttributesUsage.notification.value,
           'channelAction':
               AndroidNotificationChannelAction.createIfNotExists.index,
         })
@@ -2398,6 +2401,7 @@ void main() {
             enableLights: true,
             enableVibration: false,
             ledColor: Color.fromARGB(255, 255, 0, 0),
+            audioAttributesUsage: AudioAttributesUsage.alarm,
           ));
       expect(log, <Matcher>[
         isMethodCall('createNotificationChannel', arguments: <String, Object?>{
@@ -2415,6 +2419,7 @@ void main() {
           'ledColorRed': 255,
           'ledColorGreen': 0,
           'ledColorBlue': 0,
+          'audioAttributesUsage': AudioAttributesUsage.alarm.value,
           'channelAction':
               AndroidNotificationChannelAction.createIfNotExists.index,
         })

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2361,13 +2361,13 @@ void main() {
           .createNotificationChannel(const AndroidNotificationChannel(
             'channelId',
             'channelName',
-            description: 'channelDescriptions',
+            description: 'channelDescription',
           ));
       expect(log, <Matcher>[
         isMethodCall('createNotificationChannel', arguments: <String, Object?>{
           'id': 'channelId',
           'name': 'channelName',
-          'description': 'channelDescriptions',
+          'description': 'channelDescription',
           'groupId': null,
           'showBadge': true,
           'importance': Importance.defaultImportance.value,


### PR DESCRIPTION
Added variable "audioAttributesUsage" in AndroidNotificationChannel  to create a channel with audioAttributesUsage in the beginning.
This is need when we need to alert sound on mute/silent.

Related to #1964
