### PR TITLE
Don't set applicationContext to null onDetachedFromEngine

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1397,7 +1397,6 @@ public class FlutterLocalNotificationsPlugin
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     this.channel.setMethodCallHandler(null);
     this.channel = null;
-    this.applicationContext = null;
   }
 
   @Override


### PR DESCRIPTION
This error (#2633)  was occurring because applicationContext was null. So I made this change and the problem was solved. I also noticed that the awesome_notifications package does not set applicationContext to null at any time: https://github.com/dokumanx/awesome_notifications/blob/5e0959c57c612ba525a8118dbbfa416f32426d06/android/src/main/java/me/carda/awesome_notifications/AwesomeNotificationsPlugin.java

Please let me know if there is any reason for applicationContext to be set to null. Otherwise, just approve this PR. Thanks