### PR TITLE
[flutter_local_notifications] Android Semantic actions

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -357,6 +357,10 @@ public class FlutterLocalNotificationsPlugin
           actionBuilder.setAllowGeneratedReplies(action.allowGeneratedReplies);
         }
 
+        if (action.semanticAction != null) {
+          actionBuilder.setSemanticAction(action.semanticAction);
+        }
+
         if (action.actionInputs != null) {
           for (NotificationActionInput input : action.actionInputs) {
             RemoteInput.Builder remoteInput =

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationAction.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationAction.java
@@ -83,6 +83,7 @@ public class NotificationAction implements Serializable {
   private static final String SHOWS_USER_INTERFACE = "showsUserInterface";
   private static final String ALLOW_GENERATED_REPLIES = "allowGeneratedReplies";
   private static final String CANCEL_NOTIFICATION = "cancelNotification";
+  private static final String SEMANTIC_ACTION = "semanticAction";
 
   public final String id;
   public final String title;
@@ -92,6 +93,7 @@ public class NotificationAction implements Serializable {
   @Nullable public final Boolean contextual;
   @Nullable public final Boolean showsUserInterface;
   @Nullable public final Boolean allowGeneratedReplies;
+  @Nullable public final Integer semanticAction;
   @Nullable public final IconSource iconSource;
   // actionInputs is annotated as nullable as the Flutter API use to allow this to be nullable
   // before null-safety was added in
@@ -116,6 +118,7 @@ public class NotificationAction implements Serializable {
     contextual = (Boolean) arguments.get(CONTEXTUAL);
     showsUserInterface = (Boolean) arguments.get(SHOWS_USER_INTERFACE);
     allowGeneratedReplies = (Boolean) arguments.get(ALLOW_GENERATED_REPLIES);
+    semanticAction = (Integer) arguments.get(SEMANTIC_ACTION);
 
     Integer iconSourceIndex = (Integer) arguments.get(ICON_SOURCE);
     if (iconSourceIndex != null) {

--- a/flutter_local_notifications/android/src/test/java/com/dexterous/flutterlocalnotifications/models/NotificationActionTest.java
+++ b/flutter_local_notifications/android/src/test/java/com/dexterous/flutterlocalnotifications/models/NotificationActionTest.java
@@ -30,6 +30,7 @@ public class NotificationActionTest {
     raw.put("showsUserInterface", true);
     raw.put("allowGeneratedReplies", true);
     raw.put("iconBitmapSource", 4);
+    raw.put("semanticAction", 1);
 
     final List<Map<String, Object>> inputs = new ArrayList<>();
     final Map<String, Object> aInput = new HashMap<>();
@@ -51,6 +52,7 @@ public class NotificationActionTest {
     assertEquals(true, action.contextual);
     assertEquals(true, action.showsUserInterface);
     assertEquals(true, action.allowGeneratedReplies);
+    assertEquals(1, action.semanticAction);
     assertEquals(IconSource.ByteArray, action.iconSource);
     assertEquals(
         new NotificationActionInput(

--- a/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/enums.dart
@@ -269,6 +269,48 @@ enum AudioAttributesUsage {
   final int value;
 }
 
+/// The available semantic actions for Android notifications.
+enum SemanticAction {
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_NONE`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_NONE).
+  none(0),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_REPLY`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_REPLY).
+  reply(1),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_MARK_AS_READ`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_MARK_AS_READ).
+  markAsRead(2),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_MARK_AS_UNREAD`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_MARK_AS_UNREAD).
+  markAsUnread(3),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_DELETE`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_DELETE).
+  delete(4),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_ARCHIVE`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_ARCHIVE).
+  archive(5),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_MUTE`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_MUTE).
+  mute(6),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_UNMUTE`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_UNMUTE).
+  unmute(7),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_THUMBS_UP`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_THUMBS_UP).
+  thumbsUp(8),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_THUMBS_DOWN`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_THUMBS_DOWN).
+  thumbsDown(9),
+
+  /// Corresponds to [`Notification.Action.SEMANTIC_ACTION_CALL`](https://developer.android.com/reference/android/app/Notification.Action#SEMANTIC_ACTION_CALL).
+  call(10);
+
+  /// Constructs an instance of [SemanticAction].
+  const SemanticAction(this.value);
+
+  /// The integer representation of [SemanticAction].
+  final int value;
+}
+
 /// The available categories for Android notifications.
 enum AndroidNotificationCategory {
   /// Alarm or timer.

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -312,7 +312,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
                       _convertInputToMap(input))
                   .toList(),
               'cancelNotification': e.cancelNotification,
-              'semanticAction': e.semanticAction,
+              'semanticAction': e.semanticAction.value,
             },
           )
           .toList(),

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -312,6 +312,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
                       _convertInputToMap(input))
                   .toList(),
               'cancelNotification': e.cancelNotification,
+              'semanticAction': e.semanticAction,
             },
           )
           .toList(),

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -56,6 +56,7 @@ class AndroidNotificationAction {
     this.allowGeneratedReplies = false,
     this.inputs = const <AndroidNotificationActionInput>[],
     this.cancelNotification = true,
+    this.semanticAction = 0,
   });
 
   /// This ID will be sent back in the action handler defined in
@@ -93,6 +94,10 @@ class AndroidNotificationAction {
   /// Set whether the notification should be canceled when this action is
   /// selected.
   final bool cancelNotification;
+
+  // Sets the SemanticAction for this Action. A SemanticAction denotes what an
+  // Action's PendingIntent will do (eg. reply, mark as read, delete, etc).
+  final int semanticAction;
 }
 
 /// Contains notification details specific to Android.

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -56,7 +56,7 @@ class AndroidNotificationAction {
     this.allowGeneratedReplies = false,
     this.inputs = const <AndroidNotificationActionInput>[],
     this.cancelNotification = true,
-    this.semanticAction = 0,
+    this.semanticAction = SemanticAction.none,
   });
 
   /// This ID will be sent back in the action handler defined in
@@ -95,9 +95,9 @@ class AndroidNotificationAction {
   /// selected.
   final bool cancelNotification;
 
-  // Sets the SemanticAction for this Action. A SemanticAction denotes what an
-  // Action's PendingIntent will do (eg. reply, mark as read, delete, etc).
-  final int semanticAction;
+  /// Sets the SemanticAction for this Action. A SemanticAction denotes what an
+  /// Action's PendingIntent will do (eg. reply, mark as read, delete, etc).
+  final SemanticAction semanticAction;
 }
 
 /// Contains notification details specific to Android.

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -93,6 +93,7 @@ void main() {
             showsUserInterface: true,
             allowGeneratedReplies: true,
             cancelNotification: false,
+            semanticAction: 2,
           ),
           AndroidNotificationAction(
             'action2',
@@ -193,7 +194,8 @@ void main() {
                   'showsUserInterface': true,
                   'allowGeneratedReplies': true,
                   'inputs': <Object>[],
-                  'cancelNotification': false
+                  'cancelNotification': false,
+                  'semanticAction': 2,
                 },
                 <String, Object>{
                   'id': 'action2',
@@ -214,6 +216,7 @@ void main() {
                     }
                   ],
                   'cancelNotification': true,
+                  'semanticAction': 0,
                 }
               ],
             },

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -93,7 +93,7 @@ void main() {
             showsUserInterface: true,
             allowGeneratedReplies: true,
             cancelNotification: false,
-            semanticAction: 2,
+            semanticAction: SemanticAction.markAsRead,
           ),
           AndroidNotificationAction(
             'action2',
@@ -195,7 +195,7 @@ void main() {
                   'allowGeneratedReplies': true,
                   'inputs': <Object>[],
                   'cancelNotification': false,
-                  'semanticAction': 2,
+                  'semanticAction': SemanticAction.markAsRead.value,
                 },
                 <String, Object>{
                   'id': 'action2',
@@ -216,7 +216,7 @@ void main() {
                     }
                   ],
                   'cancelNotification': true,
-                  'semanticAction': 0,
+                  'semanticAction': SemanticAction.none.value,
                 }
               ],
             },


### PR DESCRIPTION
Resolves #2656

Adds a `semanticAction` attribute to `AndroidNotificationAction` which gets passed through to the builder.