### PR TITLE
[flutter_local_notifications / flutter_local_notifications_platform_interface] Exposes `removeAllPendingNotificationRequests` via implementing `cancelAllPendingNotifications()`

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -157,6 +157,7 @@ public class FlutterLocalNotificationsPlugin
   private static final String SHOW_METHOD = "show";
   private static final String CANCEL_METHOD = "cancel";
   private static final String CANCEL_ALL_METHOD = "cancelAll";
+  private static final String CANCEL_ALL_PENDING_METHOD = "cancelAllPendingNotifications"
   private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
   private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
   private static final String PERIODICALLY_SHOW_WITH_DURATION = "periodicallyShowWithDuration";

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1524,6 +1524,9 @@ public class FlutterLocalNotificationsPlugin
       case CANCEL_ALL_METHOD:
         cancelAllNotifications(result);
         break;
+      case CANCEL_ALL_PENDING_METHOD:
+        cancelAllPendingNotifications(result);
+        break;
       case PENDING_NOTIFICATION_REQUESTS_METHOD:
         pendingNotificationRequests(result);
         break;
@@ -1838,6 +1841,31 @@ public class FlutterLocalNotificationsPlugin
     saveScheduledNotifications(applicationContext, new ArrayList<>());
     result.success(null);
   }
+
+  private void cancelAllPendingNotifications(Result result) {
+    ArrayList<NotificationDetails> scheduledNotifications =
+        loadScheduledNotifications(applicationContext);
+
+    if (scheduledNotifications == null || scheduledNotifications.isEmpty()) {
+        result.success(null);
+        return;
+    }
+
+    AlarmManager alarmManager = getAlarmManager(applicationContext);
+    Intent intent = new Intent(applicationContext, ScheduledNotificationReceiver.class);
+
+    for (NotificationDetails scheduledNotification : scheduledNotifications) {
+      PendingIntent pendingIntent =
+          getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
+      if (pendingIntent != null && alarmManager != null) {
+          alarmManager.cancel(pendingIntent);
+      }
+    }
+
+    saveScheduledNotifications(applicationContext, new ArrayList<>());
+    result.success(null);
+  }
+
 
   public void requestNotificationsPermission(@NonNull PermissionRequestListener callback) {
     if (permissionRequestProgress != PermissionRequestProgress.None) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -157,7 +157,7 @@ public class FlutterLocalNotificationsPlugin
   private static final String SHOW_METHOD = "show";
   private static final String CANCEL_METHOD = "cancel";
   private static final String CANCEL_ALL_METHOD = "cancelAll";
-  private static final String CANCEL_ALL_PENDING_METHOD = "cancelAllPendingNotifications"
+  private static final String CANCEL_ALL_PENDING_METHOD = "cancelAllPendingNotifications";
   private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
   private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
   private static final String PERIODICALLY_SHOW_WITH_DURATION = "periodicallyShowWithDuration";

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1858,9 +1858,7 @@ public class FlutterLocalNotificationsPlugin
     for (NotificationDetails scheduledNotification : scheduledNotifications) {
       PendingIntent pendingIntent =
           getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
-      if (pendingIntent != null && alarmManager != null) {
-          alarmManager.cancel(pendingIntent);
-      }
+      alarmManager.cancel(pendingIntent);
     }
 
     saveScheduledNotifications(applicationContext, new ArrayList<>());

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -157,10 +157,10 @@ public class FlutterLocalNotificationsPlugin
   private static final String SHOW_METHOD = "show";
   private static final String CANCEL_METHOD = "cancel";
   private static final String CANCEL_ALL_METHOD = "cancelAll";
-  private static final String CANCEL_ALL_PENDING_METHOD = "cancelAllPendingNotifications";
+  private static final String CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD = "cancelAllPendingNotifications";
   private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
   private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
-  private static final String PERIODICALLY_SHOW_WITH_DURATION = "periodicallyShowWithDuration";
+  private static final String PERIODICALLY_SHOW_WITH_DURATION_METHOD = "periodicallyShowWithDuration";
   private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD =
       "getNotificationAppLaunchDetails";
   private static final String REQUEST_NOTIFICATIONS_PERMISSION_METHOD =
@@ -1516,7 +1516,7 @@ public class FlutterLocalNotificationsPlugin
       case PERIODICALLY_SHOW_METHOD:
         repeat(call, result);
         break;
-      case PERIODICALLY_SHOW_WITH_DURATION:
+      case PERIODICALLY_SHOW_WITH_DURATION_METHOD:
         repeat(call, result);
         break;
       case CANCEL_METHOD:
@@ -1525,7 +1525,7 @@ public class FlutterLocalNotificationsPlugin
       case CANCEL_ALL_METHOD:
         cancelAllNotifications(result);
         break;
-      case CANCEL_ALL_PENDING_METHOD:
+      case CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD:
         cancelAllPendingNotifications(result);
         break;
       case PENDING_NOTIFICATION_REQUESTS_METHOD:

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -442,6 +442,12 @@ class _HomePageState extends State<HomePage> {
                       await _cancelAllNotifications();
                     },
                   ),
+                  PaddedElevatedButton(
+                    buttonText: 'Cancel all pending notifications',
+                    onPressed: () async {
+                      await _cancelAllPendingNotifications();
+                    },
+                  ),
                   if (!Platform.isWindows) ...repeating.examples(context),
                   const Divider(),
                   const Text(
@@ -1889,6 +1895,10 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _cancelAllNotifications() async {
     await flutterLocalNotificationsPlugin.cancelAll();
+  }
+
+  Future<void> _cancelAllPendingNotifications() async {
+    await flutterLocalNotificationsPlugin.cancelAllPendingNotifications();
   }
 
   Future<void> _showOngoingNotification() async {

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -442,12 +442,13 @@ class _HomePageState extends State<HomePage> {
                       await _cancelAllNotifications();
                     },
                   ),
-                  PaddedElevatedButton(
-                    buttonText: 'Cancel all pending notifications',
-                    onPressed: () async {
-                      await _cancelAllPendingNotifications();
-                    },
-                  ),
+                  if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS)
+                    PaddedElevatedButton(
+                      buttonText: 'Cancel all pending notifications',
+                      onPressed: () async {
+                        await _cancelAllPendingNotifications();
+                      },
+                    ),
                   if (!Platform.isWindows) ...repeating.examples(context),
                   const Divider(),
                   const Text(

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -26,6 +26,7 @@ NSString *const PERIODICALLY_SHOW_WITH_DURATION_METHOD =
     @"periodicallyShowWithDuration";
 NSString *const CANCEL_METHOD = @"cancel";
 NSString *const CANCEL_ALL_METHOD = @"cancelAll";
+NSString *const CANCEL_ALL_PENDING_METHOD = @"cancelAllPendingNotifications";
 NSString *const PENDING_NOTIFICATIONS_REQUESTS_METHOD =
     @"pendingNotificationRequests";
 NSString *const GET_ACTIVE_NOTIFICATIONS_METHOD = @"getActiveNotifications";
@@ -185,6 +186,8 @@ static FlutterError *getFlutterError(NSError *error) {
     [self cancel:((NSNumber *)call.arguments) result:result];
   } else if ([CANCEL_ALL_METHOD isEqualToString:call.method]) {
     [self cancelAll:result];
+  } else if ([CANCEL_ALL_PENDING_METHOD isEqualToString:call.method]) {
+    [self cancelAllPendingNotifications:result];
   } else if ([GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD
                  isEqualToString:call.method]) {
 
@@ -573,6 +576,13 @@ static FlutterError *getFlutterError(NSError *error) {
       [UNUserNotificationCenter currentNotificationCenter];
   [center removeAllPendingNotificationRequests];
   [center removeAllDeliveredNotifications];
+  result(nil);
+}
+
+- (void)cancelAllPendingNotifications:(FlutterResult _Nonnull)result API_AVAILABLE(ios(10.0)) {
+  UNUserNotificationCenter *center = 
+      [UNUserNotificationCenter currentNotificationCenter];
+  [center removeAllPendingNotificationRequests];
   result(nil);
 }
 

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -26,8 +26,8 @@ NSString *const PERIODICALLY_SHOW_WITH_DURATION_METHOD =
     @"periodicallyShowWithDuration";
 NSString *const CANCEL_METHOD = @"cancel";
 NSString *const CANCEL_ALL_METHOD = @"cancelAll";
-NSString *const CANCEL_ALL_PENDING_METHOD = @"cancelAllPendingNotifications";
-NSString *const PENDING_NOTIFICATIONS_REQUESTS_METHOD =
+NSString *const CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD = @"cancelAllPendingNotifications";
+NSString *const PENDING_NOTIFICATION_REQUESTS_METHOD =
     @"pendingNotificationRequests";
 NSString *const GET_ACTIVE_NOTIFICATIONS_METHOD = @"getActiveNotifications";
 NSString *const GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD =
@@ -186,7 +186,7 @@ static FlutterError *getFlutterError(NSError *error) {
     [self cancel:((NSNumber *)call.arguments) result:result];
   } else if ([CANCEL_ALL_METHOD isEqualToString:call.method]) {
     [self cancelAll:result];
-  } else if ([CANCEL_ALL_PENDING_METHOD isEqualToString:call.method]) {
+  } else if ([CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD isEqualToString:call.method]) {
     [self cancelAllPendingNotifications:result];
   } else if ([GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD
                  isEqualToString:call.method]) {
@@ -198,7 +198,7 @@ static FlutterError *getFlutterError(NSError *error) {
     notificationAppLaunchDetails[@"notificationResponse"] =
         _launchNotificationResponseDict;
     result(notificationAppLaunchDetails);
-  } else if ([PENDING_NOTIFICATIONS_REQUESTS_METHOD
+  } else if ([PENDING_NOTIFICATION_REQUESTS_METHOD
                  isEqualToString:call.method]) {
     [self pendingNotificationRequests:result];
   } else if ([GET_ACTIVE_NOTIFICATIONS_METHOD isEqualToString:call.method]) {

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -302,6 +302,14 @@ class FlutterLocalNotificationsPlugin {
     await FlutterLocalNotificationsPlatform.instance.cancelAll();
   }
 
+  /// Cancels/removes all pending notifications.
+  ///
+  /// This applies to notifications that have been only scheduled.
+  Future<void> cancelAllPendingNotifications() async {
+    await FlutterLocalNotificationsPlatform.instance
+        .cancelAllPendingNotifications();
+  }
+
   /// Schedules a notification to be shown at the specified date and time
   /// relative to a specific time zone.
   ///

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -304,7 +304,10 @@ class FlutterLocalNotificationsPlugin {
 
   /// Cancels/removes all pending notifications.
   ///
-  /// This applies to notifications that have been only scheduled.
+  /// This only applies to notifications that have been scheduled.
+  ///
+  /// The method is supported on Android, iOS and macOS.
+  /// On other platforms, an [UnimplementedError] will be thrown.
   Future<void> cancelAllPendingNotifications() async {
     await FlutterLocalNotificationsPlatform.instance
         .cancelAllPendingNotifications();

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -43,6 +43,11 @@ class MethodChannelFlutterLocalNotificationsPlugin
   Future<void> cancelAll() => _channel.invokeMethod('cancelAll');
 
   @override
+  Future<void> cancelAllPendingNotifications() async {
+    await _channel.invokeMethod('cancelAllPendingNotifications');
+  }
+
+  @override
   Future<NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() async {
     final Map<dynamic, dynamic>? result =

--- a/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.swift
@@ -180,6 +180,8 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
             cancel(call, result)
         case "cancelAll":
             cancelAll(result)
+        case "cancelAllPendingNotifications":
+            cancelAllPendingNotifications(result)
         case "pendingNotificationRequests":
             pendingNotificationRequests(result)
         case "getActiveNotifications":
@@ -312,6 +314,12 @@ public class FlutterLocalNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
         let center = UNUserNotificationCenter.current()
         center.removeAllPendingNotificationRequests()
         center.removeAllDeliveredNotifications()
+        result(nil)
+    }
+
+    func cancelAllPendingNotifications(_ result: @escaping FlutterResult) {
+        let center = UNUserNotificationCenter.current()
+        center.removeAllPendingNotificationRequests()
         result(nil)
     }
 

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -2618,6 +2618,13 @@ void main() {
       expect(log, <Matcher>[isMethodCall('cancelAll', arguments: null)]);
     });
 
+    test('cancelAllPendingNotifications', () async {
+      await flutterLocalNotificationsPlugin.cancelAllPendingNotifications();
+      expect(log, <Matcher>[
+        isMethodCall('cancelAllPendingNotifications', arguments: null)
+      ]);
+    });
+
     test('pendingNotificationRequests', () async {
       await flutterLocalNotificationsPlugin.pendingNotificationRequests();
       expect(log, <Matcher>[

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -748,6 +748,13 @@ void main() {
       expect(log, <Matcher>[isMethodCall('cancelAll', arguments: null)]);
     });
 
+    test('cancelAllPendingNotifications', () async {
+      await flutterLocalNotificationsPlugin.cancelAllPendingNotifications();
+      expect(log, <Matcher>[
+        isMethodCall('cancelAllPendingNotifications', arguments: null)
+      ]);
+    });
+
     test('pendingNotificationRequests', () async {
       await flutterLocalNotificationsPlugin.pendingNotificationRequests();
       expect(log, <Matcher>[

--- a/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/macos_flutter_local_notifications_test.dart
@@ -669,6 +669,13 @@ void main() {
       expect(log, <Matcher>[isMethodCall('cancelAll', arguments: null)]);
     });
 
+    test('cancelAllPendingNotifications', () async {
+      await flutterLocalNotificationsPlugin.cancelAllPendingNotifications();
+      expect(log, <Matcher>[
+        isMethodCall('cancelAllPendingNotifications', arguments: null)
+      ]);
+    });
+
     test('pendingNotificationRequests', () async {
       await flutterLocalNotificationsPlugin.pendingNotificationRequests();
       expect(log, <Matcher>[

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -78,8 +78,9 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('cancelAll() has not been implemented');
   }
 
-  /// Cancels all scheduled (pending) notifications
-  /// without affecting displayed notifications.
+  /// Cancels/removes all pending notifications.
+  ///
+  /// This only applies to notifications that have been scheduled.
   Future<void> cancelAllPendingNotifications() async {
     throw UnimplementedError(
         'cancelAllPendingNotifications() has not been implemented');

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -78,7 +78,8 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('cancelAll() has not been implemented');
   }
 
-  /// Cancels all scheduled (pending) notifications without affecting displayed notifications.
+  /// Cancels all scheduled (pending) notifications
+  /// without affecting displayed notifications.
   Future<void> cancelAllPendingNotifications() async {
     throw UnimplementedError(
         'cancelAllPendingNotifications() has not been implemented');

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -78,6 +78,12 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     throw UnimplementedError('cancelAll() has not been implemented');
   }
 
+  /// Cancels all scheduled (pending) notifications without affecting displayed notifications.
+  Future<void> cancelAllPendingNotifications() async {
+    throw UnimplementedError(
+        'cancelAllPendingNotifications() has not been implemented');
+  }
+
   /// Returns a list of notifications pending to be delivered/shown
   Future<List<PendingNotificationRequest>> pendingNotificationRequests() {
     throw UnimplementedError(


### PR DESCRIPTION
### Related Issue

Issue #2567 

### Summary

This PR introduces a new method `cancelAllPendingNotifications()` to cancel only **scheduled (pending)** notifications, without removing any **delivered** notifications from the system UI (Notification Center).

Currently, the `cancelAll()` method cancels **both** pending and delivered notifications. However, in most usecases, developers need better way to clear scheduled alarms while keeping shown notifications intact.

### Platform support

- ✅ **iOS**: Uses `UNUserNotificationCenter.removeAllPendingNotificationRequests()`
- ✅ **macOS**: Uses `UNUserNotificationCenter.removeAllPendingNotificationRequests()`
- ✅ **Android**: Cancels all scheduled alarms via `AlarmManager.cancel(...)`

### Usage

```dart
await flutterLocalNotificationsPlugin.cancelAllPendingNotifications();
```

### Tests

- All test codes added & passed success.
- Added button widget to example app for manual test.
