### PR TITLE
[flutter_local_notifications] fix: typo in README

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -352,7 +352,7 @@ android {
 
 ### AndroidManifest.xml setup
 
-Previously the plugin would specify all the permissions required all of the features that the plugin support in its own `AndroidManifest.xml` file so that developers wouldn't need to do this in their own app's `AndroidManifest.xml` file. Since version 16 onwards, the plugin will now only specify the bare minimum and these [`POST_NOTIFICATIONS`] (https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS) and [`VIBRATE`](https://developer.android.com/reference/android/Manifest.permission#VIBRATE) permissions.
+Previously the plugin would specify all the permissions required all of the features that the plugin support in its own `AndroidManifest.xml` file so that developers wouldn't need to do this in their own app's `AndroidManifest.xml` file. Since version 16 onwards, the plugin will now only specify the bare minimum and these [`POST_NOTIFICATIONS`](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS) and [`VIBRATE`](https://developer.android.com/reference/android/Manifest.permission#VIBRATE) permissions.
 
 For apps that need the following functionality please complete the following in your app's `AndroidManifest.xml`
 


### PR DESCRIPTION
A space was preventing the link from properly rendering.

As this repository hosts multiple packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). Should the PR more than one package than please prefix the title of the PR with [various] The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
