### PR TITLE
[flutter_local_notifications] Allow specifying start time of periodic notifications.

### DIFF
--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -399,6 +399,7 @@ class FlutterLocalNotificationsPlugin {
     NotificationDetails notificationDetails, {
     required AndroidScheduleMode androidScheduleMode,
     String? payload,
+    int? repeatStartTime,
   }) async {
     if (kIsWeb) {
       return;
@@ -409,17 +410,22 @@ class FlutterLocalNotificationsPlugin {
           ?.periodicallyShow(id, title, body, repeatInterval,
               notificationDetails: notificationDetails.android,
               payload: payload,
-              scheduleMode: androidScheduleMode);
+              scheduleMode: androidScheduleMode,
+              repeatStartTime: repeatStartTime);
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
-              notificationDetails: notificationDetails.iOS, payload: payload);
+              notificationDetails: notificationDetails.iOS,
+              payload: payload,
+              repeatStartTime: repeatStartTime);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       await resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShow(id, title, body, repeatInterval,
-              notificationDetails: notificationDetails.macOS, payload: payload);
+              notificationDetails: notificationDetails.macOS,
+              payload: payload,
+              repeatStartTime: repeatStartTime);
     } else if (defaultTargetPlatform == TargetPlatform.windows) {
       throw UnsupportedError('Notifications do not repeat on Windows');
     } else {
@@ -446,6 +452,7 @@ class FlutterLocalNotificationsPlugin {
     NotificationDetails notificationDetails, {
     AndroidScheduleMode androidScheduleMode = AndroidScheduleMode.exact,
     String? payload,
+    int? repeatStartTime,
   }) async {
     if (kIsWeb) {
       return;
@@ -457,19 +464,24 @@ class FlutterLocalNotificationsPlugin {
               id, title, body, repeatDurationInterval,
               notificationDetails: notificationDetails.android,
               payload: payload,
-              scheduleMode: androidScheduleMode);
+              scheduleMode: androidScheduleMode,
+              repeatStartTime: repeatStartTime);
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       await resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShowWithDuration(
               id, title, body, repeatDurationInterval,
-              notificationDetails: notificationDetails.iOS, payload: payload);
+              notificationDetails: notificationDetails.iOS,
+              payload: payload,
+              repeatStartTime: repeatStartTime);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       await resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin>()
           ?.periodicallyShowWithDuration(
               id, title, body, repeatDurationInterval,
-              notificationDetails: notificationDetails.macOS, payload: payload);
+              notificationDetails: notificationDetails.macOS,
+              payload: payload,
+              repeatStartTime: repeatStartTime);
     } else {
       await FlutterLocalNotificationsPlatform.instance
           .periodicallyShowWithDuration(

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -354,13 +354,14 @@ class AndroidFlutterLocalNotificationsPlugin
     AndroidNotificationDetails? notificationDetails,
     String? payload,
     AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     await _channel.invokeMethod('periodicallyShow', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics':
           _buildPlatformSpecifics(notificationDetails, scheduleMode),
@@ -377,6 +378,7 @@ class AndroidFlutterLocalNotificationsPlugin
     AndroidNotificationDetails? notificationDetails,
     String? payload,
     AndroidScheduleMode scheduleMode = AndroidScheduleMode.exact,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     validateRepeatDurationInterval(repeatDurationInterval);
@@ -385,7 +387,7 @@ class AndroidFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics':
           _buildPlatformSpecifics(notificationDetails, scheduleMode),
@@ -754,13 +756,14 @@ class IOSFlutterLocalNotificationsPlugin
     RepeatInterval repeatInterval, {
     DarwinNotificationDetails? notificationDetails,
     String? payload,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     await _channel.invokeMethod('periodicallyShow', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
@@ -775,6 +778,7 @@ class IOSFlutterLocalNotificationsPlugin
     Duration repeatDurationInterval, {
     DarwinNotificationDetails? notificationDetails,
     String? payload,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     validateRepeatDurationInterval(repeatDurationInterval);
@@ -783,7 +787,7 @@ class IOSFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
@@ -948,13 +952,14 @@ class MacOSFlutterLocalNotificationsPlugin
     RepeatInterval repeatInterval, {
     DarwinNotificationDetails? notificationDetails,
     String? payload,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     await _channel.invokeMethod('periodicallyShow', <String, Object?>{
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatInterval': repeatInterval.index,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''
@@ -969,6 +974,7 @@ class MacOSFlutterLocalNotificationsPlugin
     Duration repeatDurationInterval, {
     DarwinNotificationDetails? notificationDetails,
     String? payload,
+    int? repeatStartTime,
   }) async {
     validateId(id);
     validateRepeatDurationInterval(repeatDurationInterval);
@@ -977,7 +983,7 @@ class MacOSFlutterLocalNotificationsPlugin
       'id': id,
       'title': title,
       'body': body,
-      'calledAt': clock.now().millisecondsSinceEpoch,
+      'calledAt': repeatStartTime ?? clock.now().millisecondsSinceEpoch,
       'repeatIntervalMilliseconds': repeatDurationInterval.inMilliseconds,
       'platformSpecifics': notificationDetails?.toMap(),
       'payload': payload ?? ''


### PR DESCRIPTION
Firstly, thank your the continued work supporting and maintaining this package, it is much appreciated.

## Current Challenge

Currently if you schedule a notification using `periodicallyShow` the notification will be sent every day since the creation of the notification. As I understand this is the currently accepted and documented behaviour.

This means that you cannot set a periodic notification to start after a specific date, such as required in the below scenario.

### Example Scenario
- Current date is `2024-01-01 12:00:00`.
- Schedule a `zonedSchedule` notification for `2024-01-05 12:00:00` to tell the user that a task is due.
- Schedule a `periodicallyShow` notification from `2024-01-06 12:00:00` to tell the user that a task is overdue every day.

### Current Outcome
- User receives an overdue notification every day from the `2024-01-01 12:00:00` onwards.

### Desired Outcome
- User receives an overdue notification every day from `2024-01-06 12:00:00` onwards.

An unresolved question [here on StackOverflow](https://stackoverflow.com/questions/78393943/flutter-repeating-local-notifications) describes a similar issue.

## Changes

Inspired by the work/changes proposed by @henriklagergren in [this discussion](https://github.com/MaikuB/flutter_local_notifications/issues/92#issuecomment-1804514149), the following change has been made based off the latest master branch.

The existing `periodicallyShow` and `periodicallyShowWithDuration` methods have been updated with an optional parameter to replace the default `calledAt` value of `clock.now().millisecondsSinceEpoch`. This is to make the change non-breaking.

## Testing

I have tested and validated the change on Android, and can at least confirm that the notifications to start at the date time now provided to the `periodicallyShow` and `periodicallyShowWithDuration` methods. This results in the desired outcome of the example scenario being presented.

I do not currently have an iOS device, so am unable to confirm that the behaviour is identical. From the testing of @anilslabs mentioned [here](https://github.com/MaikuB/flutter_local_notifications/issues/92#issuecomment-2022566442) it appears that this may not be the case.
