### PR TITLE
[Windows] Remove `details` in `zonedScheduleRawXml()`

### DIFF
--- a/flutter_local_notifications_windows/lib/src/plugin/base.dart
+++ b/flutter_local_notifications_windows/lib/src/plugin/base.dart
@@ -55,7 +55,6 @@ abstract class WindowsNotificationsBase
     int id,
     String xml,
     TZDateTime scheduledDate,
-    WindowsNotificationDetails? details,
   );
 
   /// Updates the progress bar in the notification with the given ID.

--- a/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
+++ b/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
@@ -327,7 +327,6 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
     int id,
     String xml,
     TZDateTime scheduledDate,
-    WindowsNotificationDetails? details,
   ) async =>
       using((Arena arena) {
         if (!_isReady) {

--- a/flutter_local_notifications_windows/lib/src/plugin/stub.dart
+++ b/flutter_local_notifications_windows/lib/src/plugin/stub.dart
@@ -81,7 +81,6 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
     int id,
     String xml,
     TZDateTime scheduledDate,
-    WindowsNotificationDetails? details,
   ) async {}
 
   @override


### PR DESCRIPTION
The `details` parameter was not being used, and should not have been included. My mistake

It's technically a breaking release, but a) this is such a niche function in the plugin, and b) the details were never being used in the first place. So functionally, I'd say this is non-breaking but I'll leave it up to you