### PR TITLE
[flutter_local_notifications] Add setting for ios critical alert volume

### DIFF
--- a/flutter_local_notifications/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter_local_notifications/example/ios/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		0BF8A02F46B02144A4EE82AD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		20FBC34C2D993B2100BB4F3B /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -155,6 +156,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				20FBC34C2D993B2100BB4F3B /* RunnerDebug.entitlements */,
 				519146162A0D159A0093315A /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,

--- a/flutter_local_notifications/example/ios/Runner/RunnerDebug.entitlements
+++ b/flutter_local_notifications/example/ios/Runner/RunnerDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
+</dict>
+</plist>

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -2733,8 +2733,10 @@ class _HomePageState extends State<HomePage> {
   Future<void> _showNotificationWithCriticalSound() async {
     const DarwinNotificationDetails darwinNotificationDetails =
         DarwinNotificationDetails(
-      criticalSoundVolume: 0.2,
-      interruptionLevel: InterruptionLevel.critical,
+      // Between 0.0 and 1.0
+      criticalSoundVolume: 0.5,
+      // If sound is not specified, the default sound will be used
+      sound: 'slow_spring_board.aiff',
     );
     const NotificationDetails notificationDetails = NotificationDetails(
       iOS: darwinNotificationDetails,

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -745,7 +745,7 @@ class _HomePageState extends State<HomePage> {
                     ),
                     PaddedElevatedButton(
                       buttonText:
-                          'Request permission with Critical Alert Permission',
+                          'Request permission with critical alert permission',
                       onPressed: _requestPermissionsWithCriticalAlert,
                     ),
                     PaddedElevatedButton(

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -273,6 +273,29 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> _requestPermissionsWithCriticalAlert() async {
+    if (Platform.isIOS || Platform.isMacOS) {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+            critical: true,
+          );
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              MacOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+            critical: true,
+          );
+    }
+  }
+
   void _configureSelectNotificationSubject() {
     selectNotificationStream.stream
         .listen((NotificationResponse? response) async {
@@ -721,9 +744,20 @@ class _HomePageState extends State<HomePage> {
                       onPressed: _requestPermissions,
                     ),
                     PaddedElevatedButton(
+                      buttonText:
+                          'Request permission with Critical Alert Permission',
+                      onPressed: _requestPermissionsWithCriticalAlert,
+                    ),
+                    PaddedElevatedButton(
                       buttonText: 'Show notification with subtitle',
                       onPressed: () async {
                         await _showNotificationWithSubtitle();
+                      },
+                    ),
+                    PaddedElevatedButton(
+                      buttonText: 'Show notification with critical sound',
+                      onPressed: () async {
+                        await _showNotificationWithCriticalSound();
                       },
                     ),
                     PaddedElevatedButton(
@@ -2693,6 +2727,24 @@ class _HomePageState extends State<HomePage> {
       'notification sound controlled by alarm volume',
       'alarm notification sound body',
       platformChannelSpecifics,
+    );
+  }
+
+  Future<void> _showNotificationWithCriticalSound() async {
+    const DarwinNotificationDetails darwinNotificationDetails =
+        DarwinNotificationDetails(
+      criticalSoundVolume: 0.2,
+      interruptionLevel: InterruptionLevel.critical,
+    );
+    const NotificationDetails notificationDetails = NotificationDetails(
+      iOS: darwinNotificationDetails,
+      macOS: darwinNotificationDetails,
+    );
+    await flutterLocalNotificationsPlugin.show(
+      id++,
+      'Critical sound notification title',
+      'Critical sound notification body',
+      notificationDetails,
     );
   }
 }

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -105,6 +105,8 @@ NSString *const IS_BADGE_ENABLED = @"isBadgeEnabled";
 NSString *const IS_PROVISIONAL_ENABLED = @"isProvisionalEnabled";
 NSString *const IS_CRITICAL_ENABLED = @"isCriticalEnabled";
 
+NSString *const CRITICAL_SOUND_VOLUME = @"criticalSoundVolume";
+
 typedef NS_ENUM(NSInteger, RepeatInterval) {
   EveryMinute,
   Hourly,
@@ -677,7 +679,19 @@ static FlutterError *getFlutterError(NSError *error) {
       }
     }
     if ([self containsKey:SOUND forDictionary:platformSpecifics]) {
-      content.sound = [UNNotificationSound soundNamed:platformSpecifics[SOUND]];
+      NSString *soundName = platformSpecifics[SOUND];
+      if (@available(iOS 12.0, *)) {
+        if ([self containsKey:REQUEST_CRITICAL_PERMISSION forDictionary:arguments] &&
+            [arguments[REQUEST_CRITICAL_PERMISSION] boolValue] &&
+            [self containsKey:CRITICAL_SOUND_VOLUME forDictionary:platformSpecifics]) {
+          NSNumber *volume = platformSpecifics[CRITICAL_SOUND_VOLUME];
+          content.sound = [UNNotificationSound criticalSoundNamed:soundName withAudioVolume:[volume floatValue]];
+        } else {
+          content.sound = [UNNotificationSound soundNamed:soundName];
+        }
+      } else {
+        content.sound = [UNNotificationSound soundNamed:soundName];
+      }
     }
     if ([self containsKey:SUBTITLE forDictionary:platformSpecifics]) {
       content.subtitle = platformSpecifics[SUBTITLE];

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -679,18 +679,17 @@ static FlutterError *getFlutterError(NSError *error) {
       }
     }
     if ([self containsKey:SOUND forDictionary:platformSpecifics]) {
-      NSString *soundName = platformSpecifics[SOUND];
-      if (@available(iOS 12.0, *)) {
-        if ([self containsKey:REQUEST_CRITICAL_PERMISSION forDictionary:arguments] &&
-            [arguments[REQUEST_CRITICAL_PERMISSION] boolValue] &&
-            [self containsKey:CRITICAL_SOUND_VOLUME forDictionary:platformSpecifics]) {
-          NSNumber *volume = platformSpecifics[CRITICAL_SOUND_VOLUME];
+      content.sound = [UNNotificationSound soundNamed:platformSpecifics[SOUND]];
+    }
+    if (@available(iOS 12.0, *)) {
+      if ([self containsKey:CRITICAL_SOUND_VOLUME forDictionary:platformSpecifics]) {
+        NSString *soundName = platformSpecifics[SOUND];
+        NSNumber *volume = platformSpecifics[CRITICAL_SOUND_VOLUME];
+        if (soundName) {
           content.sound = [UNNotificationSound criticalSoundNamed:soundName withAudioVolume:[volume floatValue]];
         } else {
-          content.sound = [UNNotificationSound soundNamed:soundName];
+          content.sound = [UNNotificationSound defaultCriticalSoundWithAudioVolume:[volume floatValue]];
         }
-      } else {
-        content.sound = [UNNotificationSound soundNamed:soundName];
       }
     }
     if ([self containsKey:SUBTITLE forDictionary:platformSpecifics]) {

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -683,12 +683,12 @@ static FlutterError *getFlutterError(NSError *error) {
     }
     if (@available(iOS 12.0, *)) {
       if ([self containsKey:CRITICAL_SOUND_VOLUME forDictionary:platformSpecifics]) {
-        NSString *soundName = platformSpecifics[SOUND];
         NSNumber *volume = platformSpecifics[CRITICAL_SOUND_VOLUME];
-        if (soundName) {
-          content.sound = [UNNotificationSound criticalSoundNamed:soundName withAudioVolume:[volume floatValue]];
+        // NOTE: When converting from Flutter to Objective-C, doubleValue is typically used, but this function accepts a float. As the expected value falls between 0.0 and 0.1, we will cast it directly.
+        if ([self containsKey:SOUND forDictionary:platformSpecifics]) {
+          content.sound = [UNNotificationSound criticalSoundNamed:platformSpecifics[SOUND] withAudioVolume:(float)[volume doubleValue]];
         } else {
-          content.sound = [UNNotificationSound defaultCriticalSoundWithAudioVolume:[volume floatValue]];
+          content.sound = [UNNotificationSound defaultCriticalSoundWithAudioVolume:(float)[volume doubleValue]];
         }
       }
     }

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/mappers.dart
@@ -83,5 +83,6 @@ extension DarwinNotificationDetailsMapper on DarwinNotificationDetails {
             ?.map((a) => a.toMap()) // ignore: always_specify_types
             .toList(),
         'categoryIdentifier': categoryIdentifier,
+        'criticalSoundVolume': criticalSoundVolume,
       };
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
@@ -142,6 +142,7 @@ class DarwinNotificationDetails {
   final InterruptionLevel? interruptionLevel;
 
   /// The volume for playing the critical alert sound.
+  ///
   /// The value is between 0.0 and 1.0.
   /// This is only used when the notification is configured as a critical alert.
   /// Document: https://developer.apple.com/documentation/usernotifications/unnotificationsound/criticalsoundnamed(_:withaudiovolume:)

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
@@ -150,6 +150,7 @@ class DarwinNotificationDetails {
   /// Subject to specific approval from Apple:
   /// https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
   ///
-  /// This property is only applicable to iOS 12.0 or newer.
+  /// On iOS, this property is only applicable to iOS 12.0 or newer.
+  /// On macOS, this property is only applicable to macOS 10.14 or newer.
   final double? criticalSoundVolume;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
@@ -144,6 +144,7 @@ class DarwinNotificationDetails {
   /// The volume for playing the critical alert sound.
   /// The value is between 0.0 and 1.0.
   /// This is only used when the notification is configured as a critical alert.
+  /// Document: https://developer.apple.com/documentation/usernotifications/unnotificationsound/criticalsoundnamed(_:withaudiovolume:)
   ///
   /// Subject to specific approval from Apple:
   /// https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/

--- a/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/darwin/notification_details.dart
@@ -18,6 +18,7 @@ class DarwinNotificationDetails {
     this.threadIdentifier,
     this.categoryIdentifier,
     this.interruptionLevel,
+    this.criticalSoundVolume,
   });
 
   /// Indicates if an alert should be display when the notification is triggered
@@ -139,4 +140,14 @@ class DarwinNotificationDetails {
   /// This property is only applicable to iOS 15.0 and macOS 12.0 or newer.
   /// https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3747256-interruptionlevel
   final InterruptionLevel? interruptionLevel;
+
+  /// The volume for playing the critical alert sound.
+  /// The value is between 0.0 and 1.0.
+  /// This is only used when the notification is configured as a critical alert.
+  ///
+  /// Subject to specific approval from Apple:
+  /// https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
+  ///
+  /// This property is only applicable to iOS 12.0 or newer.
+  final double? criticalSoundVolume;
 }

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -543,14 +543,14 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         var presentBanner = persistedPresentationOptions[MethodCallArguments.presentBanner] as! Bool
         var presentList = persistedPresentationOptions[MethodCallArguments.presentList] as! Bool
         if let platformSpecifics = arguments[MethodCallArguments.platformSpecifics] as? [String: AnyObject] {
-            if let sound = platformSpecifics[MethodCallArguments.sound] as? String {
-                if #available(macOS 10.14, *) {
-                    if let requestCriticalPermission = arguments[MethodCallArguments.requestCriticalPermission] as? Bool,
-                       requestCriticalPermission,
-                       let volume = platformSpecifics[MethodCallArguments.criticalSoundVolume] as? NSNumber {
+            content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
+            
+            if #available(macOS 10.14, *) {
+              if let volume = platformSpecifics[MethodCallArguments.criticalSoundVolume] as? NSNumber {
+                    if let sound = platformSpecifics[MethodCallArguments.sound] as? String {
                         content.sound = UNNotificationSound.criticalSoundNamed(UNNotificationSoundName(sound), withAudioVolume: volume.floatValue)
                     } else {
-                        content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
+                        content.sound = UNNotificationSound.defaultCriticalSound(withAudioVolume: volume.floatValue)
                     }
                 }
             }

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -54,6 +54,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         static let isBadgeEnabled = "isBadgeEnabled"
         static let isProvisionalEnabled = "isProvisionalEnabled"
         static let isCriticalEnabled = "isCriticalEnabled"
+        static let criticalSoundVolume = "criticalSoundVolume"
     }
 
     struct ErrorMessages {
@@ -543,7 +544,15 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         var presentList = persistedPresentationOptions[MethodCallArguments.presentList] as! Bool
         if let platformSpecifics = arguments[MethodCallArguments.platformSpecifics] as? [String: AnyObject] {
             if let sound = platformSpecifics[MethodCallArguments.sound] as? String {
-                content.sound = UNNotificationSound.init(named: UNNotificationSoundName.init(sound))
+                if #available(macOS 10.14, *) {
+                    if let requestCriticalPermission = arguments[MethodCallArguments.requestCriticalPermission] as? Bool,
+                       requestCriticalPermission,
+                       let volume = platformSpecifics[MethodCallArguments.criticalSoundVolume] as? NSNumber {
+                        content.sound = UNNotificationSound.criticalSoundNamed(UNNotificationSoundName(sound), withAudioVolume: volume.floatValue)
+                    } else {
+                        content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
+                    }
+                }
             }
             if let badgeNumber = platformSpecifics[MethodCallArguments.badgeNumber] as? NSNumber {
                 content.badge = badgeNumber

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -543,8 +543,10 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         var presentBanner = persistedPresentationOptions[MethodCallArguments.presentBanner] as! Bool
         var presentList = persistedPresentationOptions[MethodCallArguments.presentList] as! Bool
         if let platformSpecifics = arguments[MethodCallArguments.platformSpecifics] as? [String: AnyObject] {
-            content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
-            
+            if let sound = platformSpecifics[MethodCallArguments.sound] as? String {
+                content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
+            }
+
             if #available(macOS 10.14, *) {
               if let volume = platformSpecifics[MethodCallArguments.criticalSoundVolume] as? NSNumber {
                     if let sound = platformSpecifics[MethodCallArguments.sound] as? String {

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -544,7 +544,7 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         var presentList = persistedPresentationOptions[MethodCallArguments.presentList] as! Bool
         if let platformSpecifics = arguments[MethodCallArguments.platformSpecifics] as? [String: AnyObject] {
             if let sound = platformSpecifics[MethodCallArguments.sound] as? String {
-                content.sound = UNNotificationSound(named: UNNotificationSoundName(sound))
+              content.sound = UNNotificationSound.init(named: UNNotificationSoundName.init(sound))
             }
 
             if #available(macOS 10.14, *) {

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -237,6 +237,7 @@ void main() {
                 identifier: '2b3f705f-a680-4c9f-8075-a46a70e28373'),
           ],
           categoryIdentifier: 'category1',
+          criticalSoundVolume: 0.5,
         ),
       );
 
@@ -270,6 +271,7 @@ void main() {
               ],
               'categoryIdentifier': 'category1',
               'interruptionLevel': null,
+              'criticalSoundVolume': 0.5,
             },
           }));
     });
@@ -343,6 +345,7 @@ void main() {
                     ],
                     'categoryIdentifier': null,
                     'interruptionLevel': null,
+                    'criticalSoundVolume': null,
                   },
                 },
               ),
@@ -470,6 +473,7 @@ void main() {
                     ],
                     'categoryIdentifier': null,
                     'interruptionLevel': null,
+                    'criticalSoundVolume': null,
                   },
                 },
               ),
@@ -543,6 +547,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             }));
       });
@@ -612,6 +617,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             }));
       });
@@ -682,6 +688,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             }));
       });

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -137,6 +137,7 @@ void main() {
           ],
           categoryIdentifier: 'category1',
           interruptionLevel: InterruptionLevel.timeSensitive,
+          criticalSoundVolume: 0.5,
         ),
       );
 
@@ -176,6 +177,7 @@ void main() {
               ],
               'categoryIdentifier': 'category1',
               'interruptionLevel': 2,
+              'criticalSoundVolume': 0.5,
             },
           },
         ),
@@ -250,6 +252,7 @@ void main() {
                     ],
                     'categoryIdentifier': null,
                     'interruptionLevel': null,
+                    'criticalSoundVolume': null,
                   },
                 }));
           });
@@ -376,6 +379,7 @@ void main() {
                         ],
                         'categoryIdentifier': null,
                         'interruptionLevel': null,
+                        'criticalSoundVolume': null,
                       },
                     }));
           });
@@ -449,6 +453,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             }));
       });
@@ -523,6 +528,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             },
           ),
@@ -600,6 +606,7 @@ void main() {
                 ],
                 'categoryIdentifier': null,
                 'interruptionLevel': null,
+                'criticalSoundVolume': null,
               },
             },
           ),


### PR DESCRIPTION
## Description

This PR adds support for Critical Alert notifications on iOS/macOS platforms. Critical Alert notifications are a special type of notification that can break through Do Not Disturb and silent mode settings, requiring specific entitlements from Apple.

Reference: https://developer.apple.com/documentation/usernotifications/unnotificationsound/criticalsoundnamed(_:withaudiovolume:)
Related issue: https://github.com/MaikuB/flutter_local_notifications/issues/528

## Diff
- Add settings about Critical Alert volume. Ability to set critical sound volume (between 0.0 and 1.0)

### Example
- New example demonstrating Critical Alert functionality
- Added necessary entitlements file for debug builds
  * I tried to add it to the release build too, but the Critical Alert entitlement cannot actually be added without applying to Apple. For verification purposes, I’ve added a DEBUG-specific .entitlements file.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] Tests passed
- [x] I have updated the example.

## Breaking Changes
None

## Platform Specific Notes

This feature is only available on:
- iOS 12.0 or newer
- macOS 10.14 or newer

Note: Critical Alert capability requires special entitlement approval from Apple through their developer portal.