### PR TITLE
[flutter_local_notifications] updated minimum OS requirements to align with Flutter 3.13

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [vNext]
 
-* **Breaking change** Bumped minimum Flutter SDK requirement to 3.13
+* **Breaking changes** Bumped minimum Flutter SDK requirement to 3.13. Consequently the minimum OS requirements for each platform has been updated as well
+  * [Android] minimum Android version is now 4.4 (API level 19)
+  * [iOS] minimum iOS version is now 11
+  * [macOS] minimum macOS version is now 10.14
 * [Android] **Breaking change**  removed the deprecated `androidAllowWhileIdle` parameter from `zonedSchedule()` and `periodicallyShow()` methods. `androidScheduleMode` is now a required parameter
 * Fixed example app to have the appropriate permissions for foreground services
 * Updated readme when it comes to setting up the `AndroidManifest.xml` file to include details of what's needed for foreground services. Note these details were already available in the API docs

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -5,6 +5,10 @@
   * [iOS] minimum iOS version is now 11
   * [macOS] minimum macOS version is now 10.14
 * [Android] **Breaking change**  removed the deprecated `androidAllowWhileIdle` parameter from `zonedSchedule()` and `periodicallyShow()` methods. `androidScheduleMode` is now a required parameter
+* **Breaking change** plugin has been fixed with regards to how it registers the platform-specific implementations of the plugin. Thanks to the PR from [Kate](https://github.com/provokateurin). Any written tests done on the [FlutterLocalNotificationsPlugin] will need to manually call the `registerWith()` method that has been added to each implementation. This affects the following platforms
+  * [Android] `AndroidFlutterLocalNotificationsPlugin`
+  * [iOS] `IOSFlutterLocalNotificationsPlugin`
+  * [macOS] `MacOSFlutterLocalNotificationsPlugin`
 * Fixed example app to have the appropriate permissions for foreground services
 * Updated readme when it comes to setting up the `AndroidManifest.xml` file to include details of what's needed for foreground services. Note these details were already available in the API docs
 

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -5,7 +5,7 @@
   * [iOS] minimum iOS version is now 11
   * [macOS] minimum macOS version is now 10.14
 * [Android] **Breaking change**  removed the deprecated `androidAllowWhileIdle` parameter from `zonedSchedule()` and `periodicallyShow()` methods. `androidScheduleMode` is now a required parameter
-* **Breaking change** plugin has been fixed with regards to how it registers the platform-specific implementations of the plugin. Thanks to the PR from [Kate](https://github.com/provokateurin). Any written tests done on the [FlutterLocalNotificationsPlugin] will need to manually call the `registerWith()` method that has been added to each implementation. This affects the following platforms
+* **Breaking change** plugin has been fixed with regards to how it registers the platform-specific implementations of the plugin. Thanks to the PR from [Kate](https://github.com/provokateurin). Any written tests done on the [FlutterLocalNotificationsPlugin] will need to manually call the `registerWith()` method that has been added to each implementation. This affects the following platforms/classes where the `registerWith()` method was added
   * [Android] `AndroidFlutterLocalNotificationsPlugin`
   * [iOS] `IOSFlutterLocalNotificationsPlugin`
   * [macOS] `MacOSFlutterLocalNotificationsPlugin`

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -6,7 +6,7 @@
 A cross platform plugin for displaying local notifications.
 
 >[!IMPORTANT] 
-> Given how both quickly both Flutter ecosystem and Android ecosystem evolves, the minimum Flutter SDK version will occassionally be bumped to make it easier to maintain the plugin. Note that official plugins already follow a similar approach. This is being called out as if this affects your applications (e.g. supported OS versions) then you may need to consider maintaining your own fork in the future
+> Given how both quickly both Flutter ecosystem and Android ecosystem evolves, the minimum Flutter SDK version will occasionally be bumped to make it easier to maintain the plugin. Note that official plugins already follow a similar approach. This is being called out as if this affects your applications (e.g. supported OS versions) then you may need to consider maintaining your own fork in the future
 
 ## Table of contents
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -56,11 +56,11 @@ A cross platform plugin for displaying local notifications.
 ## 📱 Supported platforms
 
 * **Android+**. Uses the [NotificationCompat APIs](https://developer.android.com/reference/androidx/core/app/NotificationCompat) so it can be run older Android devices
-* **iOS**. Uses the [UserNotification APIs](https://developer.apple.com/documentation/usernotifications) (aka the User Notifications Framework)
-* **macOS**. On macOS versions older than 10.14, the plugin will use the [NSUserNotification APIs](https://developer.apple.com/documentation/foundation/nsusernotification). The [UserNotification APIs](https://developer.apple.com/documentation/usernotifications) (aka the User Notifications Framework) is used on macOS 10.14 or newer. Notification actions only work on macOS 10.14 or newer
+* **iOS** Uses the [UserNotification APIs](https://developer.apple.com/documentation/usernotifications) (aka the User Notifications Framework)
+* **macOS** Uses the [UserNotification APIs](https://developer.apple.com/documentation/usernotifications) (aka the User Notifications Framework)
 * **Linux**. Uses the [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/)
 
-Note: the plugin has a requires Flutter SDK 3.13 at a minimum. The list of support platforms for Flutter 3.1.3 itself can be found [here](https://github.com/flutter/website/blob/3d18ab48218101493af84953b71eac0cc6781fdd/src/reference/supported-platforms.md)
+Note: the plugin has a requires Flutter SDK 3.13 at a minimum. The list of support platforms for Flutter 3.13 itself can be found [here](https://github.com/flutter/website/blob/3d18ab48218101493af84953b71eac0cc6781fdd/src/reference/supported-platforms.md)
 
 ## ✨ Features
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -60,7 +60,7 @@ A cross platform plugin for displaying local notifications.
 * **macOS** Uses the [UserNotification APIs](https://developer.apple.com/documentation/usernotifications) (aka the User Notifications Framework)
 * **Linux**. Uses the [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/)
 
-Note: the plugin has a requires Flutter SDK 3.13 at a minimum. The list of support platforms for Flutter 3.13 itself can be found [here](https://github.com/flutter/website/blob/3d18ab48218101493af84953b71eac0cc6781fdd/src/reference/supported-platforms.md)
+Note: the plugin requires Flutter SDK 3.13 at a minimum. The list of support platforms for Flutter 3.13 itself can be found [here](https://github.com/flutter/website/blob/3d18ab48218101493af84953b71eac0cc6781fdd/src/reference/supported-platforms.md)
 
 ## ✨ Features
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -6,7 +6,7 @@
 A cross platform plugin for displaying local notifications.
 
 >[!IMPORTANT] 
-> Given how both quickly both Flutter ecosystem and Android ecosystem evolves, the minimum Flutter SDK version will be bumped to make it easier to maintain the plugin. Note that official plugins already follow a similar approach e.g. have a minimum Flutter SDK version of 3.13. This is being called out as if this affects your applications (e.g. supported OS versions) then you may need to consider maintaining your own fork in the future
+> Given how both quickly both Flutter ecosystem and Android ecosystem evolves, the minimum Flutter SDK version will occassionally be bumped to make it easier to maintain the plugin. Note that official plugins already follow a similar approach. This is being called out as if this affects your applications (e.g. supported OS versions) then you may need to consider maintaining your own fork in the future
 
 ## Table of contents
 

--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -32,7 +32,7 @@ android {
 
     defaultConfig {
         multiDexEnabled true
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/flutter_local_notifications/ios/flutter_local_notifications.podspec
+++ b/flutter_local_notifications/ios/flutter_local_notifications.podspec
@@ -16,7 +16,6 @@ Flutter plugin for displaying local notifications.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.resource_bundles = {'flutter_local_notifications_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
-  
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
 end
 

--- a/flutter_local_notifications/macos/flutter_local_notifications.podspec
+++ b/flutter_local_notifications/macos/flutter_local_notifications.podspec
@@ -16,7 +16,7 @@ Flutter plugin for displaying local notifications.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx, '10.11'
+  s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
Updated the plugin's minimum OS requirements to align with minimum Flutter 3.13 requirement.

Reference https://github.com/flutter/website/blob/3d18ab48218101493af84953b71eac0cc6781fdd/src/reference/supported-platforms.md