### PR TITLE
[flutter_local_notifications] bumped multiple dependencies used by example app

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -3,7 +3,7 @@
 *  **Breaking change** bumped minimum Flutter SDK requirement to 3.22.0 and Dart SDK requirement to 3.4.0. The minimum supported Android version is now 5.0 (API level 21)
 *  Bumped Android Gradle Plugin to 8.6.0 to align with the [minimum version](https://developer.android.com/build/releases/gradle-plugin#api-level-support) to use `compileSdk` version 35 (Android 15)
 *  [Android] bumped desugaring library to 2.1.4 and set Java compatibility to 11 instead of 8. Readme has been updated to reflect these changes  where`sourceCompatibility` and `targetCompability` should be set to JavaVersion.VERSION_11 (i.e. Java 11), and `jvmTarget` is set to `11`
-*  Bumped `flutter_timezone` dependency in example app
+*  Bumped multiple dependencies in example app
 *  Updated example app's `AndroidManifest.xml` to request internet permissions so that release builds can download remote content
 *  [Android] bumped GSON dependency to 2.12. As a result of doing so, applications should no longer need ProGuard rules related to this plugin that were needed for release builds to function. The readme has been updated to remove the associated setup to reflect this. Thanks to the PR from [Koji Wakamiya](https://github.com/koji-1009)
 

--- a/flutter_local_notifications/example/android/.gitignore
+++ b/flutter_local_notifications/example/android/.gitignore
@@ -1,5 +1,6 @@
 gradle-wrapper.jar
 /.gradle
+/.cxx
 /captures/
 /gradlew
 /gradlew.bat

--- a/flutter_local_notifications/example/android/.gitignore
+++ b/flutter_local_notifications/example/android/.gitignore
@@ -1,12 +1,14 @@
 gradle-wrapper.jar
 /.gradle
-/.cxx
 /captures/
 /gradlew
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx/
 
 # Remember to never publicly share your keystore.
-# See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
+# See https://flutter.dev/to/reference-keystore
 key.properties
+**/*.keystore
+**/*.jks

--- a/flutter_local_notifications/example/pubspec.yaml
+++ b/flutter_local_notifications/example/pubspec.yaml
@@ -3,16 +3,16 @@ description: Demonstrates how to use the flutter_local_notifications plugin.
 publish_to: none
 
 dependencies:
-  cupertino_icons: ^1.0.2
-  device_info_plus: ^9.1.2
+  cupertino_icons: ^1.0.8
+  device_info_plus: ^11.3.0
   flutter:
     sdk: flutter
   flutter_local_notifications:
     path: ../
   flutter_timezone: ^4.0.1
-  http: ^1.2.1
-  image: ^4.2.0
-  path_provider: ^2.0.0
+  http: ^1.3.0
+  image: ^4.5.2
+  path_provider: ^2.1.5
   timezone: ^0.10.0
 
 dev_dependencies:


### PR DESCRIPTION
Done to reduce Java 8 compatibility warnings