### PR TITLE
[flutter_local_notifications] added reason for using User Defaults API to iOS privacy manifest

### DIFF
--- a/flutter_local_notifications/ios/Resources/PrivacyInfo.xcprivacy
+++ b/flutter_local_notifications/ios/Resources/PrivacyInfo.xcprivacy
@@ -5,7 +5,16 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
In relation to #2177

# Reason
## flutter_local_notifications/ios/Classes/FlutterLocalNotificationsPlugin.m

I assumed that UserDefaults is being used for push notification settings in this code.

```objective-c
  NSDictionary *persistedPresentationOptions =
      [[NSUserDefaults standardUserDefaults]
          dictionaryForKey:PRESENTATION_OPTIONS_USER_DEFAULTS];
  bool presentAlert = false;
  bool presentSound = false;
  bool presentBadge = false;
  bool presentBanner = false;
  bool presentList = false;
  if (persistedPresentationOptions != nil) {
    presentAlert = [persistedPresentationOptions[PRESENT_ALERT] isEqual:@YES];
    presentSound = [persistedPresentationOptions[PRESENT_SOUND] isEqual:@YES];
    presentBadge = [persistedPresentationOptions[PRESENT_BADGE] isEqual:@YES];
    presentBanner = [persistedPresentationOptions[PRESENT_BANNER] isEqual:@YES];
    presentList = [persistedPresentationOptions[PRESENT_LIST] isEqual:@YES];
  }
```

## flutter_local_notifications/ios/Classes/FlutterEngineManager.m

It seems like it's storing handler information here.

```objective-c
- (void)registerDispatcherHandle:(NSNumber *)dispatcherHandle
                  callbackHandle:(NSNumber *)callbackHandle {
  [_persistentState setObject:callbackHandle forKey:@"callback_handle"];
  [_persistentState setObject:dispatcherHandle forKey:@"dispatcher_handle"];
}
```

# Result
Based on the usage scenarios, I believed UserDefaults would apply to "CA92.1", so I made that configuration. 
What do you think?

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api