### PR TITLE
[flutter_local_notifications] renamed Converters iOS and macOS to mitigate name clash issues

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [19.0.0-dev.7]
+
+* [iOS][macOS] **Breaking change** renamed `Converters` header and implementation to `FlutterLocalNotificationsConverters`. This would likely not affect any users of the plugin. Done to fix/mitigate issues [#2160](https://github.com/MaikuB/flutter_local_notifications/issues/2160) and [#2529](https://github.com/MaikuB/flutter_local_notifications/issues/2529) where the original name could clash
+* Restored and updated readme so that those using plugin versions 19 or lower has info on setting up Proguard rules. Thanks to the PR from [Koji Wakamiya](https://github.com/koji-1009)
+
 ## [19.0.0-dev.6]
 
 *  **Breaking change** bumped minimum Flutter SDK requirement to 3.22.0 and Dart SDK requirement to 3.4.0. The minimum supported Android version is now 5.0 (API level 21)

--- a/flutter_local_notifications/example/ios/Runner/AppDelegate.swift
+++ b/flutter_local_notifications/example/ios/Runner/AppDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 import Flutter
 import flutter_local_notifications
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
 
   override func application(

--- a/flutter_local_notifications/example/macos/Runner/AppDelegate.swift
+++ b/flutter_local_notifications/example/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/Converters.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/Converters.m
@@ -1,4 +1,4 @@
-#import "Converters.h"
+#import "./include/flutter_local_notifications/Converters.h"
 
 @implementation Converters
 

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsConverters.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsConverters.m
@@ -1,6 +1,6 @@
-#import "./include/flutter_local_notifications/Converters.h"
+#import "./include/flutter_local_notifications/FlutterLocalNotificationsConverters.h"
 
-@implementation Converters
+@implementation FlutterLocalNotificationsConverters
 
 + (UNNotificationCategoryOptions)parseNotificationCategoryOptions:
     (NSArray *)options {

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -1,6 +1,6 @@
 #import "./include/flutter_local_notifications/FlutterLocalNotificationsPlugin.h"
 #import "./include/flutter_local_notifications/ActionEventSink.h"
-#import "./include/flutter_local_notifications/Converters.h"
+#import "./include/flutter_local_notifications/FlutterLocalNotificationsConverters.h"
 #import "./include/flutter_local_notifications/FlutterEngineManager.h"
 
 @implementation FlutterLocalNotificationsPlugin {
@@ -255,7 +255,7 @@ static FlutterError *getFlutterError(NSError *error) {
         NSString *identifier = action[@"identifier"];
         NSString *title = action[@"title"];
         UNNotificationActionOptions options =
-            [Converters parseNotificationActionOptions:action[@"options"]];
+            [FlutterLocalNotificationsConverters parseNotificationActionOptions:action[@"options"]];
 
         if ((options & UNNotificationActionOptionForeground) != 0) {
           [foregroundActionIdentifiers addObject:identifier];
@@ -282,7 +282,7 @@ static FlutterError *getFlutterError(NSError *error) {
           categoryWithIdentifier:category[@"identifier"]
                          actions:newActions
                intentIdentifiers:@[]
-                         options:[Converters parseNotificationCategoryOptions:
+                         options:[FlutterLocalNotificationsConverters parseNotificationCategoryOptions:
                                                  category[@"options"]]];
 
       [notificationCategories addObject:notificationCategory];

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -1,7 +1,7 @@
 #import "./include/flutter_local_notifications/FlutterLocalNotificationsPlugin.h"
 #import "./include/flutter_local_notifications/ActionEventSink.h"
-#import "./include/flutter_local_notifications/FlutterLocalNotificationsConverters.h"
 #import "./include/flutter_local_notifications/FlutterEngineManager.h"
+#import "./include/flutter_local_notifications/FlutterLocalNotificationsConverters.h"
 
 @implementation FlutterLocalNotificationsPlugin {
   FlutterMethodChannel *_channel;
@@ -255,7 +255,8 @@ static FlutterError *getFlutterError(NSError *error) {
         NSString *identifier = action[@"identifier"];
         NSString *title = action[@"title"];
         UNNotificationActionOptions options =
-            [FlutterLocalNotificationsConverters parseNotificationActionOptions:action[@"options"]];
+            [FlutterLocalNotificationsConverters
+                parseNotificationActionOptions:action[@"options"]];
 
         if ((options & UNNotificationActionOptionForeground) != 0) {
           [foregroundActionIdentifiers addObject:identifier];
@@ -282,8 +283,9 @@ static FlutterError *getFlutterError(NSError *error) {
           categoryWithIdentifier:category[@"identifier"]
                          actions:newActions
                intentIdentifiers:@[]
-                         options:[FlutterLocalNotificationsConverters parseNotificationCategoryOptions:
-                                                 category[@"options"]]];
+                         options:[FlutterLocalNotificationsConverters
+                                     parseNotificationCategoryOptions:
+                                         category[@"options"]]];
 
       [notificationCategories addObject:notificationCategory];
     }

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/include/flutter_local_notifications/FlutterLocalNotificationsConverters.h
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/include/flutter_local_notifications/FlutterLocalNotificationsConverters.h
@@ -1,5 +1,5 @@
 //
-//  Converters.h
+//  FlutterLocalNotificationsFlutterLocalNotificationsConverters.h
 //  flutter_local_notifications
 //
 
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Converters : NSObject
+@interface FlutterLocalNotificationsConverters : NSObject
 
 + (UNNotificationCategoryOptions)parseNotificationCategoryOptions:
     (NSArray *)options API_AVAILABLE(ios(10.0), macosx(10.14));

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsConverters.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsConverters.swift
@@ -1,6 +1,6 @@
 import UserNotifications
 
-public class Converters {
+public class FlutterLocalNotificationsConverters {
     public static func parseNotificationCategoryOptions(_ options: [Any]?) -> UNNotificationCategoryOptions {
         var result: UInt = 0
 

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -277,7 +277,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                                 newActions.append(UNNotificationAction(
                                     identifier: identifier,
                                     title: title,
-                                    options: Converters.parseNotificationActionOptions(options)
+                                    options: FlutterLocalNotificationsConverters.parseNotificationActionOptions(options)
                                 ))
                             } else if type == "text" {
                                 let buttonTitle = action["buttonTitle"] as! String
@@ -285,7 +285,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                                 newActions.append(UNTextInputNotificationAction(
                                     identifier: identifier,
                                     title: title,
-                                    options: Converters.parseNotificationActionOptions(options),
+                                    options: FlutterLocalNotificationsConverters.parseNotificationActionOptions(options),
                                     textInputButtonTitle: buttonTitle,
                                     textInputPlaceholder: placeholder
                                 ))
@@ -299,7 +299,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                         intentIdentifiers: [],
                         hiddenPreviewsBodyPlaceholder: nil,
                         categorySummaryFormat: nil,
-                        options: Converters.parseNotificationCategoryOptions(category["options"] as! [NSNumber])
+                        options: FlutterLocalNotificationsConverters.parseNotificationCategoryOptions(category["options"] as! [NSNumber])
                     )
 
                     notificationCategories.insert(notificationCategory)

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 19.0.0-dev.6
+version: 19.0.0-dev.7
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Closes #2160 and #2529 