### PR TITLE
fix(windows): add runtimeobject.lib to resolve unresolved WinRT symbols

### DIFF
--- a/flutter_local_notifications_windows/windows/CMakeLists.txt
+++ b/flutter_local_notifications_windows/windows/CMakeLists.txt
@@ -21,3 +21,4 @@ set(flutter_local_notifications_windows_bundled_libraries
   $<TARGET_FILE:flutter_local_notifications_windows>
   PARENT_SCOPE
 )
+target_link_libraries(flutter_local_notifications_windows PRIVATE runtimeobject)


### PR DESCRIPTION
Without this, Windows builds fail with unresolved external symbol errors related to WINRT_IMPL_RoGetActivationFactory and RoOriginateLanguageException.

This links the missing `runtimeobject.lib` explicitly as required by MSVC since newer Windows SDKs no longer link it implicitly.

Tested on:
- Windows 11 + MSVC 2022
- Flutter stable 3.32.6

As this repository hosts multiple packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). Should the PR more than one package than please prefix the title of the PR with [various] The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
