### PR TITLE
[flutter_local_notifications] Support bypassing DnD-settings on Android

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -431,11 +431,11 @@ Developers should also be across Google's requirements on using full-screen inte
 
 ### Bypassing Do Not Disturb (DnD)
 
-If your application needs the ability to send notifications that ignore the device's DnD mode settings, you must request these permissions from Android 6.0 onwards. You can do this using `AndroidFlutterNotificationsPlugin` by calling the `requestNotificationPolicyAccess()` method which will redirect the user to a settings page where your application may be explicitly whitelisted to bypass DnD.
+If your application needs the ability to send notifications that ignore the device's DnD mode settings, you must request these permissions from Android 6.0 onwards. You can do this using `AndroidFlutterNotificationsPlugin` by calling the `requestNotificationPolicyAccess()` method which will redirect the user to a settings page where your application may be explicitly whitelisted to bypass DnD. **This method _must_ be called before attempting to create a notification channel with `bypassDnd: true`.** Failing to do so will cause the `bypassDnd` argument to be treated as `false`.
 
 For notifications to then actually ignore the DnD-status of a device, the channel must be created with `bypassDnd: true`, or the first notification on a channel that creates it must be sent with `channelBypassDnd: true`.
 
-**NOTE:** This does _not_ ignore the device's silent mode! Should you have a use case where you must notify your users (for instance in an emergency), you might want to use a package like [`sound_mode`](https://pub.dev/packages/sound_mode) or write your own platform specific code to set the `RingerMode` of the device as well as change the notification stream's volume before and after the notification.
+**NOTE:** This does _not_ ignore the device's silent mode! Should you have a use case where you must notify your users (for instance in an emergency), you might want to use a package like [`sound_mode`](https://pub.dev/packages/sound_mode) or write your own platform-specific code to set the `RingerMode` of the device as well as change the notification stream's volume before and after the notification.
 
 ### Release build configuration
 
@@ -602,7 +602,7 @@ Developers should also note that whilst accessing plugins will work, on Android 
 
 **Specifying actions on notifications**:
 
-The notification actions are platform specific and you have to specify them differently for each platform.
+The notification actions are platform-specific and you have to specify them differently for each platform.
 
 On iOS/macOS, the actions are defined on a category, please see the configuration section for details.
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -386,6 +386,7 @@ For apps that need the following functionality please complete the following in 
             android:stopWithTask="false"
             android:foregroundServiceType="<foreground service types>">
     ```
+* To be able to create channels that ignore the user's Do-Not-Disturb settings, specify the `<uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />` permission between the `<manifest>` tags. Developers will also need to follow the instructions documented [here](#bypassing-dnd)
 
 Developers can refer to the example app's `AndroidManifest.xml` to help see what the end result may look like. Do note that the example app covers all the plugin's supported functionality so will request more permissions than your own app may need
 
@@ -428,13 +429,21 @@ Note that when a full-screen intent notification actually occurs (as opposed to 
 
 Developers should also be across Google's requirements on using full-screen intents. Please refer to their documentation [here](https://source.android.com/docs/core/permissions/fsi-limits) for more information. Should you app need request permissions, the `AndroidFlutterNotificationsPlugin` class exposes the `requestFullScreenIntentPermission()` method that can be used to do so.
 
+### Bypassing dnd
+
+If your application needs the ability to send notifications that ignore the device's current Do-Not-Disturb settings, you must request these permissions from Android 6.0 onwards. You can do this using `AndroidFlutterNotificationsPlugin` by calling the `requestNotificationPolicyAccess()` method which will redirect the user to a settings page where your application may be explicitly whitelisted to bypass DnD.
+
+For notifications to then actually ignore the DnD-status of a device, the channel must be created with `bypassDnd: true`, or the first notification on a channel that creates it must be sent with `channelBypassDnd: true`.
+
+**NOTE:** This does _not_ ignore the device's silent mode! Should you have a use-case where you must notify your users (for instance in an emergency), you might want to use a package like [`sound_mode`](https://pub.dev/packages/sound_mode) or write your own platform specific code to set the `RingerMode` of the device as well as change the notification stream's volume before and after the notification.
+
 ### Release build configuration
 
 ⚠️ Ensure that you have configured the resources that should be kept so that resources like your notification icons aren't discarded by the R8 compiler by following the instructions [here](https://developer.android.com/studio/build/shrink-code#keep-resources). If you have chosen to use `@mipmap/ic_launcher` as the notification icon (against the official Android guidance), be sure to include this in the `keep.xml` file. If you fail to do this, notifications might be broken. In the worst case they will never show, instead silently failing when the system looks for a resource that has been removed. If they do still show, you might not see the icon you specified. The configuration used by the example app can be found [here](https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/example/android/app/src/main/res/raw/keep.xml) where it is specifying that all drawable resources should be kept, as well as the file used to play a custom notification sound (sound file is located [here](https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/example/android/app/src/main/res/raw/slow_spring_board.mp3)).
 
 #### ProGuard rules
 
-For flutter_local_notificaiton v19 and higher, the ProGuard rules are automatically provided by the GSON. The following documentation is for v18 and lower versions.
+For flutter_local_notification v19 and higher, the ProGuard rules are automatically provided by the GSON. The following documentation is for v18 and lower versions.
 
 Before creating the release build of your app (which is the default setting when building an APK or app bundle) you will need to customise your ProGuard configuration file as per this [link](https://developer.android.com/studio/build/shrink-code#keep-code). Rules specific to the GSON dependency being used by the plugin will need to be added. These rules can be found [here](https://github.com/google/gson/blob/main/examples/android-proguard-example/proguard.cfg). Whilst the example app has a Proguard rules (`proguard-rules.pro`) [here](https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/example/android/app/proguard-rules.pro), it is recommended that developers refer to the rules on the GSON repository in case they get updated over time.
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -435,7 +435,7 @@ If your application needs the ability to send notifications that ignore the devi
 
 For notifications to then actually ignore the DnD-status of a device, the channel must be created with `bypassDnd: true`, or the first notification on a channel that creates it must be sent with `channelBypassDnd: true`.
 
-**NOTE:** This does _not_ ignore the device's silent mode! Should you have a use-case where you must notify your users (for instance in an emergency), you might want to use a package like [`sound_mode`](https://pub.dev/packages/sound_mode) or write your own platform specific code to set the `RingerMode` of the device as well as change the notification stream's volume before and after the notification.
+**NOTE:** This does _not_ ignore the device's silent mode! Should you have a use case where you must notify your users (for instance in an emergency), you might want to use a package like [`sound_mode`](https://pub.dev/packages/sound_mode) or write your own platform specific code to set the `RingerMode` of the device as well as change the notification stream's volume before and after the notification.
 
 ### Release build configuration
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -386,7 +386,7 @@ For apps that need the following functionality please complete the following in 
             android:stopWithTask="false"
             android:foregroundServiceType="<foreground service types>">
     ```
-* To be able to create channels that ignore the user's Do-Not-Disturb settings, specify the `<uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />` permission between the `<manifest>` tags. Developers will also need to follow the instructions documented [here](#bypassing-dnd)
+* To be able to create channels that ignore the device's Do Not Disturb mode, specify the `<uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />` permission between the `<manifest>` tags. Developers will also need to follow the instructions documented [here](#bypassing-do-not-disturb-dnd)
 
 Developers can refer to the example app's `AndroidManifest.xml` to help see what the end result may look like. Do note that the example app covers all the plugin's supported functionality so will request more permissions than your own app may need
 
@@ -429,9 +429,9 @@ Note that when a full-screen intent notification actually occurs (as opposed to 
 
 Developers should also be across Google's requirements on using full-screen intents. Please refer to their documentation [here](https://source.android.com/docs/core/permissions/fsi-limits) for more information. Should you app need request permissions, the `AndroidFlutterNotificationsPlugin` class exposes the `requestFullScreenIntentPermission()` method that can be used to do so.
 
-### Bypassing dnd
+### Bypassing Do Not Disturb (DnD)
 
-If your application needs the ability to send notifications that ignore the device's current Do-Not-Disturb settings, you must request these permissions from Android 6.0 onwards. You can do this using `AndroidFlutterNotificationsPlugin` by calling the `requestNotificationPolicyAccess()` method which will redirect the user to a settings page where your application may be explicitly whitelisted to bypass DnD.
+If your application needs the ability to send notifications that ignore the device's DnD mode settings, you must request these permissions from Android 6.0 onwards. You can do this using `AndroidFlutterNotificationsPlugin` by calling the `requestNotificationPolicyAccess()` method which will redirect the user to a settings page where your application may be explicitly whitelisted to bypass DnD.
 
 For notifications to then actually ignore the DnD-status of a device, the channel must be created with `bypassDnd: true`, or the first notification on a channel that creates it must be sent with `channelBypassDnd: true`.
 
@@ -443,7 +443,7 @@ For notifications to then actually ignore the DnD-status of a device, the channe
 
 #### ProGuard rules
 
-For flutter_local_notification v19 and higher, the ProGuard rules are automatically provided by the GSON. The following documentation is for v18 and lower versions.
+For flutter_local_notifications v19 and higher, the ProGuard rules are automatically provided by the GSON. The following documentation is for v18 and lower versions.
 
 Before creating the release build of your app (which is the default setting when building an APK or app bundle) you will need to customise your ProGuard configuration file as per this [link](https://developer.android.com/studio/build/shrink-code#keep-code). Rules specific to the GSON dependency being used by the plugin will need to be added. These rules can be found [here](https://github.com/google/gson/blob/main/examples/android-proguard-example/proguard.cfg). Whilst the example app has a Proguard rules (`proguard-rules.pro`) [here](https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/example/android/app/proguard-rules.pro), it is recommended that developers refer to the rules on the GSON repository in case they get updated over time.
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1215,6 +1215,15 @@ public class FlutterLocalNotificationsPlugin
       } else {
         notificationChannel.setSound(null, null);
       }
+
+      if (notificationChannelDetails.bypassDnd) {
+        if (notificationChannel.canBypassDnd()) {
+          notificationChannel.setBypassDnd(true);
+        } else {
+          Log.w(TAG, "Channel '" + notificationChannelDetails.name + "' was set to bypass Do Not Disturb but the OS prevents it.");
+        }
+      }
+
       notificationChannel.enableVibration(
           BooleanUtils.getValue(notificationChannelDetails.enableVibration));
       if (notificationChannelDetails.vibrationPattern != null

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -39,7 +39,6 @@ import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.AlarmManagerCompat;
 import androidx.core.app.NotificationCompat;
@@ -1919,8 +1918,12 @@ public class FlutterLocalNotificationsPlugin
     }
   }
 
-  @RequiresApi(api = VERSION_CODES.M)
   public void requestNotificationPolicyAccess(@NonNull PermissionRequestListener callback) {
+    if (VERSION.SDK_INT < VERSION_CODES.M) {
+      callback.complete(false);
+      return;
+    }
+
     if (permissionRequestProgress != PermissionRequestProgress.None) {
       callback.fail(PERMISSION_REQUEST_IN_PROGRESS_ERROR_MESSAGE);
       return;
@@ -1943,8 +1946,12 @@ public class FlutterLocalNotificationsPlugin
     }
   }
 
-  @RequiresApi(api = VERSION_CODES.M)
   public void hasNotificationPolicyAccess(Result result) {
+    if (VERSION.SDK_INT < VERSION_CODES.M) {
+      result.success(false);
+      return;
+    }
+
     NotificationManager notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
     boolean isGranted = notificationManager.isNotificationPolicyAccessGranted();
     result.success(isGranted);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1221,10 +1221,11 @@ public class FlutterLocalNotificationsPlugin
       }
 
       if (BooleanUtils.getValue(notificationChannelDetails.bypassDnd)) {
-        notificationChannel.setBypassDnd(true);
-
         boolean isAccessGranted = notificationManager.isNotificationPolicyAccessGranted();
-        if (!isAccessGranted) {
+
+        if (isAccessGranted) {
+          notificationChannel.setBypassDnd(true);
+        } else {
           Log.w(TAG, "Channel '" + notificationChannelDetails.name + "' was set to bypass Do Not Disturb but the OS prevents it.");
         }
       }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationChannelDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationChannelDetails.java
@@ -13,6 +13,7 @@ public class NotificationChannelDetails implements Serializable {
   private static final String GROUP_ID = "groupId";
   private static final String SHOW_BADGE = "showBadge";
   private static final String IMPORTANCE = "importance";
+  private static final String BYPASS_DND = "bypassDnd";
   private static final String PLAY_SOUND = "playSound";
   private static final String SOUND = "sound";
   private static final String SOUND_SOURCE = "soundSource";
@@ -32,6 +33,7 @@ public class NotificationChannelDetails implements Serializable {
   public String groupId;
   public Boolean showBadge;
   public Integer importance;
+  public Boolean bypassDnd;
   public Boolean playSound;
   public String sound;
   public SoundSource soundSource;
@@ -49,6 +51,7 @@ public class NotificationChannelDetails implements Serializable {
     notificationChannel.description = (String) arguments.get(DESCRIPTION);
     notificationChannel.groupId = (String) arguments.get(GROUP_ID);
     notificationChannel.importance = (Integer) arguments.get(IMPORTANCE);
+    notificationChannel.bypassDnd = (Boolean) arguments.get(BYPASS_DND);
     notificationChannel.showBadge = (Boolean) arguments.get(SHOW_BADGE);
     notificationChannel.channelAction =
         NotificationChannelAction.values()[(Integer) arguments.get(CHANNEL_ACTION)];
@@ -82,6 +85,7 @@ public class NotificationChannelDetails implements Serializable {
     notificationChannel.name = notificationDetails.channelName;
     notificationChannel.description = notificationDetails.channelDescription;
     notificationChannel.importance = notificationDetails.importance;
+    notificationChannel.bypassDnd = notificationDetails.channelBypassDnd;
     notificationChannel.showBadge = notificationDetails.channelShowBadge;
     if (notificationDetails.channelAction == null) {
       notificationChannel.channelAction = NotificationChannelAction.CreateIfNotExists;

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -54,6 +54,7 @@ public class NotificationDetails implements Serializable {
   private static final String CHANNEL_DESCRIPTION = "channelDescription";
   private static final String CHANNEL_SHOW_BADGE = "channelShowBadge";
   private static final String IMPORTANCE = "importance";
+  private static final String CHANNEL_BYPASS_DND = "channelBypassDnd";
   private static final String STYLE_INFORMATION = "styleInformation";
   private static final String BIG_TEXT = "bigText";
   private static final String HTML_FORMAT_BIG_TEXT = "htmlFormatBigText";
@@ -137,6 +138,7 @@ public class NotificationDetails implements Serializable {
   public String channelDescription;
   public Boolean channelShowBadge;
   public Integer importance;
+  public Boolean channelBypassDnd;
   public Integer priority;
   public Boolean playSound;
   public String sound;
@@ -391,6 +393,7 @@ public class NotificationDetails implements Serializable {
       notificationDetails.channelDescription =
           (String) platformChannelSpecifics.get(CHANNEL_DESCRIPTION);
       notificationDetails.importance = (Integer) platformChannelSpecifics.get(IMPORTANCE);
+      notificationDetails.channelBypassDnd = (Boolean) platformChannelSpecifics.get(CHANNEL_BYPASS_DND);
       notificationDetails.channelShowBadge =
           (Boolean) platformChannelSpecifics.get(CHANNEL_SHOW_BADGE);
       notificationDetails.channelAction =

--- a/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_local_notifications/example/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
    <!-- NOTE: This permission isn't needed by the local notification plugin. It is only being
         requested because the example app will download remote content to demonstrate some scenarios-->
    <uses-permission android:name="android.permission.INTERNET"/>
+   <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
    <application
         android:label="flutter_local_notifications_example"
         android:icon="@mipmap/ic_launcher">

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2384,7 +2384,7 @@ class _HomePageState extends State<HomePage> {
 
     final bool? hasPolicyAccess =
         await androidPlugin?.hasNotificationPolicyAccess();
-    if (hasPolicyAccess == true) {
+    if (hasPolicyAccess ?? false) {
       await androidPlugin?.requestNotificationPolicyAccess();
     }
 

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2673,6 +2673,7 @@ class _HomePageState extends State<HomePage> {
                         'description: ${channel.description}\n'
                         'groupId: ${channel.groupId}\n'
                         'importance: ${channel.importance.value}\n'
+                        'bypassDnD: ${channel.bypassDnD}\n'
                         'playSound: ${channel.playSound}\n'
                         'sound: ${channel.sound?.sound}\n'
                         'enableVibration: ${channel.enableVibration}\n'

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -296,6 +296,13 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> _requestNotificationPolicyAccess() async {
+    final AndroidFlutterLocalNotificationsPlugin? androidImplementation =
+        flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    await androidImplementation?.requestNotificationPolicyAccess();
+  }
+
   void _configureSelectNotificationSubject() {
     selectNotificationStream.stream
         .listen((NotificationResponse? response) async {
@@ -484,6 +491,10 @@ class _HomePageState extends State<HomePage> {
                     PaddedElevatedButton(
                       buttonText: 'Request permission (API 33+)',
                       onPressed: () => _requestPermissions(),
+                    ),
+                    PaddedElevatedButton(
+                      buttonText: 'Request notification policy access',
+                      onPressed: () => _requestNotificationPolicyAccess(),
                     ),
                     PaddedElevatedButton(
                       buttonText:
@@ -700,6 +711,19 @@ class _HomePageState extends State<HomePage> {
                       buttonText: 'Delete notification channel',
                       onPressed: () async {
                         await _deleteNotificationChannel();
+                      },
+                    ),
+                    PaddedElevatedButton(
+                      buttonText:
+                          'Create notification channel that ignores dnd',
+                      onPressed: () async {
+                        await _createNotificationChannelWithDndBypass();
+                      },
+                    ),
+                    PaddedElevatedButton(
+                      buttonText: 'Show notification that ignores dnd',
+                      onPressed: () async {
+                        await _showNotificationWithDndBypass();
                       },
                     ),
                     PaddedElevatedButton(
@@ -2347,6 +2371,57 @@ class _HomePageState extends State<HomePage> {
             ));
   }
 
+  Future<void> _createNotificationChannelWithDndBypass() async {
+    const AndroidNotificationChannel androidNotificationChannel =
+        AndroidNotificationChannel('your channel id 3', 'your channel name 3',
+            description: 'your channel description 3',
+            bypassDnd: true,
+            importance: Importance.max);
+
+    final AndroidFlutterLocalNotificationsPlugin? androidPlugin =
+        flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+
+    final bool? hasPolicyAccess =
+        await androidPlugin?.hasNotificationPolicyAccess();
+    if (hasPolicyAccess == true) {
+      await androidPlugin?.requestNotificationPolicyAccess();
+    }
+
+    await androidPlugin?.createNotificationChannel(androidNotificationChannel);
+
+    await showDialog(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        content: Text(
+            'Channel with name ${androidNotificationChannel.name} created'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          )
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showNotificationWithDndBypass() async {
+    const AndroidNotificationDetails androidNotificationDetails =
+        AndroidNotificationDetails('your channel id 3', 'your channel name 3',
+            channelDescription: 'your channel description 3',
+            channelBypassDnd: true,
+            importance: Importance.max);
+    const NotificationDetails notificationDetails =
+        NotificationDetails(android: androidNotificationDetails);
+
+    await flutterLocalNotificationsPlugin.show(
+      id++,
+      'I ignored dnd',
+      'I completely ignored dnd',
+      notificationDetails,
+    );
+  }
+
   Future<void> _areNotifcationsEnabledOnAndroid() async {
     final bool? areEnabled = await flutterLocalNotificationsPlugin
         .resolvePlatformSpecificImplementation<
@@ -2673,7 +2748,7 @@ class _HomePageState extends State<HomePage> {
                         'description: ${channel.description}\n'
                         'groupId: ${channel.groupId}\n'
                         'importance: ${channel.importance.value}\n'
-                        'bypassDnD: ${channel.bypassDnD}\n'
+                        'bypassDnd: ${channel.bypassDnd}\n'
                         'playSound: ${channel.playSound}\n'
                         'sound: ${channel.sound?.sound}\n'
                         'enableVibration: ${channel.enableVibration}\n'

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -188,6 +188,26 @@ class AndroidFlutterLocalNotificationsPlugin
   Future<bool?> requestNotificationsPermission() async =>
       _channel.invokeMethod<bool>('requestNotificationsPermission');
 
+  /// Requests access to notification policy. Returns whether the
+  /// permission was granted.
+  ///
+  /// This is required for channels that bypass DnD settings.
+  ///
+  /// See also:
+  ///
+  ///  * https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted()
+  Future<bool?> requestNotificationPolicyAccess() async =>
+      _channel.invokeMethod<bool>('requestNotificationPolicyAccess');
+
+  /// Whether the app has access to notification policy.
+  ///
+  /// See also:
+  ///
+  ///  * https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted()
+  ///  * [requestNotificationPolicyAccess]
+  Future<bool?> hasNotificationPolicyAccess() async =>
+      _channel.invokeMethod<bool>('hasNotificationPolicyAccess');
+
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
   ///
@@ -534,6 +554,7 @@ class AndroidFlutterLocalNotificationsPlugin
               importance: Importance.values
                   // ignore: always_specify_types
                   .firstWhere((i) => i.value == a['importance']),
+              bypassDnd: a['bypassDnd'],
               playSound: a['playSound'],
               sound: _getNotificationChannelSound(a),
               enableLights: a['enableLights'],

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -192,7 +192,11 @@ class AndroidFlutterLocalNotificationsPlugin
   ///
   /// Returns whether the permission was granted.
   ///
-  /// This is required for channels that bypass DnD settings.
+  /// This is required for channels that bypass DnD settings. Any attempt at
+  /// creating a notification channel with `bypassDnd: true` before access is
+  /// granted will print a warning and create the channel *without setting
+  /// bypassDnd*.
+  ///
   /// On Android versions before API level 23, this is a no-op and returns
   /// false.
   ///

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -188,10 +188,13 @@ class AndroidFlutterLocalNotificationsPlugin
   Future<bool?> requestNotificationsPermission() async =>
       _channel.invokeMethod<bool>('requestNotificationsPermission');
 
-  /// Requests access to notification policy. Returns whether the
-  /// permission was granted.
+  /// Requests access to notification policy.
+  ///
+  /// Returns whether the permission was granted.
   ///
   /// This is required for channels that bypass DnD settings.
+  /// On Android versions before API level 23, this is a no-op and returns
+  /// false.
   ///
   /// See also:
   ///
@@ -200,6 +203,8 @@ class AndroidFlutterLocalNotificationsPlugin
       _channel.invokeMethod<bool>('requestNotificationPolicyAccess');
 
   /// Whether the app has access to notification policy.
+  ///
+  /// On Android versions before API level 23, this will always return false.
   ///
   /// See also:
   ///

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -45,6 +45,7 @@ extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
         'groupId': groupId,
         'showBadge': showBadge,
         'importance': importance.value,
+        'bypassDnd': bypassDnd,
         'playSound': playSound,
         'enableVibration': enableVibration,
         'vibrationPattern': vibrationPattern,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -180,6 +180,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'channelShowBadge': channelShowBadge,
         'channelAction': channelAction.index,
         'importance': importance.value,
+        'channelBypassDnd': channelBypassDnd,
         'priority': priority.value,
         'playSound': playSound,
         'enableVibration': enableVibration,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
@@ -40,7 +40,7 @@ class AndroidNotificationChannel {
   final Importance importance;
 
   /// Whether the notification channel should attempt to bypass Do Not Disturb
-  /// settings
+  /// settings.
   final bool bypassDnd;
 
   /// Indicates if a sound should be played when the notification is displayed.
@@ -84,11 +84,11 @@ class AndroidNotificationChannel {
   final Color? ledColor;
 
   /// Whether notifications posted to this channel can appear as application
-  /// icon badges in a Launcher
+  /// icon badges in a Launcher.
   final bool showBadge;
 
   /// The attribute describing what is the intended use of the audio signal,
-  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int))
+  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int)).
   /// https://developer.android.com/reference/android/media/AudioAttributes
   final AudioAttributesUsage audioAttributesUsage;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
@@ -13,6 +13,7 @@ class AndroidNotificationChannel {
     this.description,
     this.groupId,
     this.importance = Importance.defaultImportance,
+    this.bypassDnD = false,
     this.playSound = true,
     this.sound,
     this.enableVibration = true,
@@ -38,6 +39,10 @@ class AndroidNotificationChannel {
   /// The importance of the notification.
   final Importance importance;
 
+  /// Whether the notification channel should attempt to bypass Do Not Disturb
+  /// settings
+  final bool bypassDnD;
+
   /// Indicates if a sound should be played when the notification is displayed.
   ///
   /// Tied to the specified channel and cannot be changed after the channel has
@@ -54,7 +59,7 @@ class AndroidNotificationChannel {
 
   /// Indicates if vibration should be enabled when the notification is
   /// displayed.
-  //
+  ///
   /// Tied to the specified channel and cannot be changed after the channel has
   /// been created for the first time.
   final bool enableVibration;

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
@@ -13,7 +13,7 @@ class AndroidNotificationChannel {
     this.description,
     this.groupId,
     this.importance = Importance.defaultImportance,
-    this.bypassDnD = false,
+    this.bypassDnd = false,
     this.playSound = true,
     this.sound,
     this.enableVibration = true,
@@ -41,7 +41,7 @@ class AndroidNotificationChannel {
 
   /// Whether the notification channel should attempt to bypass Do Not Disturb
   /// settings
-  final bool bypassDnD;
+  final bool bypassDnd;
 
   /// Indicates if a sound should be played when the notification is displayed.
   ///

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_channel.dart
@@ -41,6 +41,10 @@ class AndroidNotificationChannel {
 
   /// Whether the notification channel should attempt to bypass Do Not Disturb
   /// settings.
+  ///
+  /// You must acquire notification policy access by calling
+  /// [AndroidFlutterLocalNotificationsPlugin.requestNotificationPolicyAccess]
+  /// before setting this to true. Otherwise this value is ignored.
   final bool bypassDnd;
 
   /// Indicates if a sound should be played when the notification is displayed.

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -171,14 +171,14 @@ class AndroidNotificationDetails {
   final String? channelDescription;
 
   /// Whether notifications posted to this channel can appear as application
-  /// icon badges in a Launcher
+  /// icon badges in a Launcher.
   final bool channelShowBadge;
 
   /// The importance of the notification.
   final Importance importance;
 
   /// Whether the notification channel should attempt to bypass Do Not Disturb
-  /// settings
+  /// settings.
   final bool channelBypassDnd;
 
   /// The priority of the notification
@@ -322,7 +322,7 @@ class AndroidNotificationDetails {
   /// The action to take for managing notification channels.
   ///
   /// Defaults to creating the notification channel using the provided details
-  /// if it doesn't exist
+  /// if it doesn't exist.
   final AndroidNotificationChannelAction channelAction;
 
   /// Defines the notification visibility on the lockscreen.
@@ -410,7 +410,7 @@ class AndroidNotificationDetails {
   final int? number;
 
   /// The attribute describing what is the intended use of the audio signal,
-  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int))
+  /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int)).
   /// https://developer.android.com/reference/android/media/AudioAttributes
   final AudioAttributesUsage audioAttributesUsage;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -179,6 +179,10 @@ class AndroidNotificationDetails {
 
   /// Whether the notification channel should attempt to bypass Do Not Disturb
   /// settings.
+  ///
+  /// You must acquire notification policy access by calling
+  /// [AndroidFlutterLocalNotificationsPlugin.requestNotificationPolicyAccess]
+  /// before setting this to true. Otherwise this value is ignored.
   final bool channelBypassDnd;
 
   /// The priority of the notification

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -104,6 +104,7 @@ class AndroidNotificationDetails {
     this.channelDescription,
     this.icon,
     this.importance = Importance.defaultImportance,
+    this.channelBypassDnd = false,
     this.priority = Priority.defaultPriority,
     this.styleInformation,
     this.playSound = true,
@@ -175,6 +176,10 @@ class AndroidNotificationDetails {
 
   /// The importance of the notification.
   final Importance importance;
+
+  /// Whether the notification channel should attempt to bypass Do Not Disturb
+  /// settings
+  final bool channelBypassDnd;
 
   /// The priority of the notification
   final Priority priority;

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -130,6 +130,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -252,6 +253,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -336,6 +338,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -421,6 +424,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -507,6 +511,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -595,6 +600,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -684,6 +690,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -773,6 +780,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -861,6 +869,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -951,6 +960,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1056,6 +1066,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1155,6 +1166,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1260,6 +1272,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1357,6 +1370,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1458,6 +1472,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1550,6 +1565,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1639,6 +1655,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1735,6 +1752,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1860,6 +1878,7 @@ void main() {
               'channelName': 'channelName',
               'channelDescription': 'channelDescription',
               'channelShowBadge': true,
+              'channelBypassDnd': false,
               'channelAction':
                   AndroidNotificationChannelAction.createIfNotExists.index,
               'importance': Importance.defaultImportance.value,
@@ -1974,6 +1993,7 @@ void main() {
                     'channelName': 'channelName',
                     'channelDescription': 'channelDescription',
                     'channelShowBadge': true,
+                    'channelBypassDnd': false,
                     'channelAction': AndroidNotificationChannelAction
                         .createIfNotExists.index,
                     'importance': Importance.defaultImportance.value,
@@ -2108,6 +2128,7 @@ void main() {
                         'channelName': 'channelName',
                         'channelDescription': 'channelDescription',
                         'channelShowBadge': true,
+                        'channelBypassDnd': false,
                         'channelAction': AndroidNotificationChannelAction
                             .createIfNotExists.index,
                         'importance': Importance.defaultImportance.value,
@@ -2204,6 +2225,7 @@ void main() {
                 'channelName': 'channelName',
                 'channelDescription': 'channelDescription',
                 'channelShowBadge': true,
+                'channelBypassDnd': false,
                 'channelAction':
                     AndroidNotificationChannelAction.createIfNotExists.index,
                 'importance': Importance.defaultImportance.value,
@@ -2299,6 +2321,7 @@ void main() {
                 'channelName': 'channelName',
                 'channelDescription': 'channelDescription',
                 'channelShowBadge': true,
+                'channelBypassDnd': false,
                 'channelAction':
                     AndroidNotificationChannelAction.createIfNotExists.index,
                 'importance': Importance.defaultImportance.value,
@@ -2395,6 +2418,7 @@ void main() {
                 'channelName': 'channelName',
                 'channelDescription': 'channelDescription',
                 'channelShowBadge': true,
+                'channelBypassDnd': false,
                 'channelAction':
                     AndroidNotificationChannelAction.createIfNotExists.index,
                 'importance': Importance.defaultImportance.value,
@@ -2501,6 +2525,7 @@ void main() {
           'groupId': null,
           'showBadge': true,
           'importance': Importance.defaultImportance.value,
+          'bypassDnd': false,
           'playSound': true,
           'enableVibration': true,
           'vibrationPattern': null,
@@ -2526,6 +2551,7 @@ void main() {
             description: 'channelDescription',
             groupId: 'channelGroupId',
             showBadge: false,
+            bypassDnd: true,
             importance: Importance.max,
             playSound: false,
             enableLights: true,
@@ -2541,6 +2567,7 @@ void main() {
           'groupId': 'channelGroupId',
           'showBadge': false,
           'importance': Importance.max.value,
+          'bypassDnd': true,
           'playSound': false,
           'enableVibration': false,
           'vibrationPattern': null,
@@ -2695,6 +2722,7 @@ void main() {
                   'channelName': 'channelName',
                   'channelDescription': 'channelDescription',
                   'channelShowBadge': true,
+                  'channelBypassDnd': false,
                   'channelAction':
                       AndroidNotificationChannelAction.createIfNotExists.index,
                   'importance': Importance.defaultImportance.value,


### PR DESCRIPTION
Closes #1211 

- Adds new `bypassDnd` and `channelBypassDnd` options for `AndroidNotificationChannel` and `AndroidNotificationDetails` respectively
- Adds `hasNotificationPolicyAccess()` and `requestNotificationPolicyAccess()` methods to `AndroidFlutterLocalNotificationsPlugin`
- Adds relevant buttons to example
- Adds README-entry