### PR TITLE
[flutter_local_notifications] Fix Android notification callback not firing after app auto-start

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1427,7 +1427,7 @@ public class FlutterLocalNotificationsPlugin
       }else if(SELECT_NOTIFICATION.equals(mainActivityIntent.getAction())){
         Map<String, Object> notificationResponse = extractNotificationResponseMap(mainActivityIntent);
         if (SELECT_FOREGROUND_NOTIFICATION_ACTION.equals(mainActivityIntent.getAction())) {
-          processForegroundNotificationAction(intent, notificationResponse);
+          processForegroundNotificationAction(mainActivityIntent, notificationResponse);
         }
         channel.invokeMethod("didReceiveNotificationResponse", notificationResponse);
       }


### PR DESCRIPTION
Fixed an issue on the Android platform where clicking a notification after the app auto-started would not trigger the onDidReceiveNotificationResponse callback.
The original implementation only handled the onNewIntent scenario. However, when the app was auto-restarted in the background (e.g., by JobScheduler or other mechanisms), clicking a notification did not invoke the expected callback. To address this, additional logic was added in the onAttachedToActivity callback to parse and handle the specific notification action.