### PR TITLE
[flutter_local_notifications_android] Fix cancel notification with tag in action receiver

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
@@ -56,7 +56,7 @@ public class ActionBroadcastReceiver extends BroadcastReceiver {
       int notificationId = (int) action.get(FlutterLocalNotificationsPlugin.NOTIFICATION_ID);
       Object tag = action.get(FlutterLocalNotificationsPlugin.NOTIFICATION_TAG);
 
-      if(tag instanceof String) {
+      if (tag instanceof String) {
         NotificationManagerCompat.from(context).cancel((String) tag, notificationId);
       } else {
         NotificationManagerCompat.from(context).cancel(notificationId);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java
@@ -53,8 +53,14 @@ public class ActionBroadcastReceiver extends BroadcastReceiver {
         FlutterLocalNotificationsPlugin.extractNotificationResponseMap(intent);
 
     if (intent.getBooleanExtra(FlutterLocalNotificationsPlugin.CANCEL_NOTIFICATION, false)) {
-      NotificationManagerCompat.from(context)
-          .cancel((int) action.get(FlutterLocalNotificationsPlugin.NOTIFICATION_ID));
+      int notificationId = (int) action.get(FlutterLocalNotificationsPlugin.NOTIFICATION_ID);
+      Object tag = action.get(FlutterLocalNotificationsPlugin.NOTIFICATION_TAG);
+
+      if(tag instanceof String) {
+        NotificationManagerCompat.from(context).cancel((String) tag, notificationId);
+      } else {
+        NotificationManagerCompat.from(context).cancel(notificationId);
+      }
     }
 
     if (actionEventSink == null) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -121,6 +121,7 @@ public class FlutterLocalNotificationsPlugin
 
   static final String PAYLOAD = "payload";
   static final String NOTIFICATION_ID = "notificationId";
+  static final String NOTIFICATION_TAG = "notificationTag";
   static final String CANCEL_NOTIFICATION = "cancelNotification";
 
   private static final String TAG = "FLTLocalNotifPlugin";
@@ -309,6 +310,7 @@ public class FlutterLocalNotificationsPlugin
 
         actionIntent
             .putExtra(NOTIFICATION_ID, notificationDetails.id)
+            .putExtra(NOTIFICATION_TAG, notificationDetails.tag)
             .putExtra(ACTION_ID, action.id)
             .putExtra(CANCEL_NOTIFICATION, action.cancelNotification)
             .putExtra(PAYLOAD, notificationDetails.payload);
@@ -623,6 +625,7 @@ public class FlutterLocalNotificationsPlugin
     final int notificationId = intent.getIntExtra(NOTIFICATION_ID, 0);
     final Map<String, Object> notificationResponseMap = new HashMap<>();
     notificationResponseMap.put(NOTIFICATION_ID, notificationId);
+    notificationResponseMap.put(NOTIFICATION_TAG, intent.getStringExtra(NOTIFICATION_TAG));
     notificationResponseMap.put(ACTION_ID, intent.getStringExtra(ACTION_ID));
     notificationResponseMap.put(
         FlutterLocalNotificationsPlugin.PAYLOAD,


### PR DESCRIPTION
Notifications with tags were not cancelled when an action gets invoked.