### PR TITLE
[flutter_local_notifications] bumped Windows dependency

### DIFF
--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_local_notifications_linux: ^5.0.1-dev.1
-  flutter_local_notifications_windows: ^1.0.0-dev.1
+  flutter_local_notifications_windows: ^1.0.0-dev.2
   flutter_local_notifications_platform_interface: ^8.1.0-dev.1
   timezone: ^0.10.0
 


### PR DESCRIPTION
Follow up to https://github.com/MaikuB/flutter_local_notifications/pull/2497 where Windows dependency should've been bumped