### PR TITLE
[Android] Add title & description text styling for notifications (API 24+)

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -38,6 +38,7 @@ A cross platform plugin for displaying local notifications.
    - [Handling notifications whilst the app is in the foreground](#handling-notifications-whilst-the-app-is-in-the-foreground)
 - **[❓ Usage](#-usage)**
    - [Notification Actions](#notification-actions)
+   - [[Android] Title text styling (API 24+)](#android-title-text-styling-api-24)
    - [Example app](#example-app)
    - [API reference](#api-reference)
 - **[Initialisation](#initialisation)**
@@ -629,6 +630,29 @@ Future<void> _showNotificationWithActions() async {
 ```
 
 Each notification will have a internal ID & an public action title.
+
+### [Android] Title text styling (API 24+)
+
+Style only the notification title on Android 7.0+ using a decorated custom
+layout. Older Android versions will silently fall back to the default system
+template.
+
+```dart
+final androidDetails = AndroidNotificationDetails(
+  'reminders',
+  'Reminders',
+  titleStyle: const AndroidNotificationTitleStyle(
+    color: 0xFF58CC02,
+    sizeSp: 16,
+    bold: true,
+    italic: false,
+  ),
+);
+```
+
+> [!NOTE]
+> This only affects the title text. Ensure sufficient contrast for
+> accessibility.
 
 ### Example app
 

--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -641,17 +641,24 @@ template.
 final androidDetails = AndroidNotificationDetails(
   'reminders',
   'Reminders',
-  titleStyle: const AndroidNotificationTitleStyle(
-    color: 0xFF58CC02,
-    sizeSp: 16,
-    bold: true,
-    italic: false,
+    titleStyle: const AndroidNotificationTitleStyle(
+        color: 0xFF58CC02,
+        sizeSp: 16,
+        bold: true,
+        italic: false,
+        iconSpacing: 2,
+    ),
+    descriptionStyle: const AndroidNotificationDescriptionStyle(
+        color: 0xFFFF0000,
+        sizeSp: 14,
+        bold: false,
+        italic: true,
   ),
 );
 ```
 
 > [!NOTE]
-> This only affects the title text. Ensure sufficient contrast for
+> These options affect the title and body text respectively. Ensure sufficient contrast for
 > accessibility.
 
 ### Example app

--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0"
     }
 }
 
@@ -25,7 +25,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.dexterous.flutterlocalnotifications'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdkVersion 21
@@ -35,12 +35,12 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     lintOptions {
@@ -53,7 +53,7 @@ dependencies {
     implementation "androidx.core:core:1.3.0"
     implementation "androidx.media:media:1.1.0"
     implementation "com.google.code.gson:gson:2.12.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.23"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:2.1.0"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
     }
 }
 
@@ -20,20 +21,26 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.dexterous.flutterlocalnotifications'
     compileSdk 35
+
+    defaultConfig {
+        minSdkVersion 21
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    defaultConfig {
-        multiDexEnabled true
-        minSdkVersion 21
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    kotlinOptions {
+        jvmTarget = "11"
     }
 
     lintOptions {
@@ -46,6 +53,7 @@ dependencies {
     implementation "androidx.core:core:1.3.0"
     implementation "androidx.media:media:1.1.0"
     implementation "com.google.code.gson:gson:2.12.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.23"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.10.0'

--- a/flutter_local_notifications/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_local_notifications/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -220,7 +220,7 @@ public class FlutterLocalNotificationsPlugin
     ts.sizeSp = 18.0;
     ts.bold = Boolean.TRUE;
     ts.italic = Boolean.FALSE;
-    ts.iconSpacingDp = 0;
+    ts.iconSpacingDp = 0d;
     return ts;
   }
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -35,6 +35,7 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
 import android.util.Log;
+import android.widget.RemoteViews;
 
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -74,6 +75,7 @@ import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 import com.dexterous.flutterlocalnotifications.utils.BooleanUtils;
 import com.dexterous.flutterlocalnotifications.utils.LongUtils;
 import com.dexterous.flutterlocalnotifications.utils.StringUtils;
+import com.dexterous.flutterlocalnotifications.TitleStyler;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -114,11 +116,11 @@ interface PermissionRequestListener {
 @Keep
 public class FlutterLocalNotificationsPlugin
     implements MethodCallHandler,
-        PluginRegistry.NewIntentListener,
-        PluginRegistry.RequestPermissionsResultListener,
-        PluginRegistry.ActivityResultListener,
-        FlutterPlugin,
-        ActivityAware {
+    PluginRegistry.NewIntentListener,
+    PluginRegistry.RequestPermissionsResultListener,
+    PluginRegistry.ActivityResultListener,
+    FlutterPlugin,
+    ActivityAware {
 
   static final String PAYLOAD = "payload";
   static final String NOTIFICATION_ID = "notificationId";
@@ -133,22 +135,17 @@ public class FlutterLocalNotificationsPlugin
   private static final String DRAWABLE = "drawable";
   private static final String DEFAULT_ICON = "defaultIcon";
   private static final String SELECT_NOTIFICATION = "SELECT_NOTIFICATION";
-  private static final String SELECT_FOREGROUND_NOTIFICATION_ACTION =
-      "SELECT_FOREGROUND_NOTIFICATION";
+  private static final String SELECT_FOREGROUND_NOTIFICATION_ACTION = "SELECT_FOREGROUND_NOTIFICATION";
   private static final String SCHEDULED_NOTIFICATIONS = "scheduled_notifications";
   private static final String INITIALIZE_METHOD = "initialize";
   private static final String GET_CALLBACK_HANDLE_METHOD = "getCallbackHandle";
   private static final String ARE_NOTIFICATIONS_ENABLED_METHOD = "areNotificationsEnabled";
-  private static final String CAN_SCHEDULE_EXACT_NOTIFICATIONS_METHOD =
-      "canScheduleExactNotifications";
-  private static final String CREATE_NOTIFICATION_CHANNEL_GROUP_METHOD =
-      "createNotificationChannelGroup";
-  private static final String DELETE_NOTIFICATION_CHANNEL_GROUP_METHOD =
-      "deleteNotificationChannelGroup";
+  private static final String CAN_SCHEDULE_EXACT_NOTIFICATIONS_METHOD = "canScheduleExactNotifications";
+  private static final String CREATE_NOTIFICATION_CHANNEL_GROUP_METHOD = "createNotificationChannelGroup";
+  private static final String DELETE_NOTIFICATION_CHANNEL_GROUP_METHOD = "deleteNotificationChannelGroup";
   private static final String CREATE_NOTIFICATION_CHANNEL_METHOD = "createNotificationChannel";
   private static final String DELETE_NOTIFICATION_CHANNEL_METHOD = "deleteNotificationChannel";
-  private static final String GET_ACTIVE_NOTIFICATION_MESSAGING_STYLE_METHOD =
-      "getActiveNotificationMessagingStyle";
+  private static final String GET_ACTIVE_NOTIFICATION_MESSAGING_STYLE_METHOD = "getActiveNotificationMessagingStyle";
   private static final String GET_NOTIFICATION_CHANNELS_METHOD = "getNotificationChannels";
   private static final String START_FOREGROUND_SERVICE = "startForegroundService";
   private static final String STOP_FOREGROUND_SERVICE = "stopForegroundService";
@@ -157,23 +154,16 @@ public class FlutterLocalNotificationsPlugin
   private static final String SHOW_METHOD = "show";
   private static final String CANCEL_METHOD = "cancel";
   private static final String CANCEL_ALL_METHOD = "cancelAll";
-  private static final String CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD =
-      "cancelAllPendingNotifications";
+  private static final String CANCEL_ALL_PENDING_NOTIFICATIONS_METHOD = "cancelAllPendingNotifications";
   private static final String ZONED_SCHEDULE_METHOD = "zonedSchedule";
   private static final String PERIODICALLY_SHOW_METHOD = "periodicallyShow";
-  private static final String PERIODICALLY_SHOW_WITH_DURATION_METHOD =
-      "periodicallyShowWithDuration";
-  private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD =
-      "getNotificationAppLaunchDetails";
-  private static final String REQUEST_NOTIFICATIONS_PERMISSION_METHOD =
-      "requestNotificationsPermission";
-  private static final String REQUEST_EXACT_ALARMS_PERMISSION_METHOD =
-      "requestExactAlarmsPermission";
+  private static final String PERIODICALLY_SHOW_WITH_DURATION_METHOD = "periodicallyShowWithDuration";
+  private static final String GET_NOTIFICATION_APP_LAUNCH_DETAILS_METHOD = "getNotificationAppLaunchDetails";
+  private static final String REQUEST_NOTIFICATIONS_PERMISSION_METHOD = "requestNotificationsPermission";
+  private static final String REQUEST_EXACT_ALARMS_PERMISSION_METHOD = "requestExactAlarmsPermission";
 
-  private static final String REQUEST_FULL_SCREEN_INTENT_PERMISSION_METHOD =
-      "requestFullScreenIntentPermission";
-  private static final String REQUEST_NOTIFICATION_POLICY_ACCESS_METHOD =
-      "requestNotificationPolicyAccess";
+  private static final String REQUEST_FULL_SCREEN_INTENT_PERMISSION_METHOD = "requestFullScreenIntentPermission";
+  private static final String REQUEST_NOTIFICATION_POLICY_ACCESS_METHOD = "requestNotificationPolicyAccess";
   private static final String HAS_NOTIFICATION_POLICY_ACCESS_METHOD = "hasNotificationPolicyAccess";
   private static final String METHOD_CHANNEL = "dexterous.com/flutter/local_notifications";
   private static final String INVALID_ICON_ERROR_CODE = "invalid_icon";
@@ -182,25 +172,18 @@ public class FlutterLocalNotificationsPlugin
   private static final String INVALID_SOUND_ERROR_CODE = "invalid_sound";
   private static final String INVALID_LED_DETAILS_ERROR_CODE = "invalid_led_details";
   private static final String UNSUPPORTED_OS_VERSION_ERROR_CODE = "unsupported_os_version";
-  private static final String GET_ACTIVE_NOTIFICATIONS_ERROR_MESSAGE =
-      "Android version must be 6.0 or newer to use getActiveNotifications";
+  private static final String GET_ACTIVE_NOTIFICATIONS_ERROR_MESSAGE = "Android version must be 6.0 or newer to use getActiveNotifications";
   private static final String GET_NOTIFICATION_CHANNELS_ERROR_CODE = "getNotificationChannelsError";
-  private static final String GET_ACTIVE_NOTIFICATION_MESSAGING_STYLE_ERROR_CODE =
-      "getActiveNotificationMessagingStyleError";
-  private static final String INVALID_LED_DETAILS_ERROR_MESSAGE =
-      "Must specify both ledOnMs and ledOffMs to configure the blink cycle on older versions of"
-          + " Android before Oreo";
+  private static final String GET_ACTIVE_NOTIFICATION_MESSAGING_STYLE_ERROR_CODE = "getActiveNotificationMessagingStyleError";
+  private static final String INVALID_LED_DETAILS_ERROR_MESSAGE = "Must specify both ledOnMs and ledOffMs to configure the blink cycle on older versions of"
+      + " Android before Oreo";
   private static final String NOTIFICATION_LAUNCHED_APP = "notificationLaunchedApp";
-  private static final String INVALID_DRAWABLE_RESOURCE_ERROR_MESSAGE =
-      "The resource %s could not be found. Please make sure it has been added as a drawable"
-          + " resource to your Android head project.";
-  private static final String INVALID_RAW_RESOURCE_ERROR_MESSAGE =
-      "The resource %s could not be found. Please make sure it has been added as a raw resource to"
-          + " your Android head project.";
-  private static final String PERMISSION_REQUEST_IN_PROGRESS_ERROR_CODE =
-      "permissionRequestInProgress";
-  private static final String PERMISSION_REQUEST_IN_PROGRESS_ERROR_MESSAGE =
-      "Another permission request is already in progress";
+  private static final String INVALID_DRAWABLE_RESOURCE_ERROR_MESSAGE = "The resource %s could not be found. Please make sure it has been added as a drawable"
+      + " resource to your Android head project.";
+  private static final String INVALID_RAW_RESOURCE_ERROR_MESSAGE = "The resource %s could not be found. Please make sure it has been added as a raw resource to"
+      + " your Android head project.";
+  private static final String PERMISSION_REQUEST_IN_PROGRESS_ERROR_CODE = "permissionRequestInProgress";
+  private static final String PERMISSION_REQUEST_IN_PROGRESS_ERROR_MESSAGE = "Another permission request is already in progress";
   private static final String EXACT_ALARMS_PERMISSION_ERROR_CODE = "exact_alarms_not_permitted";
   private static final String CANCEL_ID = "id";
   private static final String CANCEL_TAG = "tag";
@@ -223,6 +206,21 @@ public class FlutterLocalNotificationsPlugin
   private PermissionRequestListener callback;
 
   private PermissionRequestProgress permissionRequestProgress = PermissionRequestProgress.None;
+
+  private static String fmtTitleStyle(com.dexterous.flutterlocalnotifications.models.TitleStyle ts) {
+    if (ts == null)
+      return "<null>";
+    return "color=" + ts.color + " sizeSp=" + ts.sizeSp + " bold=" + ts.bold + " italic=" + ts.italic;
+  }
+
+  private static com.dexterous.flutterlocalnotifications.models.TitleStyle debugFallbackStyle() {
+    com.dexterous.flutterlocalnotifications.models.TitleStyle ts = new com.dexterous.flutterlocalnotifications.models.TitleStyle();
+    ts.color = 0xFF0000FF; // BLUE (ARGB) – TEMPORARY
+    ts.sizeSp = 18.0;
+    ts.bold = Boolean.TRUE;
+    ts.italic = Boolean.FALSE;
+    return ts;
+  }
 
   static void rescheduleNotifications(Context context) {
     ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(context);
@@ -263,8 +261,8 @@ public class FlutterLocalNotificationsPlugin
 
   protected static Notification createNotification(
       Context context, NotificationDetails notificationDetails) {
-    NotificationChannelDetails notificationChannelDetails =
-        NotificationChannelDetails.fromNotificationDetails(notificationDetails);
+    NotificationChannelDetails notificationChannelDetails = NotificationChannelDetails
+        .fromNotificationDetails(notificationDetails);
     if (canCreateNotificationChannel(context, notificationChannelDetails)) {
       setupNotificationChannel(context, notificationChannelDetails);
     }
@@ -276,27 +274,30 @@ public class FlutterLocalNotificationsPlugin
     if (VERSION.SDK_INT >= VERSION_CODES.M) {
       flags |= PendingIntent.FLAG_IMMUTABLE;
     }
-    PendingIntent pendingIntent =
-        PendingIntent.getActivity(context, notificationDetails.id, intent, flags);
-    DefaultStyleInformation defaultStyleInformation =
-        (DefaultStyleInformation) notificationDetails.styleInformation;
-    NotificationCompat.Builder builder =
-        new NotificationCompat.Builder(context, notificationDetails.channelId)
-            .setContentTitle(
-                defaultStyleInformation.htmlFormatTitle
-                    ? fromHtml(notificationDetails.title)
-                    : notificationDetails.title)
-            .setContentText(
-                defaultStyleInformation.htmlFormatBody
-                    ? fromHtml(notificationDetails.body)
-                    : notificationDetails.body)
-            .setTicker(notificationDetails.ticker)
-            .setAutoCancel(BooleanUtils.getValue(notificationDetails.autoCancel))
-            .setContentIntent(pendingIntent)
-            .setPriority(notificationDetails.priority)
-            .setOngoing(BooleanUtils.getValue(notificationDetails.ongoing))
-            .setSilent(BooleanUtils.getValue(notificationDetails.silent))
-            .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce));
+    PendingIntent pendingIntent = PendingIntent.getActivity(context, notificationDetails.id, intent, flags);
+    DefaultStyleInformation defaultStyleInformation = (DefaultStyleInformation) notificationDetails.styleInformation;
+    final boolean canCustom = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N;
+    final com.dexterous.flutterlocalnotifications.models.TitleStyle received = notificationDetails.titleStyle;
+    android.util.Log.d("FLN-TitleStyle", "ANDROID RECEIVED " + fmtTitleStyle(received)
+        + " sdk=" + android.os.Build.VERSION.SDK_INT + " title=" + notificationDetails.title);
+
+    // TEMP: keep custom path alive even if titleStyle is null, so we can see
+    // something
+    final com.dexterous.flutterlocalnotifications.models.TitleStyle effective = (canCustom && received == null)
+        ? debugFallbackStyle()
+        : received;
+
+    final RemoteViews customView = TitleStyler.INSTANCE.build(context, notificationDetails.title,
+        notificationDetails.body, effective);
+
+    NotificationCompat.Builder builder = new NotificationCompat.Builder(context, notificationDetails.channelId)
+        .setTicker(notificationDetails.ticker)
+        .setAutoCancel(BooleanUtils.getValue(notificationDetails.autoCancel))
+        .setContentIntent(pendingIntent)
+        .setPriority(notificationDetails.priority)
+        .setOngoing(BooleanUtils.getValue(notificationDetails.ongoing))
+        .setSilent(BooleanUtils.getValue(notificationDetails.silent))
+        .setOnlyAlertOnce(BooleanUtils.getValue(notificationDetails.onlyAlertOnce));
 
     if (notificationDetails.actions != null) {
       // Space out request codes by 16 so even with 16 actions they won't clash
@@ -334,10 +335,9 @@ public class FlutterLocalNotificationsPlugin
         }
 
         @SuppressLint("UnspecifiedImmutableFlag")
-        final PendingIntent actionPendingIntent =
-            action.showsUserInterface != null && action.showsUserInterface
-                ? PendingIntent.getActivity(context, requestCode++, actionIntent, actionFlags)
-                : PendingIntent.getBroadcast(context, requestCode++, actionIntent, actionFlags);
+        final PendingIntent actionPendingIntent = action.showsUserInterface != null && action.showsUserInterface
+            ? PendingIntent.getActivity(context, requestCode++, actionIntent, actionFlags)
+            : PendingIntent.getBroadcast(context, requestCode++, actionIntent, actionFlags);
 
         final Spannable actionTitleSpannable = new SpannableString(action.title);
         if (action.titleColor != null) {
@@ -363,8 +363,7 @@ public class FlutterLocalNotificationsPlugin
 
         if (action.actionInputs != null) {
           for (NotificationActionInput input : action.actionInputs) {
-            RemoteInput.Builder remoteInput =
-                new RemoteInput.Builder(INPUT_RESULT).setLabel(input.label);
+            RemoteInput.Builder remoteInput = new RemoteInput.Builder(INPUT_RESULT).setLabel(input.label);
             if (input.allowFreeFormInput != null) {
               remoteInput.setAllowFreeFormInput(input.allowFreeFormInput);
             }
@@ -426,7 +425,7 @@ public class FlutterLocalNotificationsPlugin
       builder.setShortcutId(notificationDetails.shortcutId);
     }
 
-    if (!StringUtils.isNullOrEmpty(notificationDetails.subText)) {
+    if (customView == null && !StringUtils.isNullOrEmpty(notificationDetails.subText)) {
       builder.setSubText(notificationDetails.subText);
     }
 
@@ -439,13 +438,34 @@ public class FlutterLocalNotificationsPlugin
     setSound(context, notificationDetails, builder);
     setVibrationPattern(notificationDetails, builder);
     setLights(notificationDetails, builder);
-    setStyle(context, notificationDetails, builder);
     setProgress(notificationDetails, builder);
     setCategory(notificationDetails, builder);
     setTimeoutAfter(notificationDetails, builder);
+    if (customView == null) {
+      setStyle(context, notificationDetails, builder);
+    }
+    if (customView != null) {
+      // Attach our custom layout in ALL paths and suppress any system text
+      builder.setCustomContentView(customView);
+      builder.setCustomBigContentView(customView);
+      builder.setCustomHeadsUpContentView(customView);
+      builder.setStyle(new NotificationCompat.DecoratedCustomViewStyle());
+      builder.setContentTitle((CharSequence) null);
+      builder.setContentText((CharSequence) null);
+      builder.setSubText((CharSequence) null);
+    } else {
+      // Fallback to system template
+      builder.setContentTitle(
+          defaultStyleInformation.htmlFormatTitle
+              ? fromHtml(notificationDetails.title)
+              : notificationDetails.title);
+      builder.setContentText(
+          defaultStyleInformation.htmlFormatBody
+              ? fromHtml(notificationDetails.body)
+              : notificationDetails.body);
+    }
     Notification notification = builder.build();
-    if (notificationDetails.additionalFlags != null
-        && notificationDetails.additionalFlags.length > 0) {
+    if (notificationDetails.additionalFlags != null && notificationDetails.additionalFlags.length > 0) {
       for (int additionalFlag : notificationDetails.additionalFlags) {
         notification.flags |= additionalFlag;
       }
@@ -456,18 +476,19 @@ public class FlutterLocalNotificationsPlugin
   private static Boolean canCreateNotificationChannel(
       Context context, NotificationChannelDetails notificationChannelDetails) {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
-      NotificationManager notificationManager =
-          (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-      NotificationChannel notificationChannel =
-          notificationManager.getNotificationChannel(notificationChannelDetails.id);
-      // only create/update the channel when needed/specified. Allow this happen to when
+      NotificationManager notificationManager = (NotificationManager) context
+          .getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationChannel notificationChannel = notificationManager
+          .getNotificationChannel(notificationChannelDetails.id);
+      // only create/update the channel when needed/specified. Allow this happen to
+      // when
       // channelAction may be null to support cases where notifications had been
-      // created on older versions of the plugin where channel management options weren't available
+      // created on older versions of the plugin where channel management options
+      // weren't available
       // back then
       return ((notificationChannel == null
-              && (notificationChannelDetails.channelAction == null
-                  || notificationChannelDetails.channelAction
-                      == NotificationChannelAction.CreateIfNotExists))
+          && (notificationChannelDetails.channelAction == null
+              || notificationChannelDetails.channelAction == NotificationChannelAction.CreateIfNotExists))
           || (notificationChannel != null
               && notificationChannelDetails.channelAction == NotificationChannelAction.Update));
     }
@@ -481,11 +502,11 @@ public class FlutterLocalNotificationsPlugin
     if (!StringUtils.isNullOrEmpty(notificationDetails.icon)) {
       builder.setSmallIcon(getDrawableResourceId(context, notificationDetails.icon));
     } else {
-      SharedPreferences sharedPreferences =
-          context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
+      SharedPreferences sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
       String defaultIcon = sharedPreferences.getString(DEFAULT_ICON, null);
       if (StringUtils.isNullOrEmpty(defaultIcon)) {
-        // for backwards compatibility: this is for handling the old way references to the icon used
+        // for backwards compatibility: this is for handling the old way references to
+        // the icon used
         // to be kept but should be removed in future
         builder.setSmallIcon(notificationDetails.iconResourceId);
 
@@ -498,17 +519,16 @@ public class FlutterLocalNotificationsPlugin
   @NonNull
   static Gson buildGson() {
     if (gson == null) {
-      RuntimeTypeAdapterFactory<StyleInformation> styleInformationAdapter =
-          RuntimeTypeAdapterFactory.of(StyleInformation.class)
-              .registerSubtype(DefaultStyleInformation.class)
-              .registerSubtype(BigTextStyleInformation.class)
-              .registerSubtype(BigPictureStyleInformation.class)
-              .registerSubtype(InboxStyleInformation.class)
-              .registerSubtype(MessagingStyleInformation.class);
-      GsonBuilder builder =
-          new GsonBuilder()
-              .registerTypeAdapter(ScheduleMode.class, new ScheduleMode.Deserializer())
-              .registerTypeAdapterFactory(styleInformationAdapter);
+      RuntimeTypeAdapterFactory<StyleInformation> styleInformationAdapter = RuntimeTypeAdapterFactory
+          .of(StyleInformation.class)
+          .registerSubtype(DefaultStyleInformation.class)
+          .registerSubtype(BigTextStyleInformation.class)
+          .registerSubtype(BigPictureStyleInformation.class)
+          .registerSubtype(InboxStyleInformation.class)
+          .registerSubtype(MessagingStyleInformation.class);
+      GsonBuilder builder = new GsonBuilder()
+          .registerTypeAdapter(ScheduleMode.class, new ScheduleMode.Deserializer())
+          .registerTypeAdapterFactory(styleInformationAdapter);
       gson = builder.create();
     }
     return gson;
@@ -516,12 +536,12 @@ public class FlutterLocalNotificationsPlugin
 
   private static ArrayList<NotificationDetails> loadScheduledNotifications(Context context) {
     ArrayList<NotificationDetails> scheduledNotifications = new ArrayList<>();
-    SharedPreferences sharedPreferences =
-        context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
+    SharedPreferences sharedPreferences = context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
     String json = sharedPreferences.getString(SCHEDULED_NOTIFICATIONS, null);
     if (json != null) {
       Gson gson = buildGson();
-      Type type = new TypeToken<ArrayList<NotificationDetails>>() {}.getType();
+      Type type = new TypeToken<ArrayList<NotificationDetails>>() {
+      }.getType();
       scheduledNotifications = gson.fromJson(json, type);
     }
     return scheduledNotifications;
@@ -531,15 +551,14 @@ public class FlutterLocalNotificationsPlugin
       Context context, ArrayList<NotificationDetails> scheduledNotifications) {
     Gson gson = buildGson();
     String json = gson.toJson(scheduledNotifications);
-    SharedPreferences sharedPreferences =
-        context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
+    SharedPreferences sharedPreferences = context.getSharedPreferences(SCHEDULED_NOTIFICATIONS, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putString(SCHEDULED_NOTIFICATIONS, json).apply();
   }
 
   static void removeNotificationFromCache(Context context, Integer notificationId) {
     ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(context);
-    for (Iterator<NotificationDetails> it = scheduledNotifications.iterator(); it.hasNext(); ) {
+    for (Iterator<NotificationDetails> it = scheduledNotifications.iterator(); it.hasNext();) {
       NotificationDetails notificationDetails = it.next();
       if (notificationDetails.id.equals(notificationId)) {
         it.remove();
@@ -561,7 +580,8 @@ public class FlutterLocalNotificationsPlugin
     }
   }
 
-  // This is left to support old apps need this done when a notification is rescheduled and used the
+  // This is left to support old apps need this done when a notification is
+  // rescheduled and used the
   // deprecated schedule() method of the plugin
   private static void scheduleNotification(
       Context context,
@@ -571,8 +591,7 @@ public class FlutterLocalNotificationsPlugin
     String notificationDetailsJson = gson.toJson(notificationDetails);
     Intent notificationIntent = new Intent(context, ScheduledNotificationReceiver.class);
     notificationIntent.putExtra(NOTIFICATION_DETAILS, notificationDetailsJson);
-    PendingIntent pendingIntent =
-        getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
+    PendingIntent pendingIntent = getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
 
     AlarmManager alarmManager = getAlarmManager(context);
     setupAlarm(
@@ -594,15 +613,13 @@ public class FlutterLocalNotificationsPlugin
     String notificationDetailsJson = gson.toJson(notificationDetails);
     Intent notificationIntent = new Intent(context, ScheduledNotificationReceiver.class);
     notificationIntent.putExtra(NOTIFICATION_DETAILS, notificationDetailsJson);
-    PendingIntent pendingIntent =
-        getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
+    PendingIntent pendingIntent = getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
-    long epochMilli =
-        ZonedDateTime.of(
-                LocalDateTime.parse(notificationDetails.scheduledDateTime),
-                ZoneId.of(notificationDetails.timeZoneName))
-            .toInstant()
-            .toEpochMilli();
+    long epochMilli = ZonedDateTime.of(
+        LocalDateTime.parse(notificationDetails.scheduledDateTime),
+        ZoneId.of(notificationDetails.timeZoneName))
+        .toInstant()
+        .toEpochMilli();
 
     setupAlarm(notificationDetails, alarmManager, epochMilli, pendingIntent);
 
@@ -614,17 +631,16 @@ public class FlutterLocalNotificationsPlugin
   private static void scheduleNextRepeatingNotification(
       Context context, NotificationDetails notificationDetails) {
     long repeatInterval = calculateRepeatIntervalMilliseconds(notificationDetails);
-    long notificationTriggerTime =
-        calculateNextNotificationTrigger(notificationDetails.calledAt, repeatInterval);
+    long notificationTriggerTime = calculateNextNotificationTrigger(notificationDetails.calledAt, repeatInterval);
     Gson gson = buildGson();
     String notificationDetailsJson = gson.toJson(notificationDetails);
     Intent notificationIntent = new Intent(context, ScheduledNotificationReceiver.class);
     notificationIntent.putExtra(NOTIFICATION_DETAILS, notificationDetailsJson);
-    PendingIntent pendingIntent =
-        getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
+    PendingIntent pendingIntent = getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
     if (notificationDetails.scheduleMode == null) {
-      // This is to account for notifications created in older versions prior to allowWhileIdle
+      // This is to account for notifications created in older versions prior to
+      // allowWhileIdle
       // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/4b723e750d1371206520b10a122a444c4bba7475/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L569C37-L569C37
@@ -691,19 +707,18 @@ public class FlutterLocalNotificationsPlugin
       notificationTriggerTime = calendar.getTimeInMillis();
     }
 
-    notificationTriggerTime =
-        calculateNextNotificationTrigger(notificationTriggerTime, repeatInterval);
+    notificationTriggerTime = calculateNextNotificationTrigger(notificationTriggerTime, repeatInterval);
 
     Gson gson = buildGson();
     String notificationDetailsJson = gson.toJson(notificationDetails);
     Intent notificationIntent = new Intent(context, ScheduledNotificationReceiver.class);
     notificationIntent.putExtra(NOTIFICATION_DETAILS, notificationDetailsJson);
-    PendingIntent pendingIntent =
-        getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
+    PendingIntent pendingIntent = getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
 
     if (notificationDetails.scheduleMode == null) {
-      // This is to account for notifications created in older versions prior to allowWhileIdle
+      // This is to account for notifications created in older versions prior to
+      // allowWhileIdle
       // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/4b723e750d1371206520b10a122a444c4bba7475/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L642
@@ -730,7 +745,8 @@ public class FlutterLocalNotificationsPlugin
       PendingIntent pendingIntent) {
 
     if (notificationDetails.scheduleMode == null) {
-      // This is to account for notifications created in older versions prior to allowWhileIdle
+      // This is to account for notifications created in older versions prior to
+      // allowWhileIdle
       // being added to the deserialiser.
       // Reference to old behaviour:
       // https://github.com/MaikuB/flutter_local_notifications/blob/4b723e750d1371206520b10a122a444c4bba7475/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java#L515
@@ -835,7 +851,8 @@ public class FlutterLocalNotificationsPlugin
   @SuppressWarnings("unchecked")
   private static byte[] castObjectToByteArray(Object data) {
     byte[] byteArray;
-    // if data is deserialized by gson, it is of the wrong type and we have to convert it
+    // if data is deserialized by gson, it is of the wrong type and we have to
+    // convert it
     if (data instanceof ArrayList) {
       List<Double> l = (ArrayList<Double>) data;
       byteArray = new byte[l.size()];
@@ -852,9 +869,8 @@ public class FlutterLocalNotificationsPlugin
       Context context, Object data, BitmapSource bitmapSource) {
     Bitmap bitmap = null;
     if (bitmapSource == BitmapSource.DrawableResource) {
-      bitmap =
-          BitmapFactory.decodeResource(
-              context.getResources(), getDrawableResourceId(context, (String) data));
+      bitmap = BitmapFactory.decodeResource(
+          context.getResources(), getDrawableResourceId(context, (String) data));
     } else if (bitmapSource == BitmapSource.FilePath) {
       bitmap = BitmapFactory.decodeFile((String) data);
     } else if (bitmapSource == BitmapSource.ByteArray) {
@@ -869,8 +885,7 @@ public class FlutterLocalNotificationsPlugin
     IconCompat icon = null;
     switch (iconSource) {
       case DrawableResource:
-        icon =
-            IconCompat.createWithResource(context, getDrawableResourceId(context, (String) data));
+        icon = IconCompat.createWithResource(context, getDrawableResourceId(context, (String) data));
         break;
       case BitmapFilePath:
         icon = IconCompat.createWithBitmap(BitmapFactory.decodeFile((String) data));
@@ -881,8 +896,8 @@ public class FlutterLocalNotificationsPlugin
       case FlutterBitmapAsset:
         try {
           FlutterLoader flutterLoader = FlutterInjector.instance().flutterLoader();
-          AssetFileDescriptor assetFileDescriptor =
-              context.getAssets().openFd(flutterLoader.getLookupKeyForAsset((String) data));
+          AssetFileDescriptor assetFileDescriptor = context.getAssets()
+              .openFd(flutterLoader.getLookupKeyForAsset((String) data));
           FileInputStream fileInputStream = assetFileDescriptor.createInputStream();
           icon = IconCompat.createWithBitmap(BitmapFactory.decodeStream(fileInputStream));
           fileInputStream.close();
@@ -903,8 +918,9 @@ public class FlutterLocalNotificationsPlugin
   /**
    * Sets the visibility property to the input Notification Builder
    *
-   * @throws IllegalArgumentException If `notificationDetails.visibility` is not null but also not
-   *     matches any known index.
+   * @throws IllegalArgumentException If `notificationDetails.visibility` is not
+   *                                  null but also not
+   *                                  matches any known index.
    */
   private static void setVisibility(
       NotificationDetails notificationDetails, NotificationCompat.Builder builder) {
@@ -956,7 +972,7 @@ public class FlutterLocalNotificationsPlugin
         builder.setVibrate(notificationDetails.vibrationPattern);
       }
     } else {
-      builder.setVibrate(new long[] {0});
+      builder.setVibrate(new long[] { 0 });
     }
   }
 
@@ -975,9 +991,8 @@ public class FlutterLocalNotificationsPlugin
       NotificationDetails notificationDetails,
       NotificationCompat.Builder builder) {
     if (BooleanUtils.getValue(notificationDetails.playSound)) {
-      Uri uri =
-          retrieveSoundResourceUri(
-              context, notificationDetails.sound, notificationDetails.soundSource);
+      Uri uri = retrieveSoundResourceUri(
+          context, notificationDetails.sound, notificationDetails.soundSource);
       builder.setSound(uri);
     } else {
       builder.setSound(null);
@@ -1045,21 +1060,18 @@ public class FlutterLocalNotificationsPlugin
       Context context,
       NotificationDetails notificationDetails,
       NotificationCompat.Builder builder) {
-    BigPictureStyleInformation bigPictureStyleInformation =
-        (BigPictureStyleInformation) notificationDetails.styleInformation;
+    BigPictureStyleInformation bigPictureStyleInformation = (BigPictureStyleInformation) notificationDetails.styleInformation;
     NotificationCompat.BigPictureStyle bigPictureStyle = new NotificationCompat.BigPictureStyle();
     if (bigPictureStyleInformation.contentTitle != null) {
-      CharSequence contentTitle =
-          bigPictureStyleInformation.htmlFormatContentTitle
-              ? fromHtml(bigPictureStyleInformation.contentTitle)
-              : bigPictureStyleInformation.contentTitle;
+      CharSequence contentTitle = bigPictureStyleInformation.htmlFormatContentTitle
+          ? fromHtml(bigPictureStyleInformation.contentTitle)
+          : bigPictureStyleInformation.contentTitle;
       bigPictureStyle.setBigContentTitle(contentTitle);
     }
     if (bigPictureStyleInformation.summaryText != null) {
-      CharSequence summaryText =
-          bigPictureStyleInformation.htmlFormatSummaryText
-              ? fromHtml(bigPictureStyleInformation.summaryText)
-              : bigPictureStyleInformation.summaryText;
+      CharSequence summaryText = bigPictureStyleInformation.htmlFormatSummaryText
+          ? fromHtml(bigPictureStyleInformation.summaryText)
+          : bigPictureStyleInformation.summaryText;
       bigPictureStyle.setSummaryText(summaryText);
     }
 
@@ -1084,21 +1096,18 @@ public class FlutterLocalNotificationsPlugin
 
   private static void setInboxStyle(
       NotificationDetails notificationDetails, NotificationCompat.Builder builder) {
-    InboxStyleInformation inboxStyleInformation =
-        (InboxStyleInformation) notificationDetails.styleInformation;
+    InboxStyleInformation inboxStyleInformation = (InboxStyleInformation) notificationDetails.styleInformation;
     NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
     if (inboxStyleInformation.contentTitle != null) {
-      CharSequence contentTitle =
-          inboxStyleInformation.htmlFormatContentTitle
-              ? fromHtml(inboxStyleInformation.contentTitle)
-              : inboxStyleInformation.contentTitle;
+      CharSequence contentTitle = inboxStyleInformation.htmlFormatContentTitle
+          ? fromHtml(inboxStyleInformation.contentTitle)
+          : inboxStyleInformation.contentTitle;
       inboxStyle.setBigContentTitle(contentTitle);
     }
     if (inboxStyleInformation.summaryText != null) {
-      CharSequence summaryText =
-          inboxStyleInformation.htmlFormatSummaryText
-              ? fromHtml(inboxStyleInformation.summaryText)
-              : inboxStyleInformation.summaryText;
+      CharSequence summaryText = inboxStyleInformation.htmlFormatSummaryText
+          ? fromHtml(inboxStyleInformation.summaryText)
+          : inboxStyleInformation.summaryText;
       inboxStyle.setSummaryText(summaryText);
     }
     if (inboxStyleInformation.lines != null) {
@@ -1110,8 +1119,7 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private static void setMediaStyle(NotificationCompat.Builder builder) {
-    androidx.media.app.NotificationCompat.MediaStyle mediaStyle =
-        new androidx.media.app.NotificationCompat.MediaStyle();
+    androidx.media.app.NotificationCompat.MediaStyle mediaStyle = new androidx.media.app.NotificationCompat.MediaStyle();
     builder.setStyle(mediaStyle);
   }
 
@@ -1119,11 +1127,9 @@ public class FlutterLocalNotificationsPlugin
       Context context,
       NotificationDetails notificationDetails,
       NotificationCompat.Builder builder) {
-    MessagingStyleInformation messagingStyleInformation =
-        (MessagingStyleInformation) notificationDetails.styleInformation;
+    MessagingStyleInformation messagingStyleInformation = (MessagingStyleInformation) notificationDetails.styleInformation;
     Person person = buildPerson(context, messagingStyleInformation.person);
-    NotificationCompat.MessagingStyle messagingStyle =
-        new NotificationCompat.MessagingStyle(person);
+    NotificationCompat.MessagingStyle messagingStyle = new NotificationCompat.MessagingStyle(person);
     messagingStyle.setGroupConversation(
         BooleanUtils.getValue(messagingStyleInformation.groupConversation));
     if (messagingStyleInformation.conversationTitle != null) {
@@ -1141,11 +1147,10 @@ public class FlutterLocalNotificationsPlugin
 
   private static NotificationCompat.MessagingStyle.Message createMessage(
       Context context, MessageDetails messageDetails) {
-    NotificationCompat.MessagingStyle.Message message =
-        new NotificationCompat.MessagingStyle.Message(
-            messageDetails.text,
-            messageDetails.timestamp,
-            buildPerson(context, messageDetails.person));
+    NotificationCompat.MessagingStyle.Message message = new NotificationCompat.MessagingStyle.Message(
+        messageDetails.text,
+        messageDetails.timestamp,
+        buildPerson(context, messageDetails.person));
     if (messageDetails.dataUri != null && messageDetails.dataMimeType != null) {
       message.setData(messageDetails.dataMimeType, Uri.parse(messageDetails.dataUri));
     }
@@ -1178,88 +1183,130 @@ public class FlutterLocalNotificationsPlugin
 
   private static void setBigTextStyle(
       NotificationDetails notificationDetails, NotificationCompat.Builder builder) {
-    BigTextStyleInformation bigTextStyleInformation =
-        (BigTextStyleInformation) notificationDetails.styleInformation;
+    BigTextStyleInformation bigTextStyleInformation = (BigTextStyleInformation) notificationDetails.styleInformation;
     NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle();
     if (bigTextStyleInformation.bigText != null) {
-      CharSequence bigText =
-          bigTextStyleInformation.htmlFormatBigText
-              ? fromHtml(bigTextStyleInformation.bigText)
-              : bigTextStyleInformation.bigText;
+      CharSequence bigText = bigTextStyleInformation.htmlFormatBigText
+          ? fromHtml(bigTextStyleInformation.bigText)
+          : bigTextStyleInformation.bigText;
       bigTextStyle.bigText(bigText);
     }
     if (bigTextStyleInformation.contentTitle != null) {
-      CharSequence contentTitle =
-          bigTextStyleInformation.htmlFormatContentTitle
-              ? fromHtml(bigTextStyleInformation.contentTitle)
-              : bigTextStyleInformation.contentTitle;
+      CharSequence contentTitle = bigTextStyleInformation.htmlFormatContentTitle
+          ? fromHtml(bigTextStyleInformation.contentTitle)
+          : bigTextStyleInformation.contentTitle;
       bigTextStyle.setBigContentTitle(contentTitle);
     }
     if (bigTextStyleInformation.summaryText != null) {
-      CharSequence summaryText =
-          bigTextStyleInformation.htmlFormatSummaryText
-              ? fromHtml(bigTextStyleInformation.summaryText)
-              : bigTextStyleInformation.summaryText;
+      CharSequence summaryText = bigTextStyleInformation.htmlFormatSummaryText
+          ? fromHtml(bigTextStyleInformation.summaryText)
+          : bigTextStyleInformation.summaryText;
       bigTextStyle.setSummaryText(summaryText);
     }
     builder.setStyle(bigTextStyle);
   }
 
   private static void setupNotificationChannel(
-      Context context, NotificationChannelDetails notificationChannelDetails) {
-    if (VERSION.SDK_INT >= VERSION_CODES.O) {
-      NotificationManager notificationManager =
-          (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-      NotificationChannel notificationChannel =
-          new NotificationChannel(
-              notificationChannelDetails.id,
-              notificationChannelDetails.name,
-              notificationChannelDetails.importance);
-      notificationChannel.setDescription(notificationChannelDetails.description);
-      notificationChannel.setGroup(notificationChannelDetails.groupId);
-      if (notificationChannelDetails.playSound) {
-        Integer audioAttributesUsage =
-            notificationChannelDetails.audioAttributesUsage != null
-                ? notificationChannelDetails.audioAttributesUsage
-                : AudioAttributes.USAGE_NOTIFICATION;
-        AudioAttributes audioAttributes =
-            new AudioAttributes.Builder().setUsage(audioAttributesUsage).build();
-        Uri uri =
-            retrieveSoundResourceUri(
-                context, notificationChannelDetails.sound, notificationChannelDetails.soundSource);
-        notificationChannel.setSound(uri, audioAttributes);
-      } else {
-        notificationChannel.setSound(null, null);
-      }
+      Context context, NotificationChannelDetails d) {
+    if (VERSION.SDK_INT < VERSION_CODES.O)
+      return;
 
-      if (BooleanUtils.getValue(notificationChannelDetails.bypassDnd)) {
-        boolean isAccessGranted = notificationManager.isNotificationPolicyAccessGranted();
+    final NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        if (isAccessGranted) {
-          notificationChannel.setBypassDnd(true);
-        } else {
-          Log.w(
-              TAG,
-              "Channel '"
-                  + notificationChannelDetails.name
-                  + "' was set to bypass Do Not Disturb but the OS prevents it.");
+    // -------- Sanitize & defaults --------
+    // Channel ID must be non-empty
+    final String channelId = (d.id != null && !d.id.trim().isEmpty()) ? d.id.trim() : "default";
+
+    // Channel name must be non-empty (system enforces)
+    final String channelName = (d.name != null && !d.name.trim().isEmpty()) ? d.name.trim() : "General";
+
+    // Importance must be in allowed range; default if null/out-of-range
+    int imp = (d.importance != null) ? d.importance : NotificationManager.IMPORTANCE_DEFAULT;
+    // clamp to [NONE..HIGH] (O+)
+    if (imp < NotificationManager.IMPORTANCE_NONE)
+      imp = NotificationManager.IMPORTANCE_NONE;
+    if (imp > NotificationManager.IMPORTANCE_HIGH)
+      imp = NotificationManager.IMPORTANCE_HIGH;
+
+    final boolean playSound = BooleanUtils.getValue(d.playSound);
+    final int usage = (d.audioAttributesUsage != null)
+        ? d.audioAttributesUsage
+        : AudioAttributes.USAGE_NOTIFICATION;
+
+    final boolean enableVibration = BooleanUtils.getValue(d.enableVibration);
+    final boolean enableLights = BooleanUtils.getValue(d.enableLights);
+    final boolean showBadge = BooleanUtils.getValue(d.showBadge);
+
+    // Vibration pattern: filter invalid/negative values
+    long[] vib = d.vibrationPattern;
+    if (vib != null && vib.length > 0) {
+      boolean bad = false;
+      for (int i = 0; i < vib.length; i++) {
+        if (vib[i] < 0) {
+          bad = true;
+          break;
         }
       }
-
-      notificationChannel.enableVibration(
-          BooleanUtils.getValue(notificationChannelDetails.enableVibration));
-      if (notificationChannelDetails.vibrationPattern != null
-          && notificationChannelDetails.vibrationPattern.length > 0) {
-        notificationChannel.setVibrationPattern(notificationChannelDetails.vibrationPattern);
-      }
-      boolean enableLights = BooleanUtils.getValue(notificationChannelDetails.enableLights);
-      notificationChannel.enableLights(enableLights);
-      if (enableLights && notificationChannelDetails.ledColor != null) {
-        notificationChannel.setLightColor(notificationChannelDetails.ledColor);
-      }
-      notificationChannel.setShowBadge(BooleanUtils.getValue(notificationChannelDetails.showBadge));
-      notificationManager.createNotificationChannel(notificationChannel);
+      if (bad)
+        vib = null;
     }
+
+    // -------- DIAGNOSTIC LOGS --------
+    Log.d("FLN-Channel",
+        "creating channel id=" + channelId
+            + " name=" + channelName
+            + " importance=" + imp
+            + " playSound=" + playSound
+            + " enableVibration=" + enableVibration
+            + " enableLights=" + enableLights
+            + " showBadge=" + showBadge);
+
+    // -------- Create channel --------
+    final NotificationChannel ch = new NotificationChannel(channelId, channelName, imp);
+
+    // Description (nullable OK)
+    ch.setDescription(d.description);
+
+    // Group (guard null/empty)
+    if (d.groupId != null && !d.groupId.trim().isEmpty()) {
+      ch.setGroup(d.groupId.trim());
+    }
+
+    // Sound
+    if (playSound) {
+      final AudioAttributes aa = new AudioAttributes.Builder().setUsage(usage).build();
+      final Uri soundUri = retrieveSoundResourceUri(context, d.sound, d.soundSource);
+      ch.setSound(soundUri, aa);
+    } else {
+      ch.setSound(null, null);
+    }
+
+    // Bypass DND (only if policy granted)
+    if (BooleanUtils.getValue(d.bypassDnd)) {
+      if (nm.isNotificationPolicyAccessGranted()) {
+        ch.setBypassDnd(true);
+      } else {
+        Log.w("FLN-Channel", "bypassDnd requested but policy access not granted");
+      }
+    }
+
+    // Vibration
+    ch.enableVibration(enableVibration);
+    if (enableVibration && vib != null && vib.length > 0) {
+      ch.setVibrationPattern(vib);
+    }
+
+    // Lights
+    ch.enableLights(enableLights);
+    if (enableLights && d.ledColor != null) {
+      ch.setLightColor(d.ledColor);
+    }
+
+    ch.setShowBadge(showBadge);
+
+    // Final diagnostic before creating
+    Log.d("FLN-Channel", "createNotificationChannel() now...");
+    nm.createNotificationChannel(ch);
   }
 
   private static Uri retrieveSoundResourceUri(
@@ -1268,7 +1315,8 @@ public class FlutterLocalNotificationsPlugin
     if (StringUtils.isNullOrEmpty(sound)) {
       uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
     } else {
-      // allow null as soundSource was added later and prior to that, it was assumed to be a raw
+      // allow null as soundSource was added later and prior to that, it was assumed
+      // to be a raw
       // resource
       if (soundSource == null || soundSource == SoundSource.RawResource) {
         uri = Uri.parse("android.resource://" + context.getPackageName() + "/raw/" + sound);
@@ -1326,15 +1374,11 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private static String getNextFireDate(NotificationDetails notificationDetails) {
-    if (notificationDetails.scheduledNotificationRepeatFrequency
-        == ScheduledNotificationRepeatFrequency.Daily) {
-      LocalDateTime localDateTime =
-          LocalDateTime.parse(notificationDetails.scheduledDateTime).plusDays(1);
+    if (notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Daily) {
+      LocalDateTime localDateTime = LocalDateTime.parse(notificationDetails.scheduledDateTime).plusDays(1);
       return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
-    } else if (notificationDetails.scheduledNotificationRepeatFrequency
-        == ScheduledNotificationRepeatFrequency.Weekly) {
-      LocalDateTime localDateTime =
-          LocalDateTime.parse(notificationDetails.scheduledDateTime).plusWeeks(1);
+    } else if (notificationDetails.scheduledNotificationRepeatFrequency == ScheduledNotificationRepeatFrequency.Weekly) {
+      LocalDateTime localDateTime = LocalDateTime.parse(notificationDetails.scheduledDateTime).plusWeeks(1);
       return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime);
     }
     return null;
@@ -1343,19 +1387,18 @@ public class FlutterLocalNotificationsPlugin
   private static String getNextFireDateMatchingDateTimeComponents(
       NotificationDetails notificationDetails) {
     ZoneId zoneId = ZoneId.of(notificationDetails.timeZoneName);
-    ZonedDateTime scheduledDateTime =
-        ZonedDateTime.of(LocalDateTime.parse(notificationDetails.scheduledDateTime), zoneId);
+    ZonedDateTime scheduledDateTime = ZonedDateTime.of(LocalDateTime.parse(notificationDetails.scheduledDateTime),
+        zoneId);
     ZonedDateTime now = ZonedDateTime.now(zoneId);
-    ZonedDateTime nextFireDate =
-        ZonedDateTime.of(
-            now.getYear(),
-            now.getMonthValue(),
-            now.getDayOfMonth(),
-            scheduledDateTime.getHour(),
-            scheduledDateTime.getMinute(),
-            scheduledDateTime.getSecond(),
-            scheduledDateTime.getNano(),
-            zoneId);
+    ZonedDateTime nextFireDate = ZonedDateTime.of(
+        now.getYear(),
+        now.getMonthValue(),
+        now.getDayOfMonth(),
+        scheduledDateTime.getHour(),
+        scheduledDateTime.getMinute(),
+        scheduledDateTime.getSecond(),
+        scheduledDateTime.getNano(),
+        zoneId);
     while (nextFireDate.isBefore(now)) {
       // adjust to be a date in the future that matches the time
       nextFireDate = nextFireDate.plusDays(1);
@@ -1367,8 +1410,7 @@ public class FlutterLocalNotificationsPlugin
         nextFireDate = nextFireDate.plusDays(1);
       }
       return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(nextFireDate);
-    } else if (notificationDetails.matchDateTimeComponents
-        == DateTimeComponents.DayOfMonthAndTime) {
+    } else if (notificationDetails.matchDateTimeComponents == DateTimeComponents.DayOfMonthAndTime) {
       while (nextFireDate.getDayOfMonth() != scheduledDateTime.getDayOfMonth()) {
         nextFireDate = nextFireDate.plusDays(1);
       }
@@ -1389,8 +1431,8 @@ public class FlutterLocalNotificationsPlugin
 
   private static boolean launchedActivityFromHistory(Intent intent) {
     return intent != null
-        && (intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
-            == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
+        && (intent.getFlags()
+            & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
   }
 
   private void setActivity(Activity flutterActivity) {
@@ -1421,8 +1463,7 @@ public class FlutterLocalNotificationsPlugin
     Intent mainActivityIntent = mainActivity.getIntent();
     if (!launchedActivityFromHistory(mainActivityIntent)) {
       if (SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(mainActivityIntent.getAction())) {
-        Map<String, Object> notificationResponse =
-            extractNotificationResponseMap(mainActivityIntent);
+        Map<String, Object> notificationResponse = extractNotificationResponseMap(mainActivityIntent);
         processForegroundNotificationAction(mainActivityIntent, notificationResponse);
       }
     }
@@ -1581,8 +1622,7 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private void pendingNotificationRequests(Result result) {
-    ArrayList<NotificationDetails> scheduledNotifications =
-        loadScheduledNotifications(applicationContext);
+    ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(applicationContext);
     List<Map<String, Object>> pendingNotifications = new ArrayList<>();
 
     for (NotificationDetails scheduledNotification : scheduledNotifications) {
@@ -1601,8 +1641,8 @@ public class FlutterLocalNotificationsPlugin
       result.error(UNSUPPORTED_OS_VERSION_ERROR_CODE, GET_ACTIVE_NOTIFICATIONS_ERROR_MESSAGE, null);
       return;
     }
-    NotificationManager notificationManager =
-        (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+    NotificationManager notificationManager = (NotificationManager) applicationContext
+        .getSystemService(Context.NOTIFICATION_SERVICE);
     try {
       StatusBarNotification[] activeNotifications = notificationManager.getActiveNotifications();
       List<Map<String, Object>> activeNotificationsPayload = new ArrayList<>();
@@ -1658,8 +1698,7 @@ public class FlutterLocalNotificationsPlugin
     NotificationDetails notificationDetails = extractNotificationDetails(result, call.arguments());
     if (notificationDetails != null) {
       if (notificationDetails.matchDateTimeComponents != null) {
-        notificationDetails.scheduledDateTime =
-            getNextFireDateMatchingDateTimeComponents(notificationDetails);
+        notificationDetails.scheduledDateTime = getNextFireDateMatchingDateTimeComponents(notificationDetails);
       }
       try {
         zonedScheduleNotification(applicationContext, notificationDetails, true);
@@ -1684,11 +1723,10 @@ public class FlutterLocalNotificationsPlugin
     Boolean notificationLaunchedApp = false;
     if (mainActivity != null) {
       Intent launchIntent = mainActivity.getIntent();
-      notificationLaunchedApp =
-          launchIntent != null
-              && (SELECT_NOTIFICATION.equals(launchIntent.getAction())
-                  || SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(launchIntent.getAction()))
-              && !launchedActivityFromHistory(launchIntent);
+      notificationLaunchedApp = launchIntent != null
+          && (SELECT_NOTIFICATION.equals(launchIntent.getAction())
+              || SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(launchIntent.getAction()))
+          && !launchedActivityFromHistory(launchIntent);
       if (notificationLaunchedApp) {
         notificationAppLaunchDetails.put(
             "notificationResponse", extractNotificationResponseMap(launchIntent));
@@ -1713,8 +1751,8 @@ public class FlutterLocalNotificationsPlugin
       new IsolatePreferences(applicationContext).saveCallbackKeys(dispatcherHandle, callbackHandle);
     }
 
-    SharedPreferences sharedPreferences =
-        applicationContext.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
+    SharedPreferences sharedPreferences = applicationContext.getSharedPreferences(SHARED_PREFERENCES_KEY,
+        Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putString(DEFAULT_ICON, defaultIcon).apply();
     result.success(true);
@@ -1725,7 +1763,8 @@ public class FlutterLocalNotificationsPlugin
     result.success(handle);
   }
 
-  // Extracts the details of the notifications passed from the Flutter side and also validates that
+  // Extracts the details of the notifications passed from the Flutter side and
+  // also validates that
   // some of the details (especially resources) passed are valid
   private NotificationDetails extractNotificationDetails(
       Result result, Map<String, Object> arguments) {
@@ -1756,10 +1795,9 @@ public class FlutterLocalNotificationsPlugin
     if (!StringUtils.isNullOrEmpty(notificationDetails.sound)
         && (notificationDetails.soundSource == null
             || notificationDetails.soundSource == SoundSource.RawResource)) {
-      int soundResourceId =
-          applicationContext
-              .getResources()
-              .getIdentifier(notificationDetails.sound, "raw", applicationContext.getPackageName());
+      int soundResourceId = applicationContext
+          .getResources()
+          .getIdentifier(notificationDetails.sound, "raw", applicationContext.getPackageName());
       if (soundResourceId == 0) {
         result.error(
             INVALID_SOUND_ERROR_CODE,
@@ -1774,12 +1812,12 @@ public class FlutterLocalNotificationsPlugin
   private boolean hasInvalidBigPictureResources(
       Result result, NotificationDetails notificationDetails) {
     if (notificationDetails.style == NotificationStyle.BigPicture) {
-      BigPictureStyleInformation bigPictureStyleInformation =
-          (BigPictureStyleInformation) notificationDetails.styleInformation;
+      BigPictureStyleInformation bigPictureStyleInformation = (BigPictureStyleInformation) notificationDetails.styleInformation;
       if (hasInvalidLargeIcon(
           result,
           bigPictureStyleInformation.largeIcon,
-          bigPictureStyleInformation.largeIconBitmapSource)) return true;
+          bigPictureStyleInformation.largeIconBitmapSource))
+        return true;
 
       if (bigPictureStyleInformation.bigPictureBitmapSource == BitmapSource.DrawableResource) {
         String bigPictureResourceName = (String) bigPictureStyleInformation.bigPicture;
@@ -1835,8 +1873,7 @@ public class FlutterLocalNotificationsPlugin
   private void cancelAllNotifications(Result result) {
     NotificationManagerCompat notificationManager = getNotificationManager(applicationContext);
     notificationManager.cancelAll();
-    ArrayList<NotificationDetails> scheduledNotifications =
-        loadScheduledNotifications(applicationContext);
+    ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(applicationContext);
     if (scheduledNotifications == null || scheduledNotifications.isEmpty()) {
       result.success(null);
       return;
@@ -1844,8 +1881,7 @@ public class FlutterLocalNotificationsPlugin
 
     Intent intent = new Intent(applicationContext, ScheduledNotificationReceiver.class);
     for (NotificationDetails scheduledNotification : scheduledNotifications) {
-      PendingIntent pendingIntent =
-          getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
+      PendingIntent pendingIntent = getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
       AlarmManager alarmManager = getAlarmManager(applicationContext);
       alarmManager.cancel(pendingIntent);
     }
@@ -1855,8 +1891,7 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private void cancelAllPendingNotifications(Result result) {
-    ArrayList<NotificationDetails> scheduledNotifications =
-        loadScheduledNotifications(applicationContext);
+    ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(applicationContext);
 
     if (scheduledNotifications == null || scheduledNotifications.isEmpty()) {
       result.success(null);
@@ -1867,8 +1902,7 @@ public class FlutterLocalNotificationsPlugin
     Intent intent = new Intent(applicationContext, ScheduledNotificationReceiver.class);
 
     for (NotificationDetails scheduledNotification : scheduledNotifications) {
-      PendingIntent pendingIntent =
-          getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
+      PendingIntent pendingIntent = getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
       alarmManager.cancel(pendingIntent);
     }
 
@@ -1886,14 +1920,13 @@ public class FlutterLocalNotificationsPlugin
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       String permission = Manifest.permission.POST_NOTIFICATIONS;
-      boolean permissionGranted =
-          ContextCompat.checkSelfPermission(mainActivity, permission)
-              == PackageManager.PERMISSION_GRANTED;
+      boolean permissionGranted = ContextCompat.checkSelfPermission(mainActivity,
+          permission) == PackageManager.PERMISSION_GRANTED;
 
       if (!permissionGranted) {
         permissionRequestProgress = PermissionRequestProgress.RequestingNotificationPermission;
         ActivityCompat.requestPermissions(
-            mainActivity, new String[] {permission}, NOTIFICATION_PERMISSION_REQUEST_CODE);
+            mainActivity, new String[] { permission }, NOTIFICATION_PERMISSION_REQUEST_CODE);
       } else {
         this.callback.complete(true);
         permissionRequestProgress = PermissionRequestProgress.None;
@@ -1941,8 +1974,8 @@ public class FlutterLocalNotificationsPlugin
     this.callback = callback;
 
     if (Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
       AlarmManager alarmManager = getAlarmManager(applicationContext);
       boolean permissionGranted = notificationManager.canUseFullScreenIntent();
 
@@ -1975,8 +2008,8 @@ public class FlutterLocalNotificationsPlugin
 
     this.callback = callback;
 
-    NotificationManager notificationManager =
-        (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+    NotificationManager notificationManager = (NotificationManager) applicationContext
+        .getSystemService(Context.NOTIFICATION_SERVICE);
     boolean permissionGranted = notificationManager.isNotificationPolicyAccessGranted();
 
     if (permissionGranted) {
@@ -1996,8 +2029,8 @@ public class FlutterLocalNotificationsPlugin
       return;
     }
 
-    NotificationManager notificationManager =
-        (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+    NotificationManager notificationManager = (NotificationManager) applicationContext
+        .getSystemService(Context.NOTIFICATION_SERVICE);
     boolean isGranted = notificationManager.isNotificationPolicyAccessGranted();
     result.success(isGranted);
   }
@@ -2007,8 +2040,7 @@ public class FlutterLocalNotificationsPlugin
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (permissionRequestProgress == PermissionRequestProgress.RequestingNotificationPermission
         && requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
-      boolean granted =
-          grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+      boolean granted = grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
       callback.complete(granted);
       permissionRequestProgress = PermissionRequestProgress.None;
       return granted;
@@ -2051,13 +2083,11 @@ public class FlutterLocalNotificationsPlugin
   private void createNotificationChannelGroup(MethodCall call, Result result) {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
       Map<String, Object> arguments = call.arguments();
-      NotificationChannelGroupDetails notificationChannelGroupDetails =
-          NotificationChannelGroupDetails.from(arguments);
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
-      NotificationChannelGroup notificationChannelGroup =
-          new NotificationChannelGroup(
-              notificationChannelGroupDetails.id, notificationChannelGroupDetails.name);
+      NotificationChannelGroupDetails notificationChannelGroupDetails = NotificationChannelGroupDetails.from(arguments);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationChannelGroup notificationChannelGroup = new NotificationChannelGroup(
+          notificationChannelGroupDetails.id, notificationChannelGroupDetails.name);
       if (VERSION.SDK_INT >= VERSION_CODES.P) {
         notificationChannelGroup.setDescription(notificationChannelGroupDetails.description);
       }
@@ -2068,8 +2098,8 @@ public class FlutterLocalNotificationsPlugin
 
   private void deleteNotificationChannelGroup(MethodCall call, Result result) {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
       String groupId = call.arguments();
       notificationManager.deleteNotificationChannelGroup(groupId);
     }
@@ -2078,16 +2108,15 @@ public class FlutterLocalNotificationsPlugin
 
   private void createNotificationChannel(MethodCall call, Result result) {
     Map<String, Object> arguments = call.arguments();
-    NotificationChannelDetails notificationChannelDetails =
-        NotificationChannelDetails.from(arguments);
+    NotificationChannelDetails notificationChannelDetails = NotificationChannelDetails.from(arguments);
     setupNotificationChannel(applicationContext, notificationChannelDetails);
     result.success(null);
   }
 
   private void deleteNotificationChannel(MethodCall call, Result result) {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
       String channelId = call.arguments();
       notificationManager.deleteNotificationChannel(channelId);
     }
@@ -2102,8 +2131,8 @@ public class FlutterLocalNotificationsPlugin
           null);
       return;
     }
-    NotificationManager notificationManager =
-        (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+    NotificationManager notificationManager = (NotificationManager) applicationContext
+        .getSystemService(Context.NOTIFICATION_SERVICE);
     try {
       Map<String, Object> arguments = call.arguments();
       int id = (int) arguments.get("id");
@@ -2124,8 +2153,8 @@ public class FlutterLocalNotificationsPlugin
         return;
       }
 
-      NotificationCompat.MessagingStyle messagingStyle =
-          NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(notification);
+      NotificationCompat.MessagingStyle messagingStyle = NotificationCompat.MessagingStyle
+          .extractMessagingStyleFromNotification(notification);
       if (messagingStyle == null) {
         result.success(null);
         return;
@@ -2208,8 +2237,7 @@ public class FlutterLocalNotificationsPlugin
 
   private void getNotificationChannels(Result result) {
     try {
-      NotificationManagerCompat notificationManagerCompat =
-          getNotificationManager(applicationContext);
+      NotificationManagerCompat notificationManagerCompat = getNotificationManager(applicationContext);
       List<NotificationChannel> channels = notificationManagerCompat.getNotificationChannels();
       List<Map<String, Object>> channelsPayload = new ArrayList<>();
       for (NotificationChannel channel : channels) {
@@ -2249,10 +2277,10 @@ public class FlutterLocalNotificationsPlugin
             channelPayload.put("soundSource", soundSources.indexOf(SoundSource.RawResource));
             channelPayload.put("sound", resource);
           } else {
-            // Kept for backwards compatibility when the source resource used to be based on id
+            // Kept for backwards compatibility when the source resource used to be based on
+            // id
             try {
-              String resourceName =
-                  applicationContext.getResources().getResourceEntryName(resourceId);
+              String resourceName = applicationContext.getResources().getResourceEntryName(resourceId);
               if (resourceName != null) {
                 channelPayload.put("soundSource", soundSources.indexOf(SoundSource.RawResource));
                 channelPayload.put("sound", resourceName);
@@ -2296,13 +2324,11 @@ public class FlutterLocalNotificationsPlugin
     ArrayList<Integer> foregroundServiceTypes = call.argument("foregroundServiceTypes");
     if (foregroundServiceTypes == null || foregroundServiceTypes.size() != 0) {
       if (notificationData != null && startType != null) {
-        NotificationDetails notificationDetails =
-            extractNotificationDetails(result, notificationData);
+        NotificationDetails notificationDetails = extractNotificationDetails(result, notificationData);
         if (notificationDetails != null) {
           if (notificationDetails.id != 0) {
-            ForegroundServiceStartParameter parameter =
-                new ForegroundServiceStartParameter(
-                    notificationDetails, startType, foregroundServiceTypes);
+            ForegroundServiceStartParameter parameter = new ForegroundServiceStartParameter(
+                notificationDetails, startType, foregroundServiceTypes);
             Intent intent = new Intent(applicationContext, ForegroundService.class);
             intent.putExtra(ForegroundServiceStartParameter.EXTRA, parameter);
             ContextCompat.startForegroundService(applicationContext, intent);
@@ -2363,8 +2389,8 @@ public class FlutterLocalNotificationsPlugin
     if (permissionRequestProgress == PermissionRequestProgress.RequestingFullScreenIntentPermission
         && requestCode == FULL_SCREEN_INTENT_PERMISSION_REQUEST_CODE
         && VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
       this.callback.complete(notificationManager.canUseFullScreenIntent());
       permissionRequestProgress = PermissionRequestProgress.None;
     }
@@ -2372,8 +2398,8 @@ public class FlutterLocalNotificationsPlugin
     if (permissionRequestProgress == PermissionRequestProgress.RequestingNotificationPolicyAccess
         && requestCode == NOTIFICATION_POLICY_ACCESS_REQUEST_CODE
         && VERSION.SDK_INT >= VERSION_CODES.M) {
-      NotificationManager notificationManager =
-          (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationManager notificationManager = (NotificationManager) applicationContext
+          .getSystemService(Context.NOTIFICATION_SERVICE);
       this.callback.complete(notificationManager.isNotificationPolicyAccessGranted());
       permissionRequestProgress = PermissionRequestProgress.None;
     }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/DescriptionStyle.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/DescriptionStyle.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
 @Keep
-public class TitleStyle implements Serializable {
+public class DescriptionStyle implements Serializable {
   @SerializedName("color")
   public Integer color;
 
@@ -17,8 +17,4 @@ public class TitleStyle implements Serializable {
 
   @SerializedName("italic")
   public Boolean italic;
-
-  // Distance in DP between the notification's icon and the title/body.
-  @SerializedName("iconSpacingDp")
-  public Double iconSpacingDp;
 }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -6,6 +6,7 @@ import android.os.Build.VERSION_CODES;
 
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
+import android.util.Log;
 
 import com.dexterous.flutterlocalnotifications.models.styles.BigPictureStyleInformation;
 import com.dexterous.flutterlocalnotifications.models.styles.BigTextStyleInformation;
@@ -15,6 +16,7 @@ import com.dexterous.flutterlocalnotifications.models.styles.MessagingStyleInfor
 import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 import com.dexterous.flutterlocalnotifications.utils.LongUtils;
 import com.google.gson.annotations.SerializedName;
+import com.dexterous.flutterlocalnotifications.models.TitleStyle;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -117,8 +119,7 @@ public class NotificationDetails implements Serializable {
 
   private static final String SCHEDULED_DATE_TIME = "scheduledDateTime";
   private static final String TIME_ZONE_NAME = "timeZoneName";
-  private static final String SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY =
-      "scheduledNotificationRepeatFrequency";
+  private static final String SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY = "scheduledNotificationRepeatFrequency";
   private static final String MATCH_DATE_TIME_COMPONENTS = "matchDateTimeComponents";
 
   private static final String FULL_SCREEN_INTENT = "fullScreenIntent";
@@ -128,6 +129,7 @@ public class NotificationDetails implements Serializable {
   private static final String COLORIZED = "colorized";
   private static final String NUMBER = "number";
   private static final String AUDIO_ATTRIBUTES_USAGE = "audioAttributesUsage";
+  private static final String TITLE_STYLE = "titleStyle";
 
   public Integer id;
   public String title;
@@ -198,8 +200,10 @@ public class NotificationDetails implements Serializable {
   public Boolean colorized;
   public Integer number;
   public Integer audioAttributesUsage;
+  public TitleStyle titleStyle;
 
-  // Note: this is set on the Android to save details about the icon that should be used when
+  // Note: this is set on the Android to save details about the icon that should
+  // be used when
   // re-hydrating scheduled notifications when a device has been restarted.
   public Integer iconResourceId;
 
@@ -212,13 +216,12 @@ public class NotificationDetails implements Serializable {
     notificationDetails.scheduledDateTime = (String) arguments.get(SCHEDULED_DATE_TIME);
     notificationDetails.timeZoneName = (String) arguments.get(TIME_ZONE_NAME);
     if (arguments.containsKey(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)) {
-      notificationDetails.scheduledNotificationRepeatFrequency =
-          ScheduledNotificationRepeatFrequency.values()[
-              (Integer) arguments.get(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)];
+      notificationDetails.scheduledNotificationRepeatFrequency = ScheduledNotificationRepeatFrequency
+          .values()[(Integer) arguments.get(SCHEDULED_NOTIFICATION_REPEAT_FREQUENCY)];
     }
     if (arguments.containsKey(MATCH_DATE_TIME_COMPONENTS)) {
-      notificationDetails.matchDateTimeComponents =
-          DateTimeComponents.values()[(Integer) arguments.get(MATCH_DATE_TIME_COMPONENTS)];
+      notificationDetails.matchDateTimeComponents = DateTimeComponents
+          .values()[(Integer) arguments.get(MATCH_DATE_TIME_COMPONENTS)];
     }
     if (arguments.containsKey(MILLISECONDS_SINCE_EPOCH)) {
       notificationDetails.millisecondsSinceEpoch = (Long) arguments.get(MILLISECONDS_SINCE_EPOCH);
@@ -227,12 +230,10 @@ public class NotificationDetails implements Serializable {
       notificationDetails.calledAt = (Long) arguments.get(CALLED_AT);
     }
     if (arguments.containsKey(REPEAT_INTERVAL)) {
-      notificationDetails.repeatInterval =
-          RepeatInterval.values()[(Integer) arguments.get(REPEAT_INTERVAL)];
+      notificationDetails.repeatInterval = RepeatInterval.values()[(Integer) arguments.get(REPEAT_INTERVAL)];
     }
     if (arguments.containsKey(REPEAT_INTERVAL_MILLISECONDS)) {
-      notificationDetails.repeatIntervalMilliseconds =
-          (Integer) arguments.get(REPEAT_INTERVAL_MILLISECONDS);
+      notificationDetails.repeatIntervalMilliseconds = (Integer) arguments.get(REPEAT_INTERVAL_MILLISECONDS);
     }
     if (arguments.containsKey(REPEAT_TIME)) {
       @SuppressWarnings("unchecked")
@@ -250,30 +251,43 @@ public class NotificationDetails implements Serializable {
   private static void readPlatformSpecifics(
       Map<String, Object> arguments, NotificationDetails notificationDetails) {
     @SuppressWarnings("unchecked")
-    Map<String, Object> platformChannelSpecifics =
-        (Map<String, Object>) arguments.get(PLATFORM_SPECIFICS);
+    Map<String, Object> platformChannelSpecifics = (Map<String, Object>) arguments.get(PLATFORM_SPECIFICS);
     if (platformChannelSpecifics != null) {
+      Object rawTitle = platformChannelSpecifics.get(TITLE_STYLE);
+      if (rawTitle instanceof Map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> m = (Map<String, Object>) rawTitle;
+        TitleStyle ts = new TitleStyle();
+        Object c = m.get("color");
+        Object s = m.get("sizeSp");
+        Object b = m.get("bold");
+        Object i = m.get("italic");
+        if (c instanceof Number)
+          ts.color = ((Number) c).intValue();
+        if (s instanceof Number)
+          ts.sizeSp = ((Number) s).doubleValue();
+        if (b instanceof Boolean)
+          ts.bold = (Boolean) b;
+        if (i instanceof Boolean)
+          ts.italic = (Boolean) i;
+        notificationDetails.titleStyle = ts;
+      }
       notificationDetails.autoCancel = (Boolean) platformChannelSpecifics.get(AUTO_CANCEL);
       notificationDetails.ongoing = (Boolean) platformChannelSpecifics.get(ONGOING);
       notificationDetails.silent = (Boolean) platformChannelSpecifics.get(SILENT);
-      notificationDetails.style =
-          NotificationStyle.values()[(Integer) platformChannelSpecifics.get(STYLE)];
+      notificationDetails.style = NotificationStyle.values()[(Integer) platformChannelSpecifics.get(STYLE)];
       readStyleInformation(notificationDetails, platformChannelSpecifics);
       notificationDetails.icon = (String) platformChannelSpecifics.get(ICON);
       notificationDetails.priority = (Integer) platformChannelSpecifics.get(PRIORITY);
       readSoundInformation(notificationDetails, platformChannelSpecifics);
-      notificationDetails.enableVibration =
-          (Boolean) platformChannelSpecifics.get(ENABLE_VIBRATION);
-      notificationDetails.vibrationPattern =
-          (long[]) platformChannelSpecifics.get(VIBRATION_PATTERN);
+      notificationDetails.enableVibration = (Boolean) platformChannelSpecifics.get(ENABLE_VIBRATION);
+      notificationDetails.vibrationPattern = (long[]) platformChannelSpecifics.get(VIBRATION_PATTERN);
       readGroupingInformation(notificationDetails, platformChannelSpecifics);
       notificationDetails.onlyAlertOnce = (Boolean) platformChannelSpecifics.get(ONLY_ALERT_ONCE);
       notificationDetails.showWhen = (Boolean) platformChannelSpecifics.get(SHOW_WHEN);
       notificationDetails.when = LongUtils.parseLong(platformChannelSpecifics.get(WHEN));
-      notificationDetails.usesChronometer =
-          (Boolean) platformChannelSpecifics.get(USES_CHRONOMETER);
-      notificationDetails.chronometerCountDown =
-          (Boolean) platformChannelSpecifics.get(CHRONOMETER_COUNT_DOWN);
+      notificationDetails.usesChronometer = (Boolean) platformChannelSpecifics.get(USES_CHRONOMETER);
+      notificationDetails.chronometerCountDown = (Boolean) platformChannelSpecifics.get(CHRONOMETER_COUNT_DOWN);
       readProgressInformation(notificationDetails, platformChannelSpecifics);
       readColor(notificationDetails, platformChannelSpecifics);
       readChannelInformation(notificationDetails, platformChannelSpecifics);
@@ -282,27 +296,22 @@ public class NotificationDetails implements Serializable {
       notificationDetails.ticker = (String) platformChannelSpecifics.get(TICKER);
       notificationDetails.visibility = (Integer) platformChannelSpecifics.get(VISIBILITY);
       if (platformChannelSpecifics.containsKey(SCHEDULE_MODE)) {
-        notificationDetails.scheduleMode =
-            ScheduleMode.valueOf((String) platformChannelSpecifics.get(SCHEDULE_MODE));
+        notificationDetails.scheduleMode = ScheduleMode.valueOf((String) platformChannelSpecifics.get(SCHEDULE_MODE));
       }
-      notificationDetails.timeoutAfter =
-          LongUtils.parseLong(platformChannelSpecifics.get(TIMEOUT_AFTER));
+      notificationDetails.timeoutAfter = LongUtils.parseLong(platformChannelSpecifics.get(TIMEOUT_AFTER));
       notificationDetails.category = (String) platformChannelSpecifics.get(CATEGORY);
-      notificationDetails.fullScreenIntent =
-          (Boolean) platformChannelSpecifics.get((FULL_SCREEN_INTENT));
+      notificationDetails.fullScreenIntent = (Boolean) platformChannelSpecifics.get((FULL_SCREEN_INTENT));
       notificationDetails.shortcutId = (String) platformChannelSpecifics.get(SHORTCUT_ID);
       notificationDetails.additionalFlags = (int[]) platformChannelSpecifics.get(ADDITIONAL_FLAGS);
       notificationDetails.subText = (String) platformChannelSpecifics.get(SUB_TEXT);
       notificationDetails.tag = (String) platformChannelSpecifics.get(TAG);
       notificationDetails.colorized = (Boolean) platformChannelSpecifics.get(COLORIZED);
       notificationDetails.number = (Integer) platformChannelSpecifics.get(NUMBER);
-      notificationDetails.audioAttributesUsage =
-          (Integer) platformChannelSpecifics.get(AUDIO_ATTRIBUTES_USAGE);
+      notificationDetails.audioAttributesUsage = (Integer) platformChannelSpecifics.get(AUDIO_ATTRIBUTES_USAGE);
 
       if (platformChannelSpecifics.containsKey(ACTIONS)) {
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> inputActions =
-            (List<Map<String, Object>>) platformChannelSpecifics.get(ACTIONS);
+        List<Map<String, Object>> inputActions = (List<Map<String, Object>>) platformChannelSpecifics.get(ACTIONS);
         if (inputActions != null && !inputActions.isEmpty()) {
           notificationDetails.actions = new ArrayList<>();
           for (Map<String, Object> input : inputActions) {
@@ -344,10 +353,8 @@ public class NotificationDetails implements Serializable {
   private static void readGroupingInformation(
       NotificationDetails notificationDetails, Map<String, Object> platformChannelSpecifics) {
     notificationDetails.groupKey = (String) platformChannelSpecifics.get(GROUP_KEY);
-    notificationDetails.setAsGroupSummary =
-        (Boolean) platformChannelSpecifics.get(SET_AS_GROUP_SUMMARY);
-    notificationDetails.groupAlertBehavior =
-        (Integer) platformChannelSpecifics.get(GROUP_ALERT_BEHAVIOR);
+    notificationDetails.setAsGroupSummary = (Boolean) platformChannelSpecifics.get(SET_AS_GROUP_SUMMARY);
+    notificationDetails.groupAlertBehavior = (Integer) platformChannelSpecifics.get(GROUP_ALERT_BEHAVIOR);
   }
 
   private static void readSoundInformation(
@@ -390,24 +397,19 @@ public class NotificationDetails implements Serializable {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
       notificationDetails.channelId = (String) platformChannelSpecifics.get(CHANNEL_ID);
       notificationDetails.channelName = (String) platformChannelSpecifics.get(CHANNEL_NAME);
-      notificationDetails.channelDescription =
-          (String) platformChannelSpecifics.get(CHANNEL_DESCRIPTION);
+      notificationDetails.channelDescription = (String) platformChannelSpecifics.get(CHANNEL_DESCRIPTION);
       notificationDetails.importance = (Integer) platformChannelSpecifics.get(IMPORTANCE);
-      notificationDetails.channelBypassDnd =
-          (Boolean) platformChannelSpecifics.get(CHANNEL_BYPASS_DND);
-      notificationDetails.channelShowBadge =
-          (Boolean) platformChannelSpecifics.get(CHANNEL_SHOW_BADGE);
-      notificationDetails.channelAction =
-          NotificationChannelAction.values()[
-              (Integer) platformChannelSpecifics.get(CHANNEL_ACTION)];
+      notificationDetails.channelBypassDnd = (Boolean) platformChannelSpecifics.get(CHANNEL_BYPASS_DND);
+      notificationDetails.channelShowBadge = (Boolean) platformChannelSpecifics.get(CHANNEL_SHOW_BADGE);
+      notificationDetails.channelAction = NotificationChannelAction
+          .values()[(Integer) platformChannelSpecifics.get(CHANNEL_ACTION)];
     }
   }
 
   @SuppressWarnings("unchecked")
   private static void readStyleInformation(
       NotificationDetails notificationDetails, Map<String, Object> platformSpecifics) {
-    Map<String, Object> styleInformation =
-        (Map<String, Object>) platformSpecifics.get(STYLE_INFORMATION);
+    Map<String, Object> styleInformation = (Map<String, Object>) platformSpecifics.get(STYLE_INFORMATION);
     DefaultStyleInformation defaultStyleInformation = getDefaultStyleInformation(styleInformation);
     if (notificationDetails.style == NotificationStyle.Default) {
       notificationDetails.styleInformation = defaultStyleInformation;
@@ -433,16 +435,14 @@ public class NotificationDetails implements Serializable {
     String conversationTitle = (String) styleInformation.get(CONVERSATION_TITLE);
     Boolean groupConversation = (Boolean) styleInformation.get(GROUP_CONVERSATION);
     PersonDetails person = readPersonDetails((Map<String, Object>) styleInformation.get(PERSON));
-    ArrayList<MessageDetails> messages =
-        readMessages((ArrayList<Map<String, Object>>) styleInformation.get(MESSAGES));
-    notificationDetails.styleInformation =
-        new MessagingStyleInformation(
-            person,
-            conversationTitle,
-            groupConversation,
-            messages,
-            defaultStyleInformation.htmlFormatTitle,
-            defaultStyleInformation.htmlFormatBody);
+    ArrayList<MessageDetails> messages = readMessages((ArrayList<Map<String, Object>>) styleInformation.get(MESSAGES));
+    notificationDetails.styleInformation = new MessagingStyleInformation(
+        person,
+        conversationTitle,
+        groupConversation,
+        messages,
+        defaultStyleInformation.htmlFormatTitle,
+        defaultStyleInformation.htmlFormatBody);
   }
 
   private static PersonDetails readPersonDetails(Map<String, Object> person) {
@@ -488,16 +488,15 @@ public class NotificationDetails implements Serializable {
     @SuppressWarnings("unchecked")
     ArrayList<String> lines = (ArrayList<String>) styleInformation.get(LINES);
     Boolean htmlFormatLines = (Boolean) styleInformation.get(HTML_FORMAT_LINES);
-    notificationDetails.styleInformation =
-        new InboxStyleInformation(
-            defaultStyleInformation.htmlFormatTitle,
-            defaultStyleInformation.htmlFormatBody,
-            contentTitle,
-            htmlFormatContentTitle,
-            summaryText,
-            htmlFormatSummaryText,
-            lines,
-            htmlFormatLines);
+    notificationDetails.styleInformation = new InboxStyleInformation(
+        defaultStyleInformation.htmlFormatTitle,
+        defaultStyleInformation.htmlFormatBody,
+        contentTitle,
+        htmlFormatContentTitle,
+        summaryText,
+        htmlFormatSummaryText,
+        lines,
+        htmlFormatLines);
   }
 
   private static void readBigTextStyleInformation(
@@ -510,16 +509,15 @@ public class NotificationDetails implements Serializable {
     Boolean htmlFormatContentTitle = (Boolean) styleInformation.get(HTML_FORMAT_CONTENT_TITLE);
     String summaryText = (String) styleInformation.get(SUMMARY_TEXT);
     Boolean htmlFormatSummaryText = (Boolean) styleInformation.get(HTML_FORMAT_SUMMARY_TEXT);
-    notificationDetails.styleInformation =
-        new BigTextStyleInformation(
-            defaultStyleInformation.htmlFormatTitle,
-            defaultStyleInformation.htmlFormatBody,
-            bigText,
-            htmlFormatBigText,
-            contentTitle,
-            htmlFormatContentTitle,
-            summaryText,
-            htmlFormatSummaryText);
+    notificationDetails.styleInformation = new BigTextStyleInformation(
+        defaultStyleInformation.htmlFormatTitle,
+        defaultStyleInformation.htmlFormatBody,
+        bigText,
+        htmlFormatBigText,
+        contentTitle,
+        htmlFormatContentTitle,
+        summaryText,
+        htmlFormatSummaryText);
   }
 
   private static void readBigPictureStyleInformation(
@@ -533,28 +531,25 @@ public class NotificationDetails implements Serializable {
     Object largeIcon = styleInformation.get(LARGE_ICON);
     BitmapSource largeIconBitmapSource = null;
     if (styleInformation.containsKey(LARGE_ICON_BITMAP_SOURCE)) {
-      Integer largeIconBitmapSourceArgument =
-          (Integer) styleInformation.get(LARGE_ICON_BITMAP_SOURCE);
+      Integer largeIconBitmapSourceArgument = (Integer) styleInformation.get(LARGE_ICON_BITMAP_SOURCE);
       largeIconBitmapSource = BitmapSource.values()[largeIconBitmapSourceArgument];
     }
     Object bigPicture = styleInformation.get(BIG_PICTURE);
-    Integer bigPictureBitmapSourceArgument =
-        (Integer) styleInformation.get(BIG_PICTURE_BITMAP_SOURCE);
+    Integer bigPictureBitmapSourceArgument = (Integer) styleInformation.get(BIG_PICTURE_BITMAP_SOURCE);
     BitmapSource bigPictureBitmapSource = BitmapSource.values()[bigPictureBitmapSourceArgument];
     Boolean showThumbnail = (Boolean) styleInformation.get(HIDE_EXPANDED_LARGE_ICON);
-    notificationDetails.styleInformation =
-        new BigPictureStyleInformation(
-            defaultStyleInformation.htmlFormatTitle,
-            defaultStyleInformation.htmlFormatBody,
-            contentTitle,
-            htmlFormatContentTitle,
-            summaryText,
-            htmlFormatSummaryText,
-            largeIcon,
-            largeIconBitmapSource,
-            bigPicture,
-            bigPictureBitmapSource,
-            showThumbnail);
+    notificationDetails.styleInformation = new BigPictureStyleInformation(
+        defaultStyleInformation.htmlFormatTitle,
+        defaultStyleInformation.htmlFormatBody,
+        contentTitle,
+        htmlFormatContentTitle,
+        summaryText,
+        htmlFormatSummaryText,
+        largeIcon,
+        largeIconBitmapSource,
+        bigPicture,
+        bigPictureBitmapSource,
+        showThumbnail);
   }
 
   private static DefaultStyleInformation getDefaultStyleInformation(

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -277,7 +277,7 @@ public class NotificationDetails implements Serializable {
         if (p instanceof Number){
           ts.iconSpacingDp = ((Number) p).doubleValue();
         } else {
-          ts.iconSpacingDp = 0;
+          ts.iconSpacingDp = 0d;
         }
         notificationDetails.titleStyle = ts;
       }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/NotificationDetails.java
@@ -17,6 +17,7 @@ import com.dexterous.flutterlocalnotifications.models.styles.StyleInformation;
 import com.dexterous.flutterlocalnotifications.utils.LongUtils;
 import com.google.gson.annotations.SerializedName;
 import com.dexterous.flutterlocalnotifications.models.TitleStyle;
+import com.dexterous.flutterlocalnotifications.models.DescriptionStyle;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -130,6 +131,7 @@ public class NotificationDetails implements Serializable {
   private static final String NUMBER = "number";
   private static final String AUDIO_ATTRIBUTES_USAGE = "audioAttributesUsage";
   private static final String TITLE_STYLE = "titleStyle";
+  private static final String DESCRIPTION_STYLE = "descriptionStyle";
 
   public Integer id;
   public String title;
@@ -201,6 +203,7 @@ public class NotificationDetails implements Serializable {
   public Integer number;
   public Integer audioAttributesUsage;
   public TitleStyle titleStyle;
+  public DescriptionStyle descriptionStyle;
 
   // Note: this is set on the Android to save details about the icon that should
   // be used when
@@ -262,6 +265,7 @@ public class NotificationDetails implements Serializable {
         Object s = m.get("sizeSp");
         Object b = m.get("bold");
         Object i = m.get("italic");
+        Object p = m.get("iconSpacingDp");
         if (c instanceof Number)
           ts.color = ((Number) c).intValue();
         if (s instanceof Number)
@@ -270,7 +274,31 @@ public class NotificationDetails implements Serializable {
           ts.bold = (Boolean) b;
         if (i instanceof Boolean)
           ts.italic = (Boolean) i;
+        if (p instanceof Number){
+          ts.iconSpacingDp = ((Number) p).doubleValue();
+        } else {
+          ts.iconSpacingDp = 0;
+        }
         notificationDetails.titleStyle = ts;
+      }
+      Object rawDesc = platformChannelSpecifics.get(DESCRIPTION_STYLE);
+      if (rawDesc instanceof Map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> m = (Map<String, Object>) rawDesc;
+        DescriptionStyle ds = new DescriptionStyle();
+        Object c = m.get("color");
+        Object s = m.get("sizeSp");
+        Object b = m.get("bold");
+        Object i = m.get("italic");
+        if (c instanceof Number)
+          ds.color = ((Number) c).intValue();
+        if (s instanceof Number)
+          ds.sizeSp = ((Number) s).doubleValue();
+        if (b instanceof Boolean)
+          ds.bold = (Boolean) b;
+        if (i instanceof Boolean)
+          ds.italic = (Boolean) i;
+        notificationDetails.descriptionStyle = ds;
       }
       notificationDetails.autoCancel = (Boolean) platformChannelSpecifics.get(AUTO_CANCEL);
       notificationDetails.ongoing = (Boolean) platformChannelSpecifics.get(ONGOING);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/TitleStyle.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/models/TitleStyle.java
@@ -1,0 +1,20 @@
+package com.dexterous.flutterlocalnotifications.models;
+
+import androidx.annotation.Keep;
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+
+@Keep
+public class TitleStyle implements Serializable {
+  @SerializedName("color")
+  public Integer color;
+
+  @SerializedName("sizeSp")
+  public Double sizeSp;
+
+  @SerializedName("bold")
+  public Boolean bold;
+
+  @SerializedName("italic")
+  public Boolean italic;
+}

--- a/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
+++ b/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
@@ -11,6 +11,7 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
 import com.dexterous.flutterlocalnotifications.models.TitleStyle
+import com.dexterous.flutterlocalnotifications.models.DescriptionStyle
 
 internal object TitleStyler {
   private const val TAG = "TitleStyler"
@@ -20,30 +21,32 @@ internal object TitleStyler {
   
     // Builds a RemoteViews that renders a styled title (and optional body).
     // API 24+ only. Returns null if title is empty or style is null.
-   
+
   fun build(
     context: Context,
     title: CharSequence?,
-    // NEW: body text to render below the title (default styling)
     body: CharSequence?,
-    style: TitleStyle?
+    titleStyle: TitleStyle?,
+    descriptionStyle: DescriptionStyle?
   ): RemoteViews? {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null
-    if (title.isNullOrEmpty() || style == null) return null
+    if (title.isNullOrEmpty()) return null
+    if (titleStyle == null && descriptionStyle == null) return null
 
     val rv = RemoteViews(context.packageName, R.layout.fln_notif_title_only)
     val titleId = R.id.fln_title
     val bodyId = R.id.fln_body
+    val rootId = R.id.fln_root
 
-    // 1) Build styled title (bold/italic via spans)
-    val styled: CharSequence = if ((style.bold == true) || (style.italic == true)) {
+    // Build styled title (bold/italic via spans)
+     val styledTitle: CharSequence = if ((titleStyle?.bold == true) || (titleStyle?.italic == true)) {
       val s = SpannableString(title)
       when {
-        style.bold == true && style.italic == true ->
+        titleStyle.bold == true && titleStyle.italic == true ->
           s.setSpan(StyleSpan(Typeface.BOLD_ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        style.bold == true ->
+        titleStyle.bold == true ->
           s.setSpan(StyleSpan(Typeface.BOLD), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        style.italic == true ->
+        titleStyle.italic == true ->
           s.setSpan(StyleSpan(Typeface.ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
       }
       s
@@ -52,8 +55,8 @@ internal object TitleStyler {
     }
 
     // Apply title color/size
-    style.color?.let { rv.setTextColor(titleId, it) }
-    style.sizeSp?.let {
+    titleStyle?.color?.let { rv.setTextColor(titleId, it) }
+    titleStyle?.sizeSp?.let {
       if (it > 0.0) {
         val sp = it.toFloat().coerceIn(MIN_SIZE_SP, MAX_SIZE_SP)
         rv.setTextViewTextSize(titleId, TypedValue.COMPLEX_UNIT_SP, sp)
@@ -63,13 +66,64 @@ internal object TitleStyler {
     }
 
     // Set title last (ensures spans + color/size stick)
-    rv.setTextViewText(titleId, styled)
+    rv.setTextViewText(titleId, styledTitle)
 
-    // 2) Body/description (default appearance), only if provided
+// Adjust spacing between icon and text if requested (RTL-safe)
+titleStyle?.iconSpacingDp?.let { spacing ->
+  if (spacing >= 0) {
+    val metrics = context.resources.displayMetrics
+    val startPx = TypedValue.applyDimension(
+      TypedValue.COMPLEX_UNIT_DIP,
+      spacing.toFloat(),
+      metrics
+    ).toInt()
+
+    // Defaults from resources (match XML)
+    val defaultStart = context.resources.getDimensionPixelSize(R.dimen.fln_padding_start)
+    val defaultTop = context.resources.getDimensionPixelSize(R.dimen.fln_padding_top)
+    val defaultEnd = context.resources.getDimensionPixelSize(R.dimen.fln_padding_end)
+    val defaultBottom = context.resources.getDimensionPixelSize(R.dimen.fln_padding_bottom)
+
+    val isRtl = context.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
+    val left = if (isRtl) defaultStart else startPx
+    val right = if (isRtl) startPx else defaultEnd
+
+    rv.setViewPadding(rootId, left, defaultTop, right, defaultBottom)
+  } else {
+    Log.d(TAG, "Ignoring negative iconSpacingDp: $spacing")
+  }
+}
+
+    // Body/description styled if provided
     if (!body.isNullOrEmpty()) {
+      val styledBody: CharSequence = if ((descriptionStyle?.bold == true) || (descriptionStyle?.italic == true)) {
+        val s = SpannableString(body)
+        when {
+          descriptionStyle.bold == true && descriptionStyle.italic == true ->
+            s.setSpan(StyleSpan(Typeface.BOLD_ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+          descriptionStyle.bold == true ->
+            s.setSpan(StyleSpan(Typeface.BOLD), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+          descriptionStyle.italic == true ->
+            s.setSpan(StyleSpan(Typeface.ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+        s
+      } else {
+        body
+      }
+
+      descriptionStyle?.color?.let { rv.setTextColor(bodyId, it) }
+      descriptionStyle?.sizeSp?.let {
+        if (it > 0.0) {
+          val sp = it.toFloat().coerceIn(MIN_SIZE_SP, MAX_SIZE_SP)
+          rv.setTextViewTextSize(bodyId, TypedValue.COMPLEX_UNIT_SP, sp)
+        } else {
+          Log.d(TAG, "Ignoring non-positive sizeSp: $it")
+        }
+      }
+
       rv.setViewVisibility(bodyId, View.VISIBLE)
-      rv.setTextViewText(bodyId, body)
-      // We intentionally don't override color/size: let system theme handle it
+      rv.setTextViewText(bodyId, styledBody)
     } else {
       rv.setViewVisibility(bodyId, View.GONE)
     }

--- a/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
+++ b/flutter_local_notifications/android/src/main/kotlin/com/dexterous/flutterlocalnotifications/TitleStyler.kt
@@ -1,0 +1,78 @@
+package com.dexterous.flutterlocalnotifications
+
+import android.content.Context
+import android.graphics.Typeface
+import android.os.Build
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.StyleSpan
+import android.util.Log
+import android.util.TypedValue
+import android.view.View
+import android.widget.RemoteViews
+import com.dexterous.flutterlocalnotifications.models.TitleStyle
+
+internal object TitleStyler {
+  private const val TAG = "TitleStyler"
+  private const val MAX_SIZE_SP = 26f
+  private const val MIN_SIZE_SP = 8f
+
+  
+    // Builds a RemoteViews that renders a styled title (and optional body).
+    // API 24+ only. Returns null if title is empty or style is null.
+   
+  fun build(
+    context: Context,
+    title: CharSequence?,
+    // NEW: body text to render below the title (default styling)
+    body: CharSequence?,
+    style: TitleStyle?
+  ): RemoteViews? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null
+    if (title.isNullOrEmpty() || style == null) return null
+
+    val rv = RemoteViews(context.packageName, R.layout.fln_notif_title_only)
+    val titleId = R.id.fln_title
+    val bodyId = R.id.fln_body
+
+    // 1) Build styled title (bold/italic via spans)
+    val styled: CharSequence = if ((style.bold == true) || (style.italic == true)) {
+      val s = SpannableString(title)
+      when {
+        style.bold == true && style.italic == true ->
+          s.setSpan(StyleSpan(Typeface.BOLD_ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        style.bold == true ->
+          s.setSpan(StyleSpan(Typeface.BOLD), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        style.italic == true ->
+          s.setSpan(StyleSpan(Typeface.ITALIC), 0, s.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+      s
+    } else {
+      title
+    }
+
+    // Apply title color/size
+    style.color?.let { rv.setTextColor(titleId, it) }
+    style.sizeSp?.let {
+      if (it > 0.0) {
+        val sp = it.toFloat().coerceIn(MIN_SIZE_SP, MAX_SIZE_SP)
+        rv.setTextViewTextSize(titleId, TypedValue.COMPLEX_UNIT_SP, sp)
+      } else {
+        Log.d(TAG, "Ignoring non-positive sizeSp: $it")
+      }
+    }
+
+    // Set title last (ensures spans + color/size stick)
+    rv.setTextViewText(titleId, styled)
+
+    // 2) Body/description (default appearance), only if provided
+    if (!body.isNullOrEmpty()) {
+      rv.setViewVisibility(bodyId, View.VISIBLE)
+      rv.setTextViewText(bodyId, body)
+      // We intentionally don't override color/size: let system theme handle it
+    } else {
+      rv.setViewVisibility(bodyId, View.GONE)
+    }
+    return rv
+  }
+}

--- a/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
+++ b/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
@@ -5,10 +5,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingStart="@dimen/fln_padding_start"
+    android:paddingEnd="@dimen/fln_padding_end"
+    android:paddingTop="@dimen/fln_padding_top"
+    android:paddingBottom="@dimen/fln_padding_bottom">
 
     <!-- Title (styled via RemoteViews) -->
     <TextView

--- a/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
+++ b/flutter_local_notifications/android/src/main/res/layout/fln_notif_title_only.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Compact custom content for collapsed / expanded / heads-up -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fln_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <!-- Title (styled via RemoteViews) -->
+    <TextView
+        android:id="@+id/fln_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Material.Notification.Title"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+    <!-- Body / description (default style) -->
+    <TextView
+        android:id="@+id/fln_body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Notification"
+        android:maxLines="4"
+        android:ellipsize="end"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/flutter_local_notifications/android/src/main/res/values/dimens.xml
+++ b/flutter_local_notifications/android/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="fln_padding_start">16dp</dimen>
+    <dimen name="fln_padding_end">16dp</dimen>
+    <dimen name="fln_padding_top">8dp</dimen>
+    <dimen name="fln_padding_bottom">8dp</dimen>
+</resources>

--- a/flutter_local_notifications/android/src/test/kotlin/com/dexterous/flutterlocalnotifications/TitleStylerTest.kt
+++ b/flutter_local_notifications/android/src/test/kotlin/com/dexterous/flutterlocalnotifications/TitleStylerTest.kt
@@ -1,0 +1,159 @@
+package com.dexterous.flutterlocalnotifications
+
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Build
+import android.util.TypedValue
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import com.dexterous.flutterlocalnotifications.models.DescriptionStyle
+import com.dexterous.flutterlocalnotifications.models.TitleStyle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class TitleStylerTest {
+  private lateinit var context: android.content.Context
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.M])
+  fun build_returnsNullOnPreN_andWhenStyleMissing() {
+    val style = TitleStyle().apply { bold = true }
+    val rvPreN = TitleStyler.build(context, "t", null, style, null)
+    val rvNoStyle = TitleStyler.build(context, "t", null, null, null)
+    assertNull(rvPreN)
+    assertNull(rvNoStyle)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_returnsNullWhenTitleMissing_orEmpty() {
+    val style = TitleStyle()
+    val rvNull = TitleStyler.build(context, null, null, style, null)
+    val rvEmpty = TitleStyler.build(context, "", null, style, null)
+    assertNull(rvNull)
+    assertNull(rvEmpty)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_appliesBoldItalicColorAndSize() {
+    val style = TitleStyle().apply {
+      bold = true
+      italic = true
+      color = Color.GREEN
+      sizeSp = 40.0
+    }
+     val rv = TitleStyler.build(context, "Title", "Body", style, null)
+    val root = rv!!.apply(context, null)
+    val title = root.findViewById<TextView>(R.id.fln_title)
+    val expectedSize = TypedValue.applyDimension(
+      TypedValue.COMPLEX_UNIT_SP,
+      26f,
+      context.resources.displayMetrics
+    )
+    assertEquals(Typeface.BOLD_ITALIC, title.typeface.style)
+    assertEquals(Color.GREEN, title.currentTextColor)
+    assertEquals(expectedSize, title.textSize, 0.1f)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_handlesBodyVisibility() {
+    val style = TitleStyle()
+    val withBody = TitleStyler.build(context, "t", "body", style, null)
+    val noBody = TitleStyler.build(context, "t", null, style, null)
+    val bodyView1 = withBody!!.apply(context, null).findViewById<TextView>(R.id.fln_body)
+    val bodyView2 = noBody!!.apply(context, null).findViewById<TextView>(R.id.fln_body)
+    assertEquals(View.VISIBLE, bodyView1.visibility)
+    assertEquals(View.GONE, bodyView2.visibility)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_clampsSizeSpWithinBounds() {
+    val big = TitleStyle().apply { sizeSp = 1000.0 }
+    val small = TitleStyle().apply { sizeSp = 1.0 }
+    val bigView = TitleStyler.build(context, "t", null, big, null)!!.apply(context, null)
+    val smallView = TitleStyler.build(context, "t", null, small, null)!!.apply(context, null)
+    val titleBig = bigView.findViewById<TextView>(R.id.fln_title)
+    val titleSmall = smallView.findViewById<TextView>(R.id.fln_title)
+    val maxPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 26f, context.resources.displayMetrics)
+    val minPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 8f, context.resources.displayMetrics)
+    assertEquals(maxPx, titleBig.textSize, 0.1f)
+    assertEquals(minPx, titleSmall.textSize, 0.1f)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_appliesBoldOnly_andItalicOnly() {
+    val boldStyle = TitleStyle().apply { bold = true }
+    val italicStyle = TitleStyle().apply { italic = true }
+    val boldView = TitleStyler.build(context, "t", null, boldStyle, null)!!.apply(context, null)
+    val italicView = TitleStyler.build(context, "t", null, italicStyle, null)!!.apply(context, null)
+    val titleBold = boldView.findViewById<TextView>(R.id.fln_title)
+    val titleItalic = italicView.findViewById<TextView>(R.id.fln_title)
+    assertEquals(Typeface.BOLD, titleBold.typeface.style)
+    assertEquals(Typeface.ITALIC, titleItalic.typeface.style)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_ignoresNonPositiveSizeSp() {
+    val zero = TitleStyle().apply { sizeSp = 0.0 }
+    val negative = TitleStyle().apply { sizeSp = -5.0 }
+    val zeroTitle = TitleStyler.build(context, "t", null, zero, null)!!.apply(context, null)
+      .findViewById<TextView>(R.id.fln_title)
+    val negativeTitle = TitleStyler.build(context, "t", null, negative, null)!!.apply(context, null)
+      .findViewById<TextView>(R.id.fln_title)
+    assertEquals(zeroTitle.textSize, negativeTitle.textSize, 0.1f)
+    assertTrue(zeroTitle.textSize > 0f)
+  }
+
+   @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_appliesDescriptionBoldItalicColorAndSize() {
+    val style = DescriptionStyle().apply {
+      bold = true
+      italic = true
+      color = Color.RED
+      sizeSp = 20.0
+    }
+    val rv = TitleStyler.build(context, "Title", "Body", null, style)
+    val root = rv!!.apply(context, null)
+    val body = root.findViewById<TextView>(R.id.fln_body)
+    val expectedSize = TypedValue.applyDimension(
+      TypedValue.COMPLEX_UNIT_SP,
+      20f,
+      context.resources.displayMetrics
+    )
+    assertEquals(Typeface.BOLD_ITALIC, body.typeface.style)
+    assertEquals(Color.RED, body.currentTextColor)
+    assertEquals(expectedSize, body.textSize, 0.1f)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.N])
+  fun build_ignoresNonPositiveDescriptionSizeSp() {
+    val zero = DescriptionStyle().apply { sizeSp = 0.0 }
+    val negative = DescriptionStyle().apply { sizeSp = -5.0 }
+    val zeroBody = TitleStyler.build(context, "t", "body", null, zero)!!.apply(context, null)
+      .findViewById<TextView>(R.id.fln_body)
+    val negativeBody = TitleStyler.build(context, "t", "body", null, negative)!!.apply(context, null)
+      .findViewById<TextView>(R.id.fln_body)
+    assertEquals(zeroBody.textSize, negativeBody.textSize, 0.1f)
+    assertTrue(zeroBody.textSize > 0f)
+  }
+}

--- a/flutter_local_notifications/example/android/app/build.gradle
+++ b/flutter_local_notifications/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace 'com.dexterous.flutter_local_notifications_example'
-    compileSdk 35
+    compileSdk 36
     ndkVersion = flutter.ndkVersion
 
     sourceSets {
@@ -33,20 +33,20 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     defaultConfig {
         multiDexEnabled true
         applicationId "com.dexterous.flutter_local_notifications_example"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 35
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdkVersion 21
+        targetSdkVersion 36
+        versionCode 1
+        versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/flutter_local_notifications/example/android/settings.gradle
+++ b/flutter_local_notifications/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.6.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_local_notifications/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,10 +9,12 @@ import device_info_plus
 import flutter_local_notifications
 import flutter_timezone
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -60,6 +60,15 @@ extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
       }..addAll(_convertNotificationSoundToMap(sound));
 }
 
+extension AndroidNotificationTitleStyleMapper on AndroidNotificationTitleStyle {
+  Map<String, Object?> toMap() => <String, Object?>{
+        'color': color,
+        'sizeSp': sizeSp,
+        'bold': bold,
+        'italic': italic,
+      };
+}
+
 Map<String, Object> _convertNotificationSoundToMap(
     AndroidNotificationSound? sound) {
   if (sound is RawResourceAndroidNotificationSound) {
@@ -224,6 +233,7 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
         'colorized': colorized,
         'number': number,
         'audioAttributesUsage': audioAttributesUsage.value,
+        'titleStyle': titleStyle?.toMap(),
       }
         ..addAll(_convertActionsToMap(actions))
         ..addAll(_convertStyleInformationToMap())

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'enums.dart';
 import 'initialization_settings.dart';
 import 'message.dart';
@@ -38,35 +39,89 @@ extension AndroidNotificationChannelGroupMapper
 }
 
 extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
-  Map<String, Object?> toMap() => <String, Object?>{
-        'id': id,
-        'name': name,
-        'description': description,
-        'groupId': groupId,
-        'showBadge': showBadge,
-        'importance': importance.value,
-        'bypassDnd': bypassDnd,
-        'playSound': playSound,
-        'enableVibration': enableVibration,
-        'vibrationPattern': vibrationPattern,
-        'enableLights': enableLights,
-        'ledColorAlpha': ledColor?.alpha,
-        'ledColorRed': ledColor?.red,
-        'ledColorGreen': ledColor?.green,
-        'ledColorBlue': ledColor?.blue,
-        'audioAttributesUsage': audioAttributesUsage.value,
-        'channelAction':
-            AndroidNotificationChannelAction.createIfNotExists.index,
-      }..addAll(_convertNotificationSoundToMap(sound));
+  Map<String, Object?> toMap() {
+    final Color? color = ledColor;
+
+    // Convert normalized channels (0.0–1.0) to 8-bit ints (0–255).
+    final int? alpha8 =
+        color != null ? ((color.a * 255.0).round() & 0xff) : null;
+    final int? red8 = color != null ? ((color.r * 255.0).round() & 0xff) : null;
+    final int? green8 =
+        color != null ? ((color.g * 255.0).round() & 0xff) : null;
+    final int? blue8 =
+        color != null ? ((color.b * 255.0).round() & 0xff) : null;
+
+    final Map<String, Object?> map = <String, Object?>{
+      'id': id,
+      'name': name,
+      'description': description,
+      'groupId': groupId,
+      'showBadge': showBadge,
+      'importance': importance.value,
+      'bypassDnd': bypassDnd,
+      'playSound': playSound,
+      'enableVibration': enableVibration,
+      'vibrationPattern': vibrationPattern,
+      'enableLights': enableLights,
+      'ledColorAlpha': alpha8,
+      'ledColorRed': red8,
+      'ledColorGreen': green8,
+      'ledColorBlue': blue8,
+      'audioAttributesUsage': audioAttributesUsage.value,
+      'channelAction': AndroidNotificationChannelAction.createIfNotExists.index,
+    }..addAll(_convertNotificationSoundToMap(sound));
+
+    return map;
+  }
 }
 
 extension AndroidNotificationTitleStyleMapper on AndroidNotificationTitleStyle {
-  Map<String, Object?> toMap() => <String, Object?>{
-        'color': color,
-        'sizeSp': sizeSp,
-        'bold': bold,
-        'italic': italic,
-      };
+  Map<String, Object?> toMap() {
+    final Map<String, Object?> map = <String, Object?>{};
+    if (color != null) {
+      assert(color! >= 0 && color! <= 0xFFFFFFFF);
+      map['color'] = color;
+    }
+    if (sizeSp != null) {
+      map['sizeSp'] = sizeSp;
+    }
+    if (bold != null) {
+      map['bold'] = bold;
+    }
+    if (italic != null) {
+      map['italic'] = italic;
+    }
+    if (iconSpacing != null) {
+      assert(iconSpacing! >= 0);
+      map['iconSpacingDp'] = iconSpacing;
+    }
+    assert(map.keys.toSet().length == map.length);
+    assert(map.values.every((Object? v) => v != null));
+    return map;
+  }
+}
+
+extension AndroidNotificationDescriptionStyleMapper
+    on AndroidNotificationDescriptionStyle {
+  Map<String, Object?> toMap() {
+    final Map<String, Object?> map = <String, Object?>{};
+    if (color != null) {
+      assert(color! >= 0 && color! <= 0xFFFFFFFF);
+      map['color'] = color;
+    }
+    if (sizeSp != null) {
+      map['sizeSp'] = sizeSp;
+    }
+    if (bold != null) {
+      map['bold'] = bold;
+    }
+    if (italic != null) {
+      map['italic'] = italic;
+    }
+    assert(map.keys.toSet().length == map.length);
+    assert(map.values.every((Object? v) => v != null));
+    return map;
+  }
 }
 
 Map<String, Object> _convertNotificationSoundToMap(
@@ -182,63 +237,73 @@ extension MessagingStyleInformationMapper on MessagingStyleInformation {
 }
 
 extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
-  Map<String, Object?> toMap() => <String, Object?>{
-        'icon': icon,
-        'channelId': channelId,
-        'channelName': channelName,
-        'channelDescription': channelDescription,
-        'channelShowBadge': channelShowBadge,
-        'channelAction': channelAction.index,
-        'importance': importance.value,
-        'channelBypassDnd': channelBypassDnd,
-        'priority': priority.value,
-        'playSound': playSound,
-        'enableVibration': enableVibration,
-        'vibrationPattern': vibrationPattern,
-        'groupKey': groupKey,
-        'setAsGroupSummary': setAsGroupSummary,
-        'groupAlertBehavior': groupAlertBehavior.index,
-        'autoCancel': autoCancel,
-        'ongoing': ongoing,
-        'silent': silent,
-        'colorAlpha': color?.alpha,
-        'colorRed': color?.red,
-        'colorGreen': color?.green,
-        'colorBlue': color?.blue,
-        'onlyAlertOnce': onlyAlertOnce,
-        'showWhen': showWhen,
-        'when': when,
-        'usesChronometer': usesChronometer,
-        'chronometerCountDown': chronometerCountDown,
-        'showProgress': showProgress,
-        'maxProgress': maxProgress,
-        'progress': progress,
-        'indeterminate': indeterminate,
-        'enableLights': enableLights,
-        'ledColorAlpha': ledColor?.alpha,
-        'ledColorRed': ledColor?.red,
-        'ledColorGreen': ledColor?.green,
-        'ledColorBlue': ledColor?.blue,
-        'ledOnMs': ledOnMs,
-        'ledOffMs': ledOffMs,
-        'ticker': ticker,
-        'visibility': visibility?.index,
-        'timeoutAfter': timeoutAfter,
-        'category': category?.name,
-        'fullScreenIntent': fullScreenIntent,
-        'shortcutId': shortcutId,
-        'additionalFlags': additionalFlags,
-        'subText': subText,
-        'tag': tag,
-        'colorized': colorized,
-        'number': number,
-        'audioAttributesUsage': audioAttributesUsage.value,
-        'titleStyle': titleStyle?.toMap(),
-      }
-        ..addAll(_convertActionsToMap(actions))
-        ..addAll(_convertStyleInformationToMap())
-        ..addAll(_convertNotificationSoundToMap(sound))
-        ..addAll(_convertLargeIconToMap());
+  Map<String, Object?> toMap() {
+    final Color? c = color, lc = ledColor; // cache to enable promotion
+    return <String, Object?>{
+      'icon': icon,
+      'channelId': channelId,
+      'channelName': channelName,
+      'channelDescription': channelDescription,
+      'channelShowBadge': channelShowBadge,
+      'channelAction': channelAction.index,
+      'importance': importance.value,
+      'channelBypassDnd': channelBypassDnd,
+      'priority': priority.value,
+      'playSound': playSound,
+      'enableVibration': enableVibration,
+      'vibrationPattern': vibrationPattern,
+      'groupKey': groupKey,
+      'setAsGroupSummary': setAsGroupSummary,
+      'groupAlertBehavior': groupAlertBehavior.index,
+      'autoCancel': autoCancel,
+      'ongoing': ongoing,
+      'silent': silent,
+
+      // color (nullable) — use a/r/g/b doubles -> 0–255 ints
+      'colorAlpha': c != null ? ((c.a * 255.0).round() & 0xff) : null,
+      'colorRed': c != null ? ((c.r * 255.0).round() & 0xff) : null,
+      'colorGreen': c != null ? ((c.g * 255.0).round() & 0xff) : null,
+      'colorBlue': c != null ? ((c.b * 255.0).round() & 0xff) : null,
+
+      'onlyAlertOnce': onlyAlertOnce,
+      'showWhen': showWhen,
+      'when': when,
+      'usesChronometer': usesChronometer,
+      'chronometerCountDown': chronometerCountDown,
+      'showProgress': showProgress,
+      'maxProgress': maxProgress,
+      'progress': progress,
+      'indeterminate': indeterminate,
+      'enableLights': enableLights,
+
+      // ledColor (nullable) — also switch off deprecated getters
+      'ledColorAlpha': lc != null ? ((lc.a * 255.0).round() & 0xff) : null,
+      'ledColorRed': lc != null ? ((lc.r * 255.0).round() & 0xff) : null,
+      'ledColorGreen': lc != null ? ((lc.g * 255.0).round() & 0xff) : null,
+      'ledColorBlue': lc != null ? ((lc.b * 255.0).round() & 0xff) : null,
+
+      'ledOnMs': ledOnMs,
+      'ledOffMs': ledOffMs,
+      'ticker': ticker,
+      'visibility': visibility?.index,
+      'timeoutAfter': timeoutAfter,
+      'category': category?.name,
+      'fullScreenIntent': fullScreenIntent,
+      'shortcutId': shortcutId,
+      'additionalFlags': additionalFlags,
+      'subText': subText,
+      'tag': tag,
+      'colorized': colorized,
+      'number': number,
+      'audioAttributesUsage': audioAttributesUsage.value,
+      'titleStyle': titleStyle?.toMap(),
+      'descriptionStyle': descriptionStyle?.toMap(),
+    }
+      ..addAll(_convertActionsToMap(actions))
+      ..addAll(_convertStyleInformationToMap())
+      ..addAll(_convertNotificationSoundToMap(sound))
+      ..addAll(_convertLargeIconToMap());
+  }
 
   Map<String, Object?> _convertStyleInformationToMap() {
     if (styleInformation is BigPictureStyleInformation) {
@@ -306,10 +371,18 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
             (AndroidNotificationAction e) => <String, dynamic>{
               'id': e.id,
               'title': e.title,
-              'titleColorAlpha': e.titleColor?.alpha,
-              'titleColorRed': e.titleColor?.red,
-              'titleColorGreen': e.titleColor?.green,
-              'titleColorBlue': e.titleColor?.blue,
+              'titleColorAlpha': e.titleColor != null
+                  ? ((e.titleColor!.a * 255.0).round() & 0xff)
+                  : null,
+              'titleColorRed': e.titleColor != null
+                  ? ((e.titleColor!.r * 255.0).round() & 0xff)
+                  : null,
+              'titleColorGreen': e.titleColor != null
+                  ? ((e.titleColor!.g * 255.0).round() & 0xff)
+                  : null,
+              'titleColorBlue': e.titleColor != null
+                  ? ((e.titleColor!.b * 255.0).round() & 0xff)
+                  : null,
               if (e.icon != null) ...<String, Object>{
                 'icon': e.icon!.data,
                 'iconBitmapSource': e.icon!.source.index,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:ui';
 import 'enums.dart';
 import 'initialization_settings.dart';
@@ -44,12 +46,13 @@ extension AndroidNotificationChannelMapper on AndroidNotificationChannel {
 
     // Convert normalized channels (0.0–1.0) to 8-bit ints (0–255).
     final int? alpha8 =
-        color != null ? ((color.a * 255.0).round() & 0xff) : null;
-    final int? red8 = color != null ? ((color.r * 255.0).round() & 0xff) : null;
+        color != null ? ((color.alpha * 255.0).round() & 0xff) : null;
+    final int? red8 =
+        color != null ? ((color.red * 255.0).round() & 0xff) : null;
     final int? green8 =
-        color != null ? ((color.g * 255.0).round() & 0xff) : null;
+        color != null ? ((color.green * 255.0).round() & 0xff) : null;
     final int? blue8 =
-        color != null ? ((color.b * 255.0).round() & 0xff) : null;
+        color != null ? ((color.blue * 255.0).round() & 0xff) : null;
 
     final Map<String, Object?> map = <String, Object?>{
       'id': id,
@@ -260,10 +263,10 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
       'silent': silent,
 
       // color (nullable) — use a/r/g/b doubles -> 0–255 ints
-      'colorAlpha': c != null ? ((c.a * 255.0).round() & 0xff) : null,
-      'colorRed': c != null ? ((c.r * 255.0).round() & 0xff) : null,
-      'colorGreen': c != null ? ((c.g * 255.0).round() & 0xff) : null,
-      'colorBlue': c != null ? ((c.b * 255.0).round() & 0xff) : null,
+      'colorAlpha': c != null ? ((c.alpha * 255.0).round() & 0xff) : null,
+      'colorRed': c != null ? ((c.red * 255.0).round() & 0xff) : null,
+      'colorGreen': c != null ? ((c.green * 255.0).round() & 0xff) : null,
+      'colorBlue': c != null ? ((c.blue * 255.0).round() & 0xff) : null,
 
       'onlyAlertOnce': onlyAlertOnce,
       'showWhen': showWhen,
@@ -277,10 +280,10 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
       'enableLights': enableLights,
 
       // ledColor (nullable) — also switch off deprecated getters
-      'ledColorAlpha': lc != null ? ((lc.a * 255.0).round() & 0xff) : null,
-      'ledColorRed': lc != null ? ((lc.r * 255.0).round() & 0xff) : null,
-      'ledColorGreen': lc != null ? ((lc.g * 255.0).round() & 0xff) : null,
-      'ledColorBlue': lc != null ? ((lc.b * 255.0).round() & 0xff) : null,
+      'ledColorAlpha': lc != null ? ((lc.alpha * 255.0).round() & 0xff) : null,
+      'ledColorRed': lc != null ? ((lc.red * 255.0).round() & 0xff) : null,
+      'ledColorGreen': lc != null ? ((lc.green * 255.0).round() & 0xff) : null,
+      'ledColorBlue': lc != null ? ((lc.blue * 255.0).round() & 0xff) : null,
 
       'ledOnMs': ledOnMs,
       'ledOffMs': ledOffMs,
@@ -372,16 +375,16 @@ extension AndroidNotificationDetailsMapper on AndroidNotificationDetails {
               'id': e.id,
               'title': e.title,
               'titleColorAlpha': e.titleColor != null
-                  ? ((e.titleColor!.a * 255.0).round() & 0xff)
+                  ? ((e.titleColor!.alpha * 255.0).round() & 0xff)
                   : null,
               'titleColorRed': e.titleColor != null
-                  ? ((e.titleColor!.r * 255.0).round() & 0xff)
+                  ? ((e.titleColor!.red * 255.0).round() & 0xff)
                   : null,
               'titleColorGreen': e.titleColor != null
-                  ? ((e.titleColor!.g * 255.0).round() & 0xff)
+                  ? ((e.titleColor!.green * 255.0).round() & 0xff)
                   : null,
               'titleColorBlue': e.titleColor != null
-                  ? ((e.titleColor!.b * 255.0).round() & 0xff)
+                  ? ((e.titleColor!.blue * 255.0).round() & 0xff)
                   : null,
               if (e.icon != null) ...<String, Object>{
                 'icon': e.icon!.data,

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -104,6 +104,32 @@ class AndroidNotificationAction {
   final bool invisible;
 }
 
+/// Android-only options to style the *title* text using a custom layout.
+///
+/// Effective on Android API 24+; ignored below that.
+class AndroidNotificationTitleStyle {
+  /// 32-bit ARGB color (e.g., 0xFF58CC02). Null => platform default.
+  final int? color;
+
+  /// Font size in SP (logical scaled pixels). Must be > 0.
+  final double? sizeSp;
+
+  /// Whether to render title in bold. Defaults to null (platform default).
+  final bool? bold;
+
+  /// Whether to render title in italic. Defaults to null (platform default).
+  final bool? italic;
+
+  /// Constructs an instance of [AndroidNotificationTitleStyle].
+  const AndroidNotificationTitleStyle({
+    this.color,
+    this.sizeSp,
+    this.bold,
+    this.italic,
+  })  : assert(sizeSp == null || sizeSp > 0),
+        assert(color == null || (color >= 0 && color <= 0xFFFFFFFF));
+}
+
 /// Contains notification details specific to Android.
 class AndroidNotificationDetails {
   /// Constructs an instance of [AndroidNotificationDetails].
@@ -156,6 +182,7 @@ class AndroidNotificationDetails {
     this.colorized = false,
     this.number,
     this.audioAttributesUsage = AudioAttributesUsage.notification,
+    this.titleStyle,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -426,4 +453,8 @@ class AndroidNotificationDetails {
   /// such as alarm or ringtone set in [`AudioAttributes.Builder`](https://developer.android.com/reference/android/media/AudioAttributes.Builder#setUsage(int)).
   /// https://developer.android.com/reference/android/media/AudioAttributes
   final AudioAttributesUsage audioAttributesUsage;
+
+  /// If set, uses a `DecoratedCustomViewStyle` with a custom `RemoteViews`
+  /// to render the title with the given style (API 24+ only).
+  final AndroidNotificationTitleStyle? titleStyle;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/notification_details.dart
@@ -108,10 +108,22 @@ class AndroidNotificationAction {
 ///
 /// Effective on Android API 24+; ignored below that.
 class AndroidNotificationTitleStyle {
+  /// Constructs an instance of [AndroidNotificationTitleStyle].
+  const AndroidNotificationTitleStyle({
+    this.color,
+    this.sizeSp,
+    this.bold,
+    this.italic,
+    this.iconSpacing = 0,
+  })  : assert(sizeSp == null || sizeSp > 0),
+        assert(color == null || (color >= 0 && color <= 0xFFFFFFFF)),
+        assert(iconSpacing == null || iconSpacing >= 0);
+
   /// 32-bit ARGB color (e.g., 0xFF58CC02). Null => platform default.
   final int? color;
 
-  /// Font size in SP (logical scaled pixels). Must be > 0.
+  /// Font size in SP (logical scaled pixels). Negative or zero values are
+  /// ignored on Android.
   final double? sizeSp;
 
   /// Whether to render title in bold. Defaults to null (platform default).
@@ -120,14 +132,39 @@ class AndroidNotificationTitleStyle {
   /// Whether to render title in italic. Defaults to null (platform default).
   final bool? italic;
 
-  /// Constructs an instance of [AndroidNotificationTitleStyle].
-  const AndroidNotificationTitleStyle({
+  /// Distance in dp between the notification's icon and the title/body.
+  /// Defaults to 0.
+  final double? iconSpacing;
+}
+
+/// Android-only options to style the notification body text using a custom
+/// layout.
+///
+/// Effective on Android API 24+; ignored below that.
+class AndroidNotificationDescriptionStyle {
+  /// Constructs an instance of [AndroidNotificationDescriptionStyle].
+  const AndroidNotificationDescriptionStyle({
     this.color,
     this.sizeSp,
     this.bold,
     this.italic,
   })  : assert(sizeSp == null || sizeSp > 0),
         assert(color == null || (color >= 0 && color <= 0xFFFFFFFF));
+
+  /// 32-bit ARGB color (e.g., 0xFF58CC02). Null => platform default.
+  final int? color;
+
+  /// Font size in SP (logical scaled pixels). Negative or zero values are
+  /// ignored on Android.
+  final double? sizeSp;
+
+  /// Whether to render the description in bold. Defaults to null (platform
+  /// default).
+  final bool? bold;
+
+  /// Whether to render the description in italic. Defaults to null (platform
+  /// default).
+  final bool? italic;
 }
 
 /// Contains notification details specific to Android.
@@ -183,6 +220,7 @@ class AndroidNotificationDetails {
     this.number,
     this.audioAttributesUsage = AudioAttributesUsage.notification,
     this.titleStyle,
+    this.descriptionStyle,
   });
 
   /// The icon that should be used when displaying the notification.
@@ -457,4 +495,7 @@ class AndroidNotificationDetails {
   /// If set, uses a `DecoratedCustomViewStyle` with a custom `RemoteViews`
   /// to render the title with the given style (API 24+ only).
   final AndroidNotificationTitleStyle? titleStyle;
+
+  /// Android-only options to style the notification body/description text.
+  final AndroidNotificationDescriptionStyle? descriptionStyle;
 }

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -52,6 +52,7 @@ void main() {
           sizeSp: 16,
           bold: true,
           italic: true,
+          iconSpacing: 10,
         ),
       );
 
@@ -72,6 +73,7 @@ void main() {
         'sizeSp': 16,
         'bold': true,
         'italic': true,
+        'iconSpacingDp': 10,
       });
     });
 
@@ -79,6 +81,226 @@ void main() {
       log.clear();
     });
 
+    test('show with Android title style color only', () async {
+      const AndroidNotificationDetails androidNotificationDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        titleStyle: AndroidNotificationTitleStyle(
+          color: 0xFF0000FF,
+        ),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        2,
+        'notification title',
+        'notification body',
+        const NotificationDetails(android: androidNotificationDetails),
+      );
+
+      final Map<Object?, Object?> arguments =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> platformSpecifics = Map<String, Object?>.from(
+        arguments['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(platformSpecifics['titleStyle'], <String, Object?>{
+        'color': 0xFF0000FF,
+        'iconSpacingDp': 0,
+      });
+      expect(platformSpecifics['channelId'], 'channelId');
+    });
+
+    test('show with Android description style', () async {
+      const AndroidNotificationDetails androidNotificationDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        descriptionStyle: AndroidNotificationDescriptionStyle(
+          color: 0xFF58CC02,
+          sizeSp: 16,
+          bold: true,
+          italic: true,
+        ),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        6,
+        'notification title',
+        'notification body',
+        const NotificationDetails(android: androidNotificationDetails),
+      );
+
+      final Map<Object?, Object?> arguments =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> platformSpecifics = Map<String, Object?>.from(
+        arguments['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(platformSpecifics['descriptionStyle'], <String, Object?>{
+        'color': 0xFF58CC02,
+        'sizeSp': 16,
+        'bold': true,
+        'italic': true,
+      });
+    });
+
+    test('show with Android description style color only', () async {
+      const AndroidNotificationDetails androidNotificationDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        descriptionStyle: AndroidNotificationDescriptionStyle(
+          color: 0xFF0000FF,
+        ),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        7,
+        'notification title',
+        'notification body',
+        const NotificationDetails(android: androidNotificationDetails),
+      );
+
+      final Map<Object?, Object?> arguments =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> platformSpecifics = Map<String, Object?>.from(
+        arguments['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(platformSpecifics['descriptionStyle'], <String, Object?>{
+        'color': 0xFF0000FF,
+      });
+      expect(platformSpecifics['channelId'], 'channelId');
+    });
+
+    test('show with Android description style negative size', () {
+      expect(
+        () => flutterLocalNotificationsPlugin.show(
+          8,
+          'notification title',
+          'notification body',
+          NotificationDetails(
+            android: AndroidNotificationDetails(
+              'channelId',
+              'channelName',
+              descriptionStyle: AndroidNotificationDescriptionStyle(
+                sizeSp: -10,
+              ),
+            ),
+          ),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('show with Android description style bold and italic separately',
+        () async {
+      const AndroidNotificationDetails boldDetails = AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        descriptionStyle: AndroidNotificationDescriptionStyle(bold: true),
+      );
+      const AndroidNotificationDetails italicDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        descriptionStyle: AndroidNotificationDescriptionStyle(italic: true),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        9,
+        'title',
+        'body',
+        const NotificationDetails(android: boldDetails),
+      );
+      final Map<Object?, Object?> boldArgs =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> boldSpecifics = Map<String, Object?>.from(
+        boldArgs['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(boldSpecifics['descriptionStyle'], <String, Object?>{
+        'bold': true,
+      });
+      expect(boldSpecifics['channelId'], 'channelId');
+
+      await flutterLocalNotificationsPlugin.show(
+        10,
+        'title',
+        'body',
+        const NotificationDetails(android: italicDetails),
+      );
+      final Map<Object?, Object?> italicArgs =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> italicSpecifics = Map<String, Object?>.from(
+        italicArgs['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(italicSpecifics['descriptionStyle'], <String, Object?>{
+        'italic': true,
+      });
+      expect(italicSpecifics['channelId'], 'channelId');
+    });
+
+    test('show with Android title style negative size', () {
+      expect(
+        () => flutterLocalNotificationsPlugin.show(
+          3,
+          'notification title',
+          'notification body',
+          NotificationDetails(
+            android: AndroidNotificationDetails(
+              'channelId',
+              'channelName',
+              titleStyle: AndroidNotificationTitleStyle(
+                sizeSp: -10,
+              ),
+            ),
+          ),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('show with Android title style bold and italic separately', () async {
+      const AndroidNotificationDetails boldDetails = AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        titleStyle: AndroidNotificationTitleStyle(bold: true),
+      );
+      const AndroidNotificationDetails italicDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        titleStyle: AndroidNotificationTitleStyle(italic: true),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        4,
+        'title',
+        'body',
+        const NotificationDetails(android: boldDetails),
+      );
+      final Map<Object?, Object?> boldArgs =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> boldSpecifics = Map<String, Object?>.from(
+        boldArgs['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(boldSpecifics['titleStyle'],
+          <String, Object?>{'bold': true, 'iconSpacingDp': 0.0});
+      expect(boldSpecifics['channelId'], 'channelId');
+
+      await flutterLocalNotificationsPlugin.show(
+        5,
+        'title',
+        'body',
+        const NotificationDetails(android: italicDetails),
+      );
+      final Map<Object?, Object?> italicArgs =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> italicSpecifics = Map<String, Object?>.from(
+        italicArgs['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(italicSpecifics['titleStyle'],
+          <String, Object?>{'italic': true, 'iconSpacingDp': 0.0});
+      expect(italicSpecifics['channelId'], 'channelId');
+    });
     test('initialize', () async {
       const AndroidInitializationSettings androidInitializationSettings =
           AndroidInitializationSettings('app_icon');
@@ -216,6 +438,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
               'actions': <Map<String, Object>>[
                 <String, Object>{
                   'id': 'action1',
@@ -343,6 +567,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -428,6 +654,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -514,6 +742,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -601,6 +831,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -692,6 +924,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -782,6 +1016,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -870,6 +1106,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -959,6 +1197,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1057,6 +1297,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1165,6 +1407,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1263,6 +1507,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1371,6 +1617,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1466,6 +1714,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1568,6 +1818,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1655,6 +1907,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1745,6 +1999,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1860,6 +2116,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -1988,6 +2246,8 @@ void main() {
               'colorized': false,
               'number': null,
               'audioAttributesUsage': 5,
+              'titleStyle': null,
+              'descriptionStyle': null,
             },
           }));
     });
@@ -2083,6 +2343,8 @@ void main() {
                     'colorized': false,
                     'number': null,
                     'audioAttributesUsage': 5,
+                    'titleStyle': null,
+                    'descriptionStyle': null,
                   },
                 }));
           });
@@ -2218,6 +2480,8 @@ void main() {
                         'colorized': false,
                         'number': null,
                         'audioAttributesUsage': 5,
+                        'titleStyle': null,
+                        'descriptionStyle': null,
                       },
                     }));
           });
@@ -2315,6 +2579,8 @@ void main() {
                 'colorized': false,
                 'number': null,
                 'audioAttributesUsage': 5,
+                'titleStyle': null,
+                'descriptionStyle': null,
               },
             }));
       });
@@ -2411,6 +2677,8 @@ void main() {
                 'colorized': false,
                 'number': null,
                 'audioAttributesUsage': 5,
+                'titleStyle': null,
+                'descriptionStyle': null,
               },
             }));
       });
@@ -2508,6 +2776,8 @@ void main() {
                 'colorized': false,
                 'number': null,
                 'audioAttributesUsage': 5,
+                'titleStyle': null,
+                'descriptionStyle': null,
               },
             }));
       });
@@ -2819,6 +3089,8 @@ void main() {
                   'colorized': true,
                   'number': null,
                   'audioAttributesUsage': 5,
+                  'titleStyle': null,
+                  'descriptionStyle': null,
                 },
               },
               'startType': AndroidServiceStartType.startSticky.index,

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -42,6 +42,39 @@ void main() {
       });
     });
 
+    test('show with Android title style', () async {
+      const AndroidNotificationDetails androidNotificationDetails =
+          AndroidNotificationDetails(
+        'channelId',
+        'channelName',
+        titleStyle: AndroidNotificationTitleStyle(
+          color: 0xFF58CC02,
+          sizeSp: 16,
+          bold: true,
+          italic: true,
+        ),
+      );
+
+      await flutterLocalNotificationsPlugin.show(
+        1,
+        'notification title',
+        'notification body',
+        const NotificationDetails(android: androidNotificationDetails),
+      );
+
+      final Map<Object?, Object?> arguments =
+          log.last.arguments as Map<Object?, Object?>;
+      final Map<String, Object?> platformSpecifics = Map<String, Object?>.from(
+        arguments['platformSpecifics'] as Map<Object?, Object?>,
+      );
+      expect(platformSpecifics['titleStyle'], <String, Object?>{
+        'color': 0xFF58CC02,
+        'sizeSp': 16,
+        'bold': true,
+        'italic': true,
+      });
+    });
+
     tearDown(() {
       log.clear();
     });


### PR DESCRIPTION
## Hello maintainers 

### Summary of this pull request

This PR introduces **title and description text styling for Android notifications (API 24+).**  
It allows developers to style the notification title and/or description using decorated custom layouts.  
On devices running Android versions lower than 7.0 (API < 24), the plugin will gracefully fall back to the system’s default notification template.

---

### Key Additions

#### [Android] Title & Description Styling (API 24+)

Developers can now customize the title and description text appearance in notifications:

```dart
final androidDetails = AndroidNotificationDetails(
  'reminders',
  'Reminders',
  titleStyle: const AndroidNotificationTitleStyle(
    color: 0xFF58CC02,   // Notification title color
    sizeSp: 16,          // Font size
    bold: true,          // Bold text
    italic: false,       // Italic text
    iconSpacing: 2,      // Spacing between icon and text
  ),
  descriptionStyle: const AndroidNotificationDescriptionStyle(
    color: 0xFFFF0000,   // Notification body color
    sizeSp: 14,          // Font size
    bold: false,         // Bold text
    italic: true,        // Italic text
  ),
);
```

---

### Notes

  **Compatibility:**  
- `titleStyle` and `descriptionStyle` are supported only on **API 24+**.  
- On devices with **API < 24**, these fields are ignored and the system’s default styling is applied.

---

### Tests

  Comprehensive tests have been added in `android_flutter_local_notifications_test.dart` to cover **all newly introduced features**.

---

### Request

I’d appreciate your review and consideration for merging this PR.  
It improves flexibility for Android developers who want finer control over notification appearance.  

Thank you for your time and support
