### PR TITLE
[flutter_local_notifications] updated plugin to no longer register Linux implementation

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * **Breaking change** Bumped minimum Flutter SDK requirement to 3.13
 * [Android] **Breaking change**  removed the deprecated `androidAllowWhileIdle` parameter from `zonedSchedule()` and `periodicallyShow()` methods. `androidScheduleMode` is now a required parameter
+* Bumped dependency on `flutter_local_notifications_linux` to 4.0.1. Updated app-facing packaging to no longer create and register the Linux implementation as this will now be handled by the `flutter_local_notifications_linux` package itself
 
 ## [17.2.1+2]
 

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -38,9 +38,6 @@ class FlutterLocalNotificationsPlugin {
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       FlutterLocalNotificationsPlatform.instance =
           MacOSFlutterLocalNotificationsPlugin();
-    } else if (defaultTargetPlatform == TargetPlatform.linux) {
-      FlutterLocalNotificationsPlatform.instance =
-          LinuxFlutterLocalNotificationsPlugin();
     }
   }
 

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 17.2.1+2
+version: 17.2.2
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 
@@ -10,7 +10,7 @@ dependencies:
   clock: ^1.1.0
   flutter:
     sdk: flutter
-  flutter_local_notifications_linux: ^4.0.0
+  flutter_local_notifications_linux: ^4.0.1
   flutter_local_notifications_platform_interface: ^7.2.0
   timezone: ^0.9.0
 


### PR DESCRIPTION
Follow up to #2371 and relates to #2368 

As the Linux package now handles registering the Linux implementation, the app-facing package no longer needs to do this 