### PR TITLE
[flutter_local_notifications_windows] Fix `init()` on Windows MSIX

### DIFF
--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -189,9 +189,11 @@ std::optional<bool> NativePlugin::checkIdentity() {
   }
   std::vector<wchar_t> fullName;
 =======
-  if (error == APPMODEL_ERROR_NO_PACKAGE) return false;
-  else if (error != ERROR_INSUFFICIENT_BUFFER) return std::nullopt;
-	std::vector<wchar_t> fullName(length);
+  if (error == APPMODEL_ERROR_NO_PACKAGE)
+    return false;
+  else if (error != ERROR_INSUFFICIENT_BUFFER)
+    return std::nullopt;
+  std::vector<wchar_t> fullName(length);
 >>>>>>> Stashed changes
   error = GetCurrentPackageFullName(&length, fullName.data());
   if (error != ERROR_SUCCESS) return std::nullopt;

--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -186,7 +186,7 @@ std::optional<bool> NativePlugin::checkIdentity() {
   } else if (error != ERROR_INSUFFICIENT_BUFFER) {
     return std::nullopt;
   }
-	std::vector<wchar_t> fullName(length);
+  std::vector<wchar_t> fullName(length);
   error = GetCurrentPackageFullName(&length, fullName.data());
   if (error != ERROR_SUCCESS) return std::nullopt;
   return true;

--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -181,20 +181,12 @@ std::optional<bool> NativePlugin::checkIdentity() {
   if (!IsWindows8OrGreater()) return false;
   uint32_t length = 0;
   auto error = GetCurrentPackageFullName(&length, nullptr);
-<<<<<<< Updated upstream
   if (error == APPMODEL_ERROR_NO_PACKAGE) {
     return false;
   } else if (error != ERROR_INSUFFICIENT_BUFFER) {
     return std::nullopt;
   }
-  std::vector<wchar_t> fullName;
-=======
-  if (error == APPMODEL_ERROR_NO_PACKAGE)
-    return false;
-  else if (error != ERROR_INSUFFICIENT_BUFFER)
-    return std::nullopt;
-  std::vector<wchar_t> fullName(length);
->>>>>>> Stashed changes
+	std::vector<wchar_t> fullName(length);
   error = GetCurrentPackageFullName(&length, fullName.data());
   if (error != ERROR_SUCCESS) return std::nullopt;
   return true;

--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -181,12 +181,18 @@ std::optional<bool> NativePlugin::checkIdentity() {
   if (!IsWindows8OrGreater()) return false;
   uint32_t length = 0;
   auto error = GetCurrentPackageFullName(&length, nullptr);
+<<<<<<< Updated upstream
   if (error == APPMODEL_ERROR_NO_PACKAGE) {
     return false;
   } else if (error != ERROR_INSUFFICIENT_BUFFER) {
     return std::nullopt;
   }
   std::vector<wchar_t> fullName;
+=======
+  if (error == APPMODEL_ERROR_NO_PACKAGE) return false;
+  else if (error != ERROR_INSUFFICIENT_BUFFER) return std::nullopt;
+	std::vector<wchar_t> fullName(length);
+>>>>>>> Stashed changes
   error = GetCurrentPackageFullName(&length, fullName.data());
   if (error != ERROR_SUCCESS) return std::nullopt;
   return true;


### PR DESCRIPTION
A `std::vector` didn't have a starting size, which messed up the Windows APIs. Windows builds will work in release EXEs but will fail the `init()` call in MSIX, so this should be patched before the initial Windows release
