### PR TITLE
[flutter_local_notifications] Fix crashes related to Android foreground service start type

### DIFF
--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -262,6 +262,8 @@ class AndroidFlutterLocalNotificationsPlugin
   /// Information on selecting an appropriate `startType` for your app's use
   /// case should be taken from the official Android documentation, check [`Service.onStartCommand`](https://developer.android.com/reference/android/app/Service#onStartCommand(android.content.Intent,%20int,%20int)).
   /// The there mentioned constants can be found in [AndroidServiceStartType].
+  /// WARNING: We strongly disadvise using [AndroidServiceStartType.startSticky]
+  /// because it can lead to crashes, see this [github issue](https://github.com/MaikuB/flutter_local_notifications/issues/2446).
   ///
   /// The notification for the foreground service will not be dismissible
   /// and automatically removed when using [stopForegroundService].
@@ -278,7 +280,7 @@ class AndroidFlutterLocalNotificationsPlugin
   Future<void> startForegroundService(int id, String? title, String? body,
       {AndroidNotificationDetails? notificationDetails,
       String? payload,
-      AndroidServiceStartType startType = AndroidServiceStartType.startSticky,
+      AndroidServiceStartType startType = AndroidServiceStartType.startRedeliverIntent,
       Set<AndroidServiceForegroundType>? foregroundServiceTypes}) {
     validateId(id);
     if (id == 0) {

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -125,6 +125,9 @@ enum AndroidServiceForegroundType {
 }
 
 /// The available start types for an Android service.
+/// 
+/// WARNING: We strongly disadvise using [AndroidServiceStartType.startSticky]
+/// because it can lead to crashes, see this [github issue](https://github.com/MaikuB/flutter_local_notifications/issues/2446).
 enum AndroidServiceStartType {
   /// Corresponds to [`Service.START_STICKY_COMPATIBILITY`](https://developer.android.com/reference/android/app/Service#START_STICKY_COMPATIBILITY).
   startStickyCompatibility,

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2631,7 +2631,7 @@ void main() {
               'payload': '',
               'platformSpecifics': null,
             },
-            'startType': AndroidServiceStartType.startSticky.index,
+            'startType': AndroidServiceStartType.startRedeliverIntent.index,
             'foregroundServiceTypes': null
           }));
     });
@@ -2747,7 +2747,7 @@ void main() {
                   'audioAttributesUsage': 5,
                 },
               },
-              'startType': AndroidServiceStartType.startSticky.index,
+              'startType': AndroidServiceStartType.startRedeliverIntent.index,
               'foregroundServiceTypes': null
             },
           ));


### PR DESCRIPTION
See MaikuB/flutter_local_notifications#2446