### PR TITLE
[various] bumped minimum plugin_platform_interface version

### DIFF
--- a/flutter_local_notifications_linux/pubspec.yaml
+++ b/flutter_local_notifications_linux/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  flutter_local_notifications_platform_interface: ^8.1.0-dev.1
+  flutter_local_notifications_platform_interface: ^9.0.0-dev.1
   path: ^1.8.0
   xdg_directories: ">=0.2.0+1 <2.0.0"
 

--- a/flutter_local_notifications_platform_interface/CHANGELOG.md
+++ b/flutter_local_notifications_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [9.0.0-dev.1]
 
 *  **Breaking change** bumped minimum Flutter SDK requirement to 3.22.0 and Dart SDK requirement to 3.4.0
+*  Bumped minimum `plugin_platform_interface` version to 2.1.8
 
 ## [8.1.0-dev.1]
 

--- a/flutter_local_notifications_platform_interface/pubspec.yaml
+++ b/flutter_local_notifications_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=3.22.0"
 
 dependencies:
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
   flutter_test:

--- a/flutter_local_notifications_windows/pubspec.yaml
+++ b/flutter_local_notifications_windows/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^2.1.2
-  flutter_local_notifications_platform_interface: ^8.1.0-dev.1
+  flutter_local_notifications_platform_interface: ^9.0.0-dev.1
   meta: ^1.11.0
   timezone: ^0.10.0
   xml: ^6.5.0


### PR DESCRIPTION
Also follows up on https://github.com/MaikuB/flutter_local_notifications/pull/2543 to align the platform interface version referenced by Windows and Linux plugin