### PR TITLE
[flutter_local_notifications] Updated docs to reflect actual iOS pending notifications limit behaviour

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -124,7 +124,7 @@ It has been reported that Samsung's implementation of Android has imposed a maxi
 
 ### iOS pending notifications limit
 
-There is a limit imposed by iOS where it will only keep 64 notifications that will fire the soonest.
+There is a limit imposed by iOS where it will only keep the 64 notifications that were last set on any iOS versions newer than 9. On iOS versions 9 and older, the 64 notifications that fire soonest are kept. [See here for more details.](http://ileyf.cn.openradar.appspot.com/38065340)
 
 ### Scheduled notifications and daylight saving time
 


### PR DESCRIPTION
In relation to #2275 