### PR TITLE
[flutter_local_notifications] (rebased) Apply named parameters for functions in lib/src/flutter_local_notifications_plugin.dart

### DIFF
--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -1039,7 +1039,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1130,7 +1133,10 @@ class _HomePageState extends State<HomePage> {
       windows: windowsNotificationsDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item z');
   }
 
@@ -1181,8 +1187,11 @@ class _HomePageState extends State<HomePage> {
       windows: windowsNotificationDetails,
     );
 
-    await flutterLocalNotificationsPlugin.show(id++, 'Text Input Notification',
-        'Expand to see input action', notificationDetails,
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'Text Input Notification',
+        body: 'Expand to see input action',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1201,7 +1210,10 @@ class _HomePageState extends State<HomePage> {
       linux: linuxNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item z');
   }
 
@@ -1260,7 +1272,10 @@ class _HomePageState extends State<HomePage> {
       windows: windowsNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1305,11 +1320,12 @@ class _HomePageState extends State<HomePage> {
           TextButton(
             onPressed: () async {
               await flutterLocalNotificationsPlugin.zonedSchedule(
-                  0,
-                  'scheduled title',
-                  'scheduled body',
-                  tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
-                  const NotificationDetails(
+                  id: 0,
+                  title: 'scheduled title',
+                  body: 'scheduled body',
+                  scheduledDate: tz.TZDateTime.now(tz.local)
+                      .add(const Duration(seconds: 5)),
+                  notificationDetails: const NotificationDetails(
                       android: AndroidNotificationDetails(
                           'full screen channel id', 'full screen channel name',
                           channelDescription: 'full screen channel description',
@@ -1338,7 +1354,9 @@ class _HomePageState extends State<HomePage> {
       android: androidNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', null, notificationDetails,
+        id: id++,
+        body: 'plain title',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1352,8 +1370,11 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
       android: androidNotificationDetails,
     );
-    await flutterLocalNotificationsPlugin
-        .show(id++, null, 'plain body', notificationDetails, payload: 'item x');
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        body: 'plain body',
+        notificationDetails: notificationDetails,
+        payload: 'item x');
   }
 
   Future<void> _cancelNotification() async {
@@ -1395,10 +1416,10 @@ class _HomePageState extends State<HomePage> {
       windows: windowsNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-      id++,
-      'custom sound notification title',
-      'custom sound notification body',
-      notificationDetails,
+      id: id++,
+      title: 'custom sound notification title',
+      body: 'custom sound notification body',
+      notificationDetails: notificationDetails,
     );
   }
 
@@ -1425,19 +1446,22 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'title of notification with custom vibration pattern, LED and icon',
-        'body of notification with custom vibration pattern, LED and icon',
-        notificationDetails);
+        id: id++,
+        title:
+            'title of notification with custom vibration pattern, LED and icon',
+        body:
+            'body of notification with custom vibration pattern, LED and icon',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _zonedScheduleNotification() async {
     await flutterLocalNotificationsPlugin.zonedSchedule(
-        0,
-        'scheduled title',
-        'scheduled body',
-        tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
-        const NotificationDetails(
+        id: 0,
+        title: 'scheduled title',
+        body: 'scheduled body',
+        scheduledDate:
+            tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
+        notificationDetails: const NotificationDetails(
             android: AndroidNotificationDetails(
                 'your channel id', 'your channel name',
                 channelDescription: 'your channel description')),
@@ -1446,11 +1470,12 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _zonedScheduleAlarmClockNotification() async {
     await flutterLocalNotificationsPlugin.zonedSchedule(
-        123,
-        'scheduled alarm clock title',
-        'scheduled alarm clock body',
-        tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
-        const NotificationDetails(
+        id: 123,
+        title: 'scheduled alarm clock title',
+        body: 'scheduled alarm clock body',
+        scheduledDate:
+            tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
+        notificationDetails: const NotificationDetails(
             android: AndroidNotificationDetails(
                 'alarm_clock_channel', 'Alarm Clock Channel',
                 channelDescription: 'Alarm Clock Notification')),
@@ -1475,7 +1500,10 @@ class _HomePageState extends State<HomePage> {
         iOS: darwinNotificationDetails,
         macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, '<b>silent</b> title', '<b>silent</b> body', notificationDetails);
+        id: id++,
+        title: '<b>silent</b> title',
+        body: '<b>silent</b> body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showNotificationSilently() async {
@@ -1498,7 +1526,10 @@ class _HomePageState extends State<HomePage> {
         iOS: darwinNotificationDetails,
         macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, '<b>silent</b> title', '<b>silent</b> body', notificationDetails);
+        id: id++,
+        title: '<b>silent</b> title',
+        body: '<b>silent</b> body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showSoundUriNotification() async {
@@ -1516,7 +1547,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'uri sound title', 'uri sound body', notificationDetails);
+        id: id++,
+        title: 'uri sound title',
+        body: 'uri sound body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showTimeoutNotification() async {
@@ -1527,8 +1561,11 @@ class _HomePageState extends State<HomePage> {
             styleInformation: DefaultStyleInformation(true, true));
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
-    await flutterLocalNotificationsPlugin.show(id++, 'timeout notification',
-        'Times out after 3 seconds', notificationDetails);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'timeout notification',
+        body: 'Times out after 3 seconds',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showInsistentNotification() async {
@@ -1544,7 +1581,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'insistent title', 'insistent body', notificationDetails,
+        id: id++,
+        title: 'insistent title',
+        body: 'insistent body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1577,7 +1617,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'big text title', 'silent body', notificationDetails);
+        id: id++,
+        title: 'big text title',
+        body: 'silent body',
+        notificationDetails: notificationDetails);
   }
 
   Future<String> _base64encodedImage(String url) async {
@@ -1609,7 +1652,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'big text title', 'silent body', notificationDetails);
+        id: id++,
+        title: 'big text title',
+        body: 'silent body',
+        notificationDetails: notificationDetails);
   }
 
   Future<Uint8List> _getByteArrayFromUrl(String url) async {
@@ -1638,7 +1684,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'big text title', 'silent body', notificationDetails);
+        id: id++,
+        title: 'big text title',
+        body: 'silent body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showBigPictureNotificationHiddenLargeIcon() async {
@@ -1662,7 +1711,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'big text title', 'silent body', notificationDetails);
+        id: id++,
+        title: 'big text title',
+        body: 'silent body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showNotificationMediaStyle() async {
@@ -1679,7 +1731,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'notification title', 'notification body', notificationDetails);
+        id: id++,
+        title: 'notification title',
+        body: 'notification body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showBigTextNotification() async {
@@ -1700,7 +1755,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'big text title', 'silent body', notificationDetails);
+        id: id++,
+        title: 'big text title',
+        body: 'silent body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showInboxNotification() async {
@@ -1719,7 +1777,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'inbox title', 'inbox body', notificationDetails);
+        id: id++,
+        title: 'inbox title',
+        body: 'inbox body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showMessagingNotification() async {
@@ -1786,14 +1847,20 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id, 'message title', 'message body', notificationDetails);
+        id: id,
+        title: 'message title',
+        body: 'message body',
+        notificationDetails: notificationDetails);
 
     // wait 10 seconds and add another message to simulate another response
     await Future<void>.delayed(const Duration(seconds: 10), () async {
       messages.add(Message("I'm so sorry!!! But I really like thai food ...",
           DateTime.now().add(const Duration(minutes: 11)), null));
       await flutterLocalNotificationsPlugin.show(
-          id++, 'message title', 'message body', notificationDetails);
+          id: id++,
+          title: 'message title',
+          body: 'message body',
+          notificationDetails: notificationDetails);
     });
   }
 
@@ -1811,8 +1878,11 @@ class _HomePageState extends State<HomePage> {
             groupKey: groupKey);
     const NotificationDetails firstNotificationPlatformSpecifics =
         NotificationDetails(android: firstNotificationAndroidSpecifics);
-    await flutterLocalNotificationsPlugin.show(id++, 'Alex Faarborg',
-        'You will not believe...', firstNotificationPlatformSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'Alex Faarborg',
+        body: 'You will not believe...',
+        notificationDetails: firstNotificationPlatformSpecifics);
     const AndroidNotificationDetails secondNotificationAndroidSpecifics =
         AndroidNotificationDetails(groupChannelId, groupChannelName,
             channelDescription: groupChannelDescription,
@@ -1822,10 +1892,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails secondNotificationPlatformSpecifics =
         NotificationDetails(android: secondNotificationAndroidSpecifics);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'Jeff Chang',
-        'Please join us to celebrate the...',
-        secondNotificationPlatformSpecifics);
+        id: id++,
+        title: 'Jeff Chang',
+        body: 'Please join us to celebrate the...',
+        notificationDetails: secondNotificationPlatformSpecifics);
 
     // Create the summary notification to support older devices that pre-date
     /// Android 7.0 (API level 24).
@@ -1849,7 +1919,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'Attention', 'Two messages', notificationDetails);
+        id: id++,
+        title: 'Attention',
+        body: 'Two messages',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showNotificationWithTag() async {
@@ -1863,7 +1936,9 @@ class _HomePageState extends State<HomePage> {
       android: androidNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-        id++, 'first notification', null, notificationDetails);
+        id: id++,
+        title: 'first notification',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _checkPendingNotificationRequests() async {
@@ -1902,10 +1977,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'ongoing notification title',
-        'ongoing notification body',
-        notificationDetails);
+        id: id++,
+        title: 'ongoing notification title',
+        body: 'ongoing notification body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showNotificationWithNoBadge() async {
@@ -1919,7 +1994,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'no badge title', 'no badge body', notificationDetails,
+        id: id++,
+        title: 'no badge title',
+        body: 'no badge body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1942,10 +2020,10 @@ class _HomePageState extends State<HomePage> {
         final NotificationDetails notificationDetails =
             NotificationDetails(android: androidNotificationDetails);
         await flutterLocalNotificationsPlugin.show(
-            progressId,
-            'progress notification title',
-            'progress notification body',
-            notificationDetails,
+            id: progressId,
+            title: 'progress notification title',
+            body: 'progress notification body',
+            notificationDetails: notificationDetails,
             payload: 'item x');
       });
     }
@@ -1965,10 +2043,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'indeterminate progress notification title',
-        'indeterminate progress notification body',
-        notificationDetails,
+        id: id++,
+        title: 'indeterminate progress notification title',
+        body: 'indeterminate progress notification body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -1982,10 +2060,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'updated notification channel',
-        'check settings to see updated channel description',
-        notificationDetails,
+        id: id++,
+        title: 'updated notification channel',
+        body: 'check settings to see updated channel description',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2000,10 +2078,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'public notification title',
-        'public notification body',
-        notificationDetails,
+        id: id++,
+        title: 'public notification title',
+        body: 'public notification body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2015,10 +2093,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'title of notification with a subtitle',
-        'body of notification with a subtitle',
-        notificationDetails,
+        id: id++,
+        title: 'title of notification with a subtitle',
+        body: 'body of notification with a subtitle',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2028,7 +2106,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'icon badge title', 'icon badge body', notificationDetails,
+        id: id++,
+        title: 'icon badge title',
+        body: 'icon badge body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2049,19 +2130,37 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails thread2PlatformChannelSpecifics =
         buildNotificationDetailsForThread('thread2');
 
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 1',
-        'first notification', thread1PlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 1',
-        'second notification', thread1PlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 1',
-        'third notification', thread1PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 1',
+        body: 'first notification',
+        notificationDetails: thread1PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 1',
+        body: 'second notification',
+        notificationDetails: thread1PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 1',
+        body: 'third notification',
+        notificationDetails: thread1PlatformChannelSpecifics);
 
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 2',
-        'first notification', thread2PlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 2',
-        'second notification', thread2PlatformChannelSpecifics);
-    await flutterLocalNotificationsPlugin.show(id++, 'thread 2',
-        'third notification', thread2PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 2',
+        body: 'first notification',
+        notificationDetails: thread2PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 2',
+        body: 'second notification',
+        notificationDetails: thread2PlatformChannelSpecifics);
+    await flutterLocalNotificationsPlugin.show(
+        id: id++,
+        title: 'thread 2',
+        body: 'third notification',
+        notificationDetails: thread2PlatformChannelSpecifics);
   }
 
   Future<void> _showNotificationWithTimeSensitiveInterruptionLevel() async {
@@ -2072,10 +2171,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'title of time sensitive notification',
-        'body of time sensitive notification',
-        notificationDetails,
+        id: id++,
+        title: 'title of time sensitive notification',
+        body: 'body of time sensitive notification',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2088,10 +2187,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'title of banner notification',
-        'body of banner notification',
-        notificationDetails,
+        id: id++,
+        title: 'title of banner notification',
+        body: 'body of banner notification',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2104,10 +2203,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'title of notification shown only in notification centre',
-        'body of notification shown only in notification centre',
-        notificationDetails,
+        id: id++,
+        title: 'title of notification shown only in notification centre',
+        body: 'body of notification shown only in notification centre',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2121,7 +2220,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2138,7 +2240,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2156,7 +2261,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2175,7 +2283,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails =
         NotificationDetails(android: androidNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++, 'plain title', 'plain body', notificationDetails,
+        id: id++,
+        title: 'plain title',
+        body: 'plain body',
+        notificationDetails: notificationDetails,
         payload: 'item x');
   }
 
@@ -2196,10 +2307,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'notification with attachment title',
-        'notification with attachment body',
-        notificationDetails);
+        id: id++,
+        title: 'notification with attachment title',
+        body: 'notification with attachment body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _showNotificationWithClippedThumbnailAttachment() async {
@@ -2224,10 +2335,10 @@ class _HomePageState extends State<HomePage> {
     final NotificationDetails notificationDetails = NotificationDetails(
         iOS: darwinNotificationDetails, macOS: darwinNotificationDetails);
     await flutterLocalNotificationsPlugin.show(
-        id++,
-        'notification with attachment title',
-        'notification with attachment body',
-        notificationDetails);
+        id: id++,
+        title: 'notification with attachment title',
+        body: 'notification with attachment body',
+        notificationDetails: notificationDetails);
   }
 
   Future<void> _createNotificationChannelGroup() async {
@@ -2782,7 +2893,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails platformChannelSpecifics =
         NotificationDetails(android: androidPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
-        0, 'icon badge title', 'icon badge body', platformChannelSpecifics,
+        id: 0,
+        title: 'icon badge title',
+        body: 'icon badge body',
+        notificationDetails: platformChannelSpecifics,
         payload: 'item x');
   }
 
@@ -2799,10 +2913,10 @@ class _HomePageState extends State<HomePage> {
     const NotificationDetails platformChannelSpecifics =
         NotificationDetails(android: androidPlatformChannelSpecifics);
     await flutterLocalNotificationsPlugin.show(
-      0,
-      'notification sound controlled by alarm volume',
-      'alarm notification sound body',
-      platformChannelSpecifics,
+      id: 0,
+      title: 'notification sound controlled by alarm volume',
+      body: 'alarm notification sound body',
+      notificationDetails: platformChannelSpecifics,
     );
   }
 
@@ -2819,24 +2933,23 @@ class _HomePageState extends State<HomePage> {
       macOS: darwinNotificationDetails,
     );
     await flutterLocalNotificationsPlugin.show(
-      id++,
-      'Critical sound notification title',
-      'Critical sound notification body',
-      notificationDetails,
+      id: id++,
+      title: 'Critical sound notification title',
+      body: 'Critical sound notification body',
+      notificationDetails: notificationDetails,
     );
   }
 }
 
 Future<void> _showLinuxNotificationWithBodyMarkup() async {
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with body markup',
-    '<b>bold text</b>\n'
+    id: id++,
+    title: 'notification with body markup',
+    body: '<b>bold text</b>\n'
         '<i>italic text</i>\n'
         '<u>underline text</u>\n'
         'https://example.com\n'
         '<a href="https://example.com">example.com</a>',
-    null,
   );
 }
 
@@ -2849,10 +2962,9 @@ Future<void> _showLinuxNotificationWithCategory() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with category',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with category',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2881,10 +2993,9 @@ Future<void> _showLinuxNotificationWithByteDataIcon() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with byte data icon',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with byte data icon',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2895,10 +3006,9 @@ Future<void> _showLinuxNotificationWithPathIcon(String path) async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    0,
-    'notification with file path icon',
-    null,
-    platformChannelSpecifics,
+    id: 0,
+    title: 'notification with file path icon',
+    notificationDetails: platformChannelSpecifics,
   );
 }
 
@@ -2911,10 +3021,9 @@ Future<void> _showLinuxNotificationWithThemeIcon() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with theme icon',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with theme icon',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2927,10 +3036,9 @@ Future<void> _showLinuxNotificationWithThemeSound() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with theme sound',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with theme sound',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2943,10 +3051,9 @@ Future<void> _showLinuxNotificationWithCriticalUrgency() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with critical urgency',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with critical urgency',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2961,10 +3068,9 @@ Future<void> _showLinuxNotificationWithTimeout() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification with timeout',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification with timeout',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2977,10 +3083,9 @@ Future<void> _showLinuxNotificationSuppressSound() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'suppress notification sound',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'suppress notification sound',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -2993,10 +3098,9 @@ Future<void> _showLinuxNotificationTransient() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'transient notification',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'transient notification',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -3009,10 +3113,9 @@ Future<void> _showLinuxNotificationResident() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'resident notification',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'resident notification',
+    notificationDetails: notificationDetails,
   );
 }
 
@@ -3023,10 +3126,9 @@ Future<void> _showLinuxNotificationDifferentLocation() async {
     linux: linuxPlatformChannelSpecifics,
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'notification on different screen location',
-    null,
-    notificationDetails,
+    id: id++,
+    title: 'notification on different screen location',
+    notificationDetails: notificationDetails,
   );
 }
 

--- a/flutter_local_notifications/example/lib/repeating.dart
+++ b/flutter_local_notifications/example/lib/repeating.dart
@@ -70,11 +70,11 @@ List<Widget> examples(BuildContext context) => <Widget>[
 /// To test we don't validate past dates when using `matchDateTimeComponents`
 Future<void> _scheduleDailyTenAMLastYearNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'daily scheduled notification title',
-      'daily scheduled notification body',
-      _nextInstanceOfTenAMLastYear(),
-      const NotificationDetails(
+      id: 0,
+      title: 'daily scheduled notification title',
+      body: 'daily scheduled notification body',
+      scheduledDate: _nextInstanceOfTenAMLastYear(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails(
             'daily notification channel id', 'daily notification channel name',
             channelDescription: 'daily notification description'),
@@ -85,11 +85,11 @@ Future<void> _scheduleDailyTenAMLastYearNotification() async {
 
 Future<void> _scheduleWeeklyTenAMNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'weekly scheduled notification title',
-      'weekly scheduled notification body',
-      _nextInstanceOfTenAM(),
-      const NotificationDetails(
+      id: 0,
+      title: 'weekly scheduled notification title',
+      body: 'weekly scheduled notification body',
+      scheduledDate: _nextInstanceOfTenAM(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails('weekly notification channel id',
             'weekly notification channel name',
             channelDescription: 'weekly notificationdescription'),
@@ -100,11 +100,11 @@ Future<void> _scheduleWeeklyTenAMNotification() async {
 
 Future<void> _scheduleWeeklyMondayTenAMNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'weekly scheduled notification title',
-      'weekly scheduled notification body',
-      _nextInstanceOfMondayTenAM(),
-      const NotificationDetails(
+      id: 0,
+      title: 'weekly scheduled notification title',
+      body: 'weekly scheduled notification body',
+      scheduledDate: _nextInstanceOfMondayTenAM(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails('weekly notification channel id',
             'weekly notification channel name',
             channelDescription: 'weekly notificationdescription'),
@@ -115,11 +115,11 @@ Future<void> _scheduleWeeklyMondayTenAMNotification() async {
 
 Future<void> _scheduleMonthlyMondayTenAMNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'monthly scheduled notification title',
-      'monthly scheduled notification body',
-      _nextInstanceOfMondayTenAM(),
-      const NotificationDetails(
+      id: 0,
+      title: 'monthly scheduled notification title',
+      body: 'monthly scheduled notification body',
+      scheduledDate: _nextInstanceOfMondayTenAM(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails('monthly notification channel id',
             'monthly notification channel name',
             channelDescription: 'monthly notificationdescription'),
@@ -130,11 +130,11 @@ Future<void> _scheduleMonthlyMondayTenAMNotification() async {
 
 Future<void> _scheduleYearlyMondayTenAMNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'yearly scheduled notification title',
-      'yearly scheduled notification body',
-      _nextInstanceOfMondayTenAM(),
-      const NotificationDetails(
+      id: 0,
+      title: 'yearly scheduled notification title',
+      body: 'yearly scheduled notification body',
+      scheduledDate: _nextInstanceOfMondayTenAM(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails('yearly notification channel id',
             'yearly notification channel name',
             channelDescription: 'yearly notification description'),
@@ -151,11 +151,11 @@ Future<void> _repeatNotification() async {
   const NotificationDetails notificationDetails =
       NotificationDetails(android: androidNotificationDetails);
   await flutterLocalNotificationsPlugin.periodicallyShow(
-    id++,
-    'repeating title',
-    'repeating body',
-    RepeatInterval.everyMinute,
-    notificationDetails,
+    id: id++,
+    title: 'repeating title',
+    body: 'repeating body',
+    repeatInterval: RepeatInterval.everyMinute,
+    notificationDetails: notificationDetails,
     androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
   );
 }
@@ -168,22 +168,22 @@ Future<void> _repeatPeriodicallyWithDurationNotification() async {
   const NotificationDetails notificationDetails =
       NotificationDetails(android: androidNotificationDetails);
   await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
-    id++,
-    'repeating period title',
-    'repeating period body',
-    const Duration(minutes: 5),
-    notificationDetails,
+    id: id++,
+    title: 'repeating period title',
+    body: 'repeating period body',
+    repeatDurationInterval: const Duration(minutes: 5),
+    notificationDetails: notificationDetails,
     androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
   );
 }
 
 Future<void> _scheduleDailyTenAMNotification() async {
   await flutterLocalNotificationsPlugin.zonedSchedule(
-      0,
-      'daily scheduled notification title',
-      'daily scheduled notification body',
-      _nextInstanceOfTenAM(),
-      const NotificationDetails(
+      id: 0,
+      title: 'daily scheduled notification title',
+      body: 'daily scheduled notification body',
+      scheduledDate: _nextInstanceOfTenAM(),
+      notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails(
             'daily notification channel id', 'daily notification channel name',
             channelDescription: 'daily notification description'),

--- a/flutter_local_notifications/example/lib/windows.dart
+++ b/flutter_local_notifications/example/lib/windows.dart
@@ -145,19 +145,19 @@ List<Widget> examples() => <Widget>[
 
 Future<void> _showWindowsNotificationWithDuration() async {
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is a short notification',
-    'This will last about 7 seconds',
-    const NotificationDetails(
+    id: id++,
+    title: 'This is a short notification',
+    body: 'This will last about 7 seconds',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
           duration: WindowsNotificationDuration.short),
     ),
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is a long notification',
-    'This will last about 25 seconds',
-    const NotificationDetails(
+    id: id++,
+    title: 'This is a long notification',
+    body: 'This will last about 25 seconds',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
           duration: WindowsNotificationDuration.long),
     ),
@@ -166,10 +166,9 @@ Future<void> _showWindowsNotificationWithDuration() async {
 
 Future<void> _showWindowsNotificationWithScenarios() async {
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is an alarm',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is an alarm',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
         scenario: WindowsNotificationScenario.alarm,
         actions: <WindowsAction>[
@@ -179,10 +178,9 @@ Future<void> _showWindowsNotificationWithScenarios() async {
     ),
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is an incoming call',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is an incoming call',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
         scenario: WindowsNotificationScenario.incomingCall,
         actions: <WindowsAction>[
@@ -192,10 +190,9 @@ Future<void> _showWindowsNotificationWithScenarios() async {
     ),
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is a reminder',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is a reminder',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
           scenario: WindowsNotificationScenario.reminder,
           actions: <WindowsAction>[
@@ -204,10 +201,9 @@ Future<void> _showWindowsNotificationWithScenarios() async {
     ),
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is an urgent notification',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is an urgent notification',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
           scenario: WindowsNotificationScenario.urgent,
           actions: <WindowsAction>[
@@ -219,10 +215,10 @@ Future<void> _showWindowsNotificationWithScenarios() async {
 
 Future<void> _showWindowsNotificationWithDetails() =>
     flutterLocalNotificationsPlugin.show(
-      id++,
-      'This one has more details',
-      'And a different timestamp!',
-      NotificationDetails(
+      id: id++,
+      title: 'This one has more details',
+      body: 'And a different timestamp!',
+      notificationDetails: NotificationDetails(
         windows: WindowsNotificationDetails(
           subtitle: 'This is the subtitle',
           timestamp:
@@ -233,10 +229,11 @@ Future<void> _showWindowsNotificationWithDetails() =>
 
 Future<void> _showWindowsNotificationWithImages() =>
     flutterLocalNotificationsPlugin.show(
-      id++,
-      'This notification has an image',
-      'You can show images from assets or the network. See the columns example as well.',
-      NotificationDetails(
+      id: id++,
+      title: 'This notification has an image',
+      body:
+          'You can show images from assets or the network. See the columns example as well.',
+      notificationDetails: NotificationDetails(
         windows: WindowsNotificationDetails(
           images: <WindowsImage>[
             WindowsImage(
@@ -250,10 +247,10 @@ Future<void> _showWindowsNotificationWithImages() =>
 
 Future<void> _showWindowsNotificationWithGroups() =>
     flutterLocalNotificationsPlugin.show(
-      id++,
-      'This notification has many groups',
-      'Each group stays together. Web images only load in MSIX builds',
-      NotificationDetails(
+      id: id++,
+      title: 'This notification has many groups',
+      body: 'Each group stays together. Web images only load in MSIX builds',
+      notificationDetails: NotificationDetails(
         windows: WindowsNotificationDetails(
           subtitle: 'Caption text is fainter',
           rows: <WindowsRow>[
@@ -294,10 +291,10 @@ Future<void> _showWindowsNotificationWithProgress() async {
       flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
           FlutterLocalNotificationsWindows>();
   await flutterLocalNotificationsPlugin.show(
-    notificationId,
-    'This notification has progress bars',
-    'You can have precise or indeterminate',
-    NotificationDetails(
+    id: notificationId,
+    title: 'This notification has progress bars',
+    body: 'You can have precise or indeterminate',
+    notificationDetails: NotificationDetails(
       windows: WindowsNotificationDetails(
         progressBars: <WindowsProgressBar>[
           WindowsProgressBar(
@@ -350,10 +347,10 @@ Future<void> _showWindowsNotificationWithDynamic() async {
       flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
           FlutterLocalNotificationsWindows>();
   await flutterLocalNotificationsPlugin.show(
-    notificationId,
-    'Dynamic content',
-    'This notification will be updated from Dart code',
-    const NotificationDetails(
+    id: notificationId,
+    title: 'Dynamic content',
+    body: 'This notification will be updated from Dart code',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(
         subtitle: '{stopwatch}',
       ),
@@ -376,10 +373,10 @@ Future<void> _showWindowsNotificationWithDynamic() async {
 
 Future<void> _showWindowsNotificationWithActivation() =>
     flutterLocalNotificationsPlugin.show(
-      id++,
-      'These buttons do different things',
-      'Click on each one!',
-      const NotificationDetails(
+      id: id++,
+      title: 'These buttons do different things',
+      body: 'Click on each one!',
+      notificationDetails: const NotificationDetails(
         windows: WindowsNotificationDetails(
           actions: <WindowsAction>[
             WindowsAction(
@@ -400,10 +397,10 @@ Future<void> _showWindowsNotificationWithActivation() =>
 
 Future<void> _showWindowsNotificationWithButtonStyle() =>
     flutterLocalNotificationsPlugin.show(
-      id++,
-      'Incoming call',
-      'Your best friend',
-      const NotificationDetails(
+      id: id++,
+      title: 'Incoming call',
+      body: 'Your best friend',
+      notificationDetails: const NotificationDetails(
         windows: WindowsNotificationDetails(
           actions: <WindowsAction>[
             WindowsAction(
@@ -428,18 +425,16 @@ Future<void> _showWindowsNotificationWithHeader() async {
     arguments: 'header-clicked',
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is the first notification',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is the first notification',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(header: header),
     ),
   );
   await flutterLocalNotificationsPlugin.show(
-    id++,
-    'This is the second notification',
-    null,
-    const NotificationDetails(
+    id: id++,
+    title: 'This is the second notification',
+    notificationDetails: const NotificationDetails(
       windows: WindowsNotificationDetails(header: header),
     ),
   );

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -230,11 +230,11 @@ class FlutterLocalNotificationsPlugin {
 
   /// Show a notification with an optional payload that will be passed back to
   /// the app when a notification is tapped.
-  Future<void> show(
-    int id,
+  Future<void> show({
+    required int id,
     String? title,
     String? body,
-    NotificationDetails? notificationDetails, {
+    NotificationDetails? notificationDetails,
     String? payload,
   }) async {
     if (kIsWeb) {
@@ -331,13 +331,13 @@ class FlutterLocalNotificationsPlugin {
   ///
   /// On Windows, this will only set a notification on the [scheduledDate], and
   /// not repeat, regardless of the value for [matchDateTimeComponents].
-  Future<void> zonedSchedule(
-    int id,
+  Future<void> zonedSchedule({
+    required int id,
+    required TZDateTime scheduledDate,
+    required NotificationDetails notificationDetails,
+    required AndroidScheduleMode androidScheduleMode,
     String? title,
     String? body,
-    TZDateTime scheduledDate,
-    NotificationDetails notificationDetails, {
-    required AndroidScheduleMode androidScheduleMode,
     String? payload,
     DateTimeComponents? matchDateTimeComponents,
   }) async {
@@ -391,13 +391,13 @@ class FlutterLocalNotificationsPlugin {
   /// On Android, this will also require additional setup for the app,
   /// especially in the app's `AndroidManifest.xml` file. Please see check the
   /// readme for further details.
-  Future<void> periodicallyShow(
-    int id,
+  Future<void> periodicallyShow({
+    required int id,
+    required RepeatInterval repeatInterval,
+    required NotificationDetails notificationDetails,
+    required AndroidScheduleMode androidScheduleMode,
     String? title,
     String? body,
-    RepeatInterval repeatInterval,
-    NotificationDetails notificationDetails, {
-    required AndroidScheduleMode androidScheduleMode,
     String? payload,
   }) async {
     if (kIsWeb) {
@@ -438,12 +438,12 @@ class FlutterLocalNotificationsPlugin {
   /// On Android, this will also require additional setup for the app,
   /// especially in the app's `AndroidManifest.xml` file. Please see check the
   /// readme for further details.
-  Future<void> periodicallyShowWithDuration(
-    int id,
+  Future<void> periodicallyShowWithDuration({
+    required int id,
+    required Duration repeatDurationInterval,
+    required NotificationDetails notificationDetails,
     String? title,
     String? body,
-    Duration repeatDurationInterval,
-    NotificationDetails notificationDetails, {
     AndroidScheduleMode androidScheduleMode = AndroidScheduleMode.exact,
     String? payload,
   }) async {

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -66,7 +66,7 @@ void main() {
           InitializationSettings(android: androidInitializationSettings);
       await flutterLocalNotificationsPlugin.initialize(initializationSettings);
       await flutterLocalNotificationsPlugin.show(
-          1, 'notification title', 'notification body', null);
+          id: 1, title: 'notification title', body: 'notification body');
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object?>{
@@ -110,11 +110,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-        1,
-        'notification title',
-        'notification body',
-        const NotificationDetails(android: androidNotificationDetails),
-      );
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
         log.last,
         isMethodCall(
@@ -236,10 +236,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -321,10 +322,11 @@ void main() {
               additionalFlags: Int32List.fromList(<int>[4, 32]));
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -407,10 +409,11 @@ void main() {
           AndroidNotificationDetails('channelId', 'channelName',
               channelDescription: 'channelDescription', when: timestamp);
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -494,10 +497,11 @@ void main() {
               when: timestamp,
               usesChronometer: true);
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -583,10 +587,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -673,10 +678,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -763,10 +769,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -852,10 +859,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -943,10 +951,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1049,10 +1058,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1149,10 +1159,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1255,10 +1266,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1353,10 +1365,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1455,10 +1468,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1548,10 +1562,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1638,10 +1653,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          const NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              const NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1735,10 +1751,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1861,10 +1878,11 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1,
-          'notification title',
-          'notification body',
-          NotificationDetails(android: androidNotificationDetails));
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails:
+              NotificationDetails(android: androidNotificationDetails));
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object>{
@@ -1969,11 +1987,12 @@ void main() {
                 AndroidNotificationDetails('channelId', 'channelName',
                     channelDescription: 'channelDescription');
             await flutterLocalNotificationsPlugin.periodicallyShow(
-              1,
-              'notification title',
-              'notification body',
-              repeatInterval,
-              const NotificationDetails(android: androidNotificationDetails),
+              id: 1,
+              title: 'notification title',
+              body: 'notification body',
+              repeatInterval: repeatInterval,
+              notificationDetails: const NotificationDetails(
+                  android: androidNotificationDetails),
               androidScheduleMode: AndroidScheduleMode.exact,
             );
 
@@ -2071,11 +2090,11 @@ void main() {
           expect(
               () async => await flutterLocalNotificationsPlugin
                       .periodicallyShowWithDuration(
-                    1,
-                    'notification title',
-                    'notification body',
-                    thirtySeconds,
-                    const NotificationDetails(
+                    id: 1,
+                    title: 'notification title',
+                    body: 'notification body',
+                    repeatDurationInterval: thirtySeconds,
+                    notificationDetails: const NotificationDetails(
                         android: androidNotificationDetails),
                   ),
               throwsA(isA<ArgumentError>()));
@@ -2103,11 +2122,12 @@ void main() {
                 AndroidNotificationDetails('channelId', 'channelName',
                     channelDescription: 'channelDescription');
             await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
-              1,
-              'notification title',
-              'notification body',
-              repeatDurationInterval,
-              const NotificationDetails(android: androidNotificationDetails),
+              id: 1,
+              title: 'notification title',
+              body: 'notification body',
+              repeatDurationInterval: repeatDurationInterval,
+              notificationDetails: const NotificationDetails(
+                  android: androidNotificationDetails),
             );
 
             expect(
@@ -2202,11 +2222,12 @@ void main() {
             AndroidNotificationDetails('channelId', 'channelName',
                 channelDescription: 'channelDescription');
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            const NotificationDetails(android: androidNotificationDetails),
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails:
+                const NotificationDetails(android: androidNotificationDetails),
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle);
         expect(
             log.last,
@@ -2296,11 +2317,12 @@ void main() {
             AndroidNotificationDetails('channelId', 'channelName',
                 channelDescription: 'channelDescription');
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            const NotificationDetails(android: androidNotificationDetails),
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails:
+                const NotificationDetails(android: androidNotificationDetails),
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
             matchDateTimeComponents: DateTimeComponents.time);
         expect(
@@ -2392,11 +2414,12 @@ void main() {
             AndroidNotificationDetails('channelId', 'channelName',
                 channelDescription: 'channelDescription');
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            const NotificationDetails(android: androidNotificationDetails),
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails:
+                const NotificationDetails(android: androidNotificationDetails),
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
             matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime);
         expect(

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -204,7 +204,7 @@ void main() {
           InitializationSettings(iOS: iosInitializationSettings);
       await flutterLocalNotificationsPlugin.initialize(initializationSettings);
       await flutterLocalNotificationsPlugin.show(
-          1, 'notification title', 'notification body', null);
+          id: 1, title: 'notification title', body: 'notification body');
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object?>{
@@ -242,7 +242,10 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-          1, 'notification title', 'notification body', notificationDetails);
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails: notificationDetails);
 
       expect(
           log.last,
@@ -307,11 +310,11 @@ void main() {
             );
 
             await flutterLocalNotificationsPlugin.periodicallyShow(
-                1,
-                'notification title',
-                'notification body',
-                repeatInterval,
-                notificationDetails,
+                id: 1,
+                title: 'notification title',
+                body: 'notification body',
+                repeatInterval: repeatInterval,
+                notificationDetails: notificationDetails,
                 androidScheduleMode: AndroidScheduleMode.exact);
 
             expect(
@@ -389,11 +392,11 @@ void main() {
           expect(
               () async => await flutterLocalNotificationsPlugin
                       .periodicallyShowWithDuration(
-                    1,
-                    'notification title',
-                    'notification body',
-                    thirtySeconds,
-                    notificationDetails,
+                    id: 1,
+                    title: 'notification title',
+                    body: 'notification body',
+                    repeatDurationInterval: thirtySeconds,
+                    notificationDetails: notificationDetails,
                   ),
               throwsA(isA<ArgumentError>()));
         });
@@ -434,11 +437,11 @@ void main() {
             );
 
             await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
-              1,
-              'notification title',
-              'notification body',
-              repeatDurationInterval,
-              notificationDetails,
+              id: 1,
+              title: 'notification title',
+              body: 'notification body',
+              repeatDurationInterval: repeatDurationInterval,
+              notificationDetails: notificationDetails,
             );
 
             expect(
@@ -510,11 +513,11 @@ void main() {
             ]));
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            notificationDetails,
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails: notificationDetails,
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle);
 
         expect(
@@ -578,11 +581,11 @@ void main() {
             ]));
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            notificationDetails,
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails: notificationDetails,
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
             matchDateTimeComponents: DateTimeComponents.time);
 
@@ -648,11 +651,11 @@ void main() {
             ]));
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            notificationDetails,
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails: notificationDetails,
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
             matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime);
 

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -100,7 +100,7 @@ void main() {
           InitializationSettings(macOS: macOSInitializationSettings);
       await flutterLocalNotificationsPlugin.initialize(initializationSettings);
       await flutterLocalNotificationsPlugin.show(
-          1, 'notification title', 'notification body', null);
+          id: 1, title: 'notification title', body: 'notification body');
       expect(
           log.last,
           isMethodCall('show', arguments: <String, Object?>{
@@ -142,11 +142,10 @@ void main() {
       );
 
       await flutterLocalNotificationsPlugin.show(
-        1,
-        'notification title',
-        'notification body',
-        notificationDetails,
-      );
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          notificationDetails: notificationDetails);
 
       expect(
         log.last,
@@ -215,11 +214,11 @@ void main() {
             );
 
             await flutterLocalNotificationsPlugin.periodicallyShow(
-              1,
-              'notification title',
-              'notification body',
-              repeatInterval,
-              notificationDetails,
+              id: 1,
+              title: 'notification title',
+              body: 'notification body',
+              repeatInterval: repeatInterval,
+              notificationDetails: notificationDetails,
               androidScheduleMode: AndroidScheduleMode.exact,
             );
 
@@ -294,11 +293,11 @@ void main() {
           expect(
               () async => await flutterLocalNotificationsPlugin
                       .periodicallyShowWithDuration(
-                    1,
-                    'notification title',
-                    'notification body',
-                    thirtySeconds,
-                    notificationDetails,
+                    id: 1,
+                    title: 'notification title',
+                    body: 'notification body',
+                    repeatDurationInterval: thirtySeconds,
+                    notificationDetails: notificationDetails,
                   ),
               throwsA(isA<ArgumentError>()));
         });
@@ -340,11 +339,11 @@ void main() {
             );
 
             await flutterLocalNotificationsPlugin.periodicallyShowWithDuration(
-              1,
-              'notification title',
-              'notification body',
-              repeatDurationInterval,
-              notificationDetails,
+              id: 1,
+              title: 'notification title',
+              body: 'notification body',
+              repeatDurationInterval: repeatDurationInterval,
+              notificationDetails: notificationDetails,
             );
 
             expect(
@@ -416,11 +415,11 @@ void main() {
         );
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-            1,
-            'notification title',
-            'notification body',
-            scheduledDate,
-            notificationDetails,
+            id: 1,
+            title: 'notification title',
+            body: 'notification body',
+            scheduledDate: scheduledDate,
+            notificationDetails: notificationDetails,
             androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle);
 
         expect(
@@ -486,11 +485,11 @@ void main() {
         );
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-          1,
-          'notification title',
-          'notification body',
-          scheduledDate,
-          notificationDetails,
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          scheduledDate: scheduledDate,
+          notificationDetails: notificationDetails,
           androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
           matchDateTimeComponents: DateTimeComponents.time,
         );
@@ -563,11 +562,11 @@ void main() {
         );
 
         await flutterLocalNotificationsPlugin.zonedSchedule(
-          1,
-          'notification title',
-          'notification body',
-          scheduledDate,
-          notificationDetails,
+          id: 1,
+          title: 'notification title',
+          body: 'notification body',
+          scheduledDate: scheduledDate,
+          notificationDetails: notificationDetails,
           androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
           matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
         );


### PR DESCRIPTION
## Proposal for applying named parameters for functions in flutter_local_notifications_plugin.dart

Hi, this is same PR with previous PR #2610 
This is rebased version with feature branch.

As @Levi-Lesches mentioned that this work is massive breaking changes,
this would be hard to merged in short time.

Would you mind to check and review for this proposal in next major release? @MaikuB 
If this isn’t ideal, I’m also considering an alternative approach:

## (Alternative way) Keep original form of functions, and add same-working copied functions with named parameter.
* Example
```dart
Future<void> zonedSchedule(
    int id,
    String? title,
    String? body,
    TZDateTime scheduledDate,
    NotificationDetails notificationDetails, {
    required AndroidScheduleMode androidScheduleMode,
    String? payload,
    DateTimeComponents? matchDateTimeComponents,
  });
Future<void> zonedScheduleWithNamed({
    required int id,
    required TZDateTime scheduledDate,
    required NotificationDetails notificationDetails,
    required AndroidScheduleMode androidScheduleMode,
    String? title,
    String? body,
    String? payload,
    DateTimeComponents? matchDateTimeComponents,
  });
```

Feel free to check about this request! I'm really happy to communicate and work with great dev like you guys:)
