### PR TITLE
[flutter_local_notifications] fix: handle exception while loading resource name

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -2130,11 +2130,16 @@ public class FlutterLocalNotificationsPlugin
             channelPayload.put("sound", resource);
           } else {
             // Kept for backwards compatibility when the source resource used to be based on id
-            String resourceName =
-                applicationContext.getResources().getResourceEntryName(resourceId);
-            if (resourceName != null) {
-              channelPayload.put("soundSource", soundSources.indexOf(SoundSource.RawResource));
-              channelPayload.put("sound", resourceName);
+            try {
+              String resourceName =
+                      applicationContext.getResources().getResourceEntryName(resourceId);
+              if (resourceName != null) {
+                channelPayload.put("soundSource", soundSources.indexOf(SoundSource.RawResource));
+                channelPayload.put("sound", resourceName);
+              }
+            } catch (Exception e) {
+              channelPayload.put("sound", null);
+              channelPayload.put("playSound", false);
             }
           }
         } else {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -2132,7 +2132,7 @@ public class FlutterLocalNotificationsPlugin
             // Kept for backwards compatibility when the source resource used to be based on id
             try {
               String resourceName =
-                      applicationContext.getResources().getResourceEntryName(resourceId);
+                  applicationContext.getResources().getResourceEntryName(resourceId);
               if (resourceName != null) {
                 channelPayload.put("soundSource", soundSources.indexOf(SoundSource.RawResource));
                 channelPayload.put("sound", resourceName);


### PR DESCRIPTION
As discussed in #2309

We deployed the fix to production and we see no more errors 🥳 