### PR TITLE
[flutter_local_notifications] Add support for specifying custom Activity to open on notification tap (Android)

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -132,6 +132,7 @@ public class FlutterLocalNotificationsPlugin
   private static final String CALLBACK_HANDLE = "callback_handle";
   private static final String DRAWABLE = "drawable";
   private static final String DEFAULT_ICON = "defaultIcon";
+  private static final String FLUTTER_ACTIVITY = "flutterActivity";
   private static final String SELECT_NOTIFICATION = "SELECT_NOTIFICATION";
   private static final String SELECT_FOREGROUND_NOTIFICATION_ACTION =
       "SELECT_FOREGROUND_NOTIFICATION";
@@ -1001,6 +1002,14 @@ public class FlutterLocalNotificationsPlugin
   }
 
   private static Intent getLaunchIntent(Context context) {
+    SharedPreferences sharedPreferences =
+          context.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
+    String flutterActivity = sharedPreferences.getString(FLUTTER_ACTIVITY, null);
+    if (!StringUtils.isNullOrEmpty(flutterActivity)) {
+      Intent result = new Intent();
+      result.setClassName(context, flutterActivity);
+      return result;
+    }
     String packageName = context.getPackageName();
     PackageManager packageManager = context.getPackageManager();
     return packageManager.getLaunchIntentForPackage(packageName);
@@ -1707,6 +1716,7 @@ public class FlutterLocalNotificationsPlugin
       return;
     }
 
+    String flutterActivity = (String) arguments.get(FLUTTER_ACTIVITY);
     Long dispatcherHandle = LongUtils.parseLong(call.argument(DISPATCHER_HANDLE));
     Long callbackHandle = LongUtils.parseLong(call.argument(CALLBACK_HANDLE));
     if (dispatcherHandle != null && callbackHandle != null) {
@@ -1716,7 +1726,9 @@ public class FlutterLocalNotificationsPlugin
     SharedPreferences sharedPreferences =
         applicationContext.getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = sharedPreferences.edit();
-    editor.putString(DEFAULT_ICON, defaultIcon).apply();
+    editor.putString(DEFAULT_ICON, defaultIcon)
+            .putString(FLUTTER_ACTIVITY, flutterActivity)
+            .apply();
     result.success(true);
   }
 

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -147,7 +147,7 @@ class AndroidFlutterLocalNotificationsPlugin
     _onDidReceiveNotificationResponse = onDidReceiveNotificationResponse;
     _channel.setMethodCallHandler(_handleMethod);
 
-    final Map<String, Object> arguments = initializationSettings.toMap();
+    final Map<String, Object?> arguments = initializationSettings.toMap();
 
     _evaluateBackgroundNotificationCallback(
         onDidReceiveBackgroundNotificationResponse, arguments);
@@ -1051,7 +1051,7 @@ class MacOSFlutterLocalNotificationsPlugin
 void _evaluateBackgroundNotificationCallback(
   DidReceiveBackgroundNotificationResponseCallback?
       didReceiveBackgroundNotificationResponseCallback,
-  Map<String, Object> arguments,
+  Map<String, Object?> arguments,
 ) {
   if (didReceiveBackgroundNotificationResponseCallback != null) {
     final CallbackHandle? callback = PluginUtilities.getCallbackHandle(

--- a/flutter_local_notifications/lib/src/platform_specifics/android/initialization_settings.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/initialization_settings.dart
@@ -1,8 +1,17 @@
 /// Plugin initialization settings for Android.
 class AndroidInitializationSettings {
   /// Constructs an instance of [AndroidInitializationSettings].
-  const AndroidInitializationSettings(this.defaultIcon);
+  const AndroidInitializationSettings(
+    this.defaultIcon, {
+    this.flutterActivity,
+  });
 
   /// Specifies the default icon for notifications.
   final String defaultIcon;
+
+  /// Specifies the fully qualified name of the custom Flutter `Activity` to be launched
+  /// when the notification is tapped.
+  ///
+  /// Example: `com.example.ui.HomeFlutterActivity`
+  final String? flutterActivity;
 }

--- a/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
+++ b/flutter_local_notifications/lib/src/platform_specifics/android/method_channel_mappers.dart
@@ -15,7 +15,10 @@ import 'styles/messaging_style_information.dart';
 
 // ignore_for_file: avoid_as, public_member_api_docs
 extension AndroidInitializationSettingsMapper on AndroidInitializationSettings {
-  Map<String, Object> toMap() => <String, Object>{'defaultIcon': defaultIcon};
+  Map<String, Object?> toMap() => <String, Object?>{
+    'defaultIcon': defaultIcon,
+    'flutterActivity': flutterActivity
+  };
 }
 
 extension MessageMapper on Message {


### PR DESCRIPTION
## Changes
- Added an optional initialization parameter for specifying the target Activity name.
- If the parameter is not provided, the default behavior remains unchanged.

## Why
In some applications, the default launcher Activity is not suitable as a notification entry point. 
This enhancement gives developers more flexibility and control over app navigation from notifications.

## Notes
- Backward compatible: existing code without the new parameter continues to work as before.
