### PR TITLE
[flutter_local_notifications] Add openAppNotificationSettings() for Android and iOS

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -100,11 +100,13 @@ Note: the plugin requires Flutter SDK 3.22 at a minimum. The list of support pla
 * [Android] Full-screen intent notifications
 * [Android] Start a foreground service
 * [Android] Ability to check if notifications are enabled
+* [Android] Open app notification settings
 * [iOS (all supported versions) & macOS 10.14+] Request notification permissions and customise the permissions being requested around displaying notifications
 * [iOS 10+] Request CarPlay notification permissions for notifications to appear in CarPlay interface
 * [iOS 10 or newer and macOS 10.14 or newer] Display notifications with attachments
 * [iOS 12.0+] Support for custom notification settings UI via "Configure Notifications in <application name>" button in notification context menu (API available on macOS 10.14+ but UI button does not appear in practice)
 * [iOS and macOS 10.14 or newer] Ability to check if notifications are enabled with specific type check
+* [iOS 15.4+] Attempt to open the app's notification settings page (falls back to app settings on older iOS versions)
 * [Linux] Ability to to use themed/Flutter Assets icons and sound
 * [Linux] Ability to to set the category
 * [Linux] Configuring the urgency

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -367,6 +367,36 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> _openAppNotificationSettingsOnIOS() async {
+    final IOSFlutterLocalNotificationsPlugin? iosImplementation =
+        flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin
+            >();
+
+    final bool opened =
+        await iosImplementation?.openAppNotificationSettings() ?? false;
+
+    if (!opened && mounted) {
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          content: const Text(
+            'Unable to open the app settings page on this device.',
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
   void _configureSelectNotificationSubject() {
     selectNotificationStream.stream.listen((
       NotificationResponse? response,
@@ -853,6 +883,11 @@ class _HomePageState extends State<HomePage> {
                   buttonText: 'Request permission',
                   onPressed: _requestPermissions,
                 ),
+                if (Platform.isIOS)
+                  PaddedElevatedButton(
+                    buttonText: 'Open notification settings',
+                    onPressed: _openAppNotificationSettingsOnIOS,
+                  ),
                 PaddedElevatedButton(
                   buttonText:
                       'Request permission with critical alert permission',

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -337,6 +337,36 @@ class _HomePageState extends State<HomePage> {
     await androidImplementation?.requestNotificationPolicyAccess();
   }
 
+  Future<void> _openAppNotificationSettings() async {
+    final AndroidFlutterLocalNotificationsPlugin? androidImplementation =
+        flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin
+            >();
+
+    final bool opened =
+        await androidImplementation?.openAppNotificationSettings() ?? false;
+
+    if (!opened && mounted) {
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          content: const Text(
+            'Unable to open the app notification settings screen on this device.',
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
   void _configureSelectNotificationSubject() {
     selectNotificationStream.stream.listen((
       NotificationResponse? response,
@@ -540,6 +570,10 @@ class _HomePageState extends State<HomePage> {
                 PaddedElevatedButton(
                   buttonText: 'Check if notifications are enabled for this app',
                   onPressed: _areNotifcationsEnabledOnAndroid,
+                ),
+                PaddedElevatedButton(
+                  buttonText: 'Open app notification settings',
+                  onPressed: _openAppNotificationSettings,
                 ),
                 PaddedElevatedButton(
                   buttonText: 'Request permission (API 33+)',

--- a/flutter_local_notifications/example/lib/main.dart
+++ b/flutter_local_notifications/example/lib/main.dart
@@ -338,14 +338,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _openAppNotificationSettings() async {
-    final AndroidFlutterLocalNotificationsPlugin? androidImplementation =
-        flutterLocalNotificationsPlugin
-            .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin
-            >();
-
     final bool opened =
-        await androidImplementation?.openAppNotificationSettings() ?? false;
+        await flutterLocalNotificationsPlugin.openAppNotificationSettings() ??
+        false;
 
     if (!opened && mounted) {
       await showDialog<void>(
@@ -353,36 +348,6 @@ class _HomePageState extends State<HomePage> {
         builder: (BuildContext context) => AlertDialog(
           content: const Text(
             'Unable to open the app notification settings screen on this device.',
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
-    }
-  }
-
-  Future<void> _openAppNotificationSettingsOnIOS() async {
-    final IOSFlutterLocalNotificationsPlugin? iosImplementation =
-        flutterLocalNotificationsPlugin
-            .resolvePlatformSpecificImplementation<
-              IOSFlutterLocalNotificationsPlugin
-            >();
-
-    final bool opened =
-        await iosImplementation?.openAppNotificationSettings() ?? false;
-
-    if (!opened && mounted) {
-      await showDialog<void>(
-        context: context,
-        builder: (BuildContext context) => AlertDialog(
-          content: const Text(
-            'Unable to open the app settings page on this device.',
           ),
           actions: <Widget>[
             TextButton(
@@ -886,7 +851,7 @@ class _HomePageState extends State<HomePage> {
                 if (Platform.isIOS)
                   PaddedElevatedButton(
                     buttonText: 'Open notification settings',
-                    onPressed: _openAppNotificationSettingsOnIOS,
+                    onPressed: _openAppNotificationSettings,
                   ),
                 PaddedElevatedButton(
                   buttonText:

--- a/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Sources/flutter_local_notifications/FlutterLocalNotificationsPlugin.m
@@ -225,35 +225,49 @@ static FlutterError *getFlutterError(NSError *error) {
 }
 
 - (void)openAppNotificationSettings:(FlutterResult _Nonnull)result {
-  NSString *urlString = UIApplicationOpenSettingsURLString;
-  // Note: iOS provides UIApplicationOpenNotificationSettingsURLString (iOS 15.4+),
-  // but some iOS versions/devices may still redirect to the Settings app root.
-  // Opening the app's Settings page is the most reliable way to guide users to
-  // notification settings across iOS versions.
-
-  NSURL *url = [NSURL URLWithString:urlString];
-  if (url == nil) {
-    result(@(NO));
-    return;
-  }
-
+  // Best-effort: open this app's notification settings in the Settings app.
+  // On iOS 15.4+, UIApplicationOpenNotificationSettingsURLString deep links to
+  // the app's Notifications page. If that fails or is unavailable, fall back
+  // to UIApplicationOpenSettingsURLString (this app's page in Settings).
+  // Fallback is based on openURL reporting failure, not canOpenURL.
+  // Note: even on supported versions, the destination screen may vary by
+  // OS/device configuration.
   dispatch_async(dispatch_get_main_queue(), ^{
     UIApplication *application = [UIApplication sharedApplication];
-    if (![application canOpenURL:url]) {
-      result(@(NO));
-      return;
+
+    void (^openAppSettings)(void) = ^{
+      NSURL *settingsUrl =
+          [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+      if (settingsUrl == nil) {
+        result(@(NO));
+        return;
+      }
+
+      [application openURL:settingsUrl
+                     options:@{}
+           completionHandler:^(BOOL success) {
+             result(@(success));
+           }];
+    };
+
+    if (@available(iOS 15.4, *)) {
+      NSURL *notificationSettingsUrl = [NSURL
+          URLWithString:UIApplicationOpenNotificationSettingsURLString];
+      if (notificationSettingsUrl != nil) {
+        [application openURL:notificationSettingsUrl
+                       options:@{}
+             completionHandler:^(BOOL success) {
+               if (success) {
+                 result(@(YES));
+               } else {
+                 openAppSettings();
+               }
+             }];
+        return;
+      }
     }
 
-    if (@available(iOS 10.0, *)) {
-      [application openURL:url
-                   options:@{}
-         completionHandler:^(BOOL success) {
-           result(@(success));
-         }];
-    } else {
-      BOOL success = [application openURL:url];
-      result(@(success));
-    }
+    openAppSettings();
   });
 }
 

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -605,6 +605,23 @@ class FlutterLocalNotificationsPlugin {
   Future<List<PendingNotificationRequest>> pendingNotificationRequests() =>
       FlutterLocalNotificationsPlatform.instance.pendingNotificationRequests();
 
+  /// Opens the system settings UI where the user can manage notification
+  /// permissions for the app.
+  ///
+  /// On iOS, this will attempt to open the app's notification settings page and
+  /// fall back to opening the app's Settings page when needed.
+  ///
+  /// On platforms that don't support this API, an [UnimplementedError] will be
+  /// thrown.
+  Future<bool?> openAppNotificationSettings() {
+    if (kIsWeb) {
+      throw UnimplementedError(
+        'openAppNotificationSettings() is not supported on web',
+      );
+    }
+    return FlutterLocalNotificationsPlatform.instance.openAppNotificationSettings();
+  }
+
   /// Returns the list of active notifications shown by the application that
   /// haven't been dismissed/removed.
   ///

--- a/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
+++ b/flutter_local_notifications/lib/src/flutter_local_notifications_plugin.dart
@@ -619,7 +619,8 @@ class FlutterLocalNotificationsPlugin {
         'openAppNotificationSettings() is not supported on web',
       );
     }
-    return FlutterLocalNotificationsPlatform.instance.openAppNotificationSettings();
+    return FlutterLocalNotificationsPlatform.instance
+        .openAppNotificationSettings();
   }
 
   /// Returns the list of active notifications shown by the application that

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -625,6 +625,9 @@ class AndroidFlutterLocalNotificationsPlugin
 
   /// Opens the operating system notification settings screen for this app.
   ///
+  /// On Android, this attempts to open the app's notification settings screen
+  /// and falls back to the app details screen if needed.
+  ///
   /// Returns whether an activity could be launched.
   Future<bool?> openAppNotificationSettings() async =>
       await _channel.invokeMethod<bool>('openAppNotificationSettings');
@@ -791,6 +794,20 @@ class IOSFlutterLocalNotificationsPlugin
           isCarPlayEnabled: dict['isCarPlayEnabled'] ?? false,
         );
       });
+
+  /// Opens the system settings UI where the user can manage notification
+  /// permissions for the app.
+  ///
+  /// On iOS 15.4 and newer, this attempts to open the app's Notifications
+  /// settings page. If that's not possible, it falls back to opening the app's
+  /// Settings page.
+  ///
+  /// Note that iOS may still redirect to the Settings app root depending on the
+  /// OS version and device configuration.
+  ///
+  /// Returns whether the settings page could be opened.
+  Future<bool?> openAppNotificationSettings() async =>
+      await _channel.invokeMethod<bool>('openAppNotificationSettings');
 
   /// Schedules a notification to be shown at the specified time in the
   /// future in a specific time zone.

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -623,6 +623,12 @@ class AndroidFlutterLocalNotificationsPlugin
   Future<bool?> areNotificationsEnabled() async =>
       await _channel.invokeMethod<bool>('areNotificationsEnabled');
 
+  /// Opens the operating system notification settings screen for this app.
+  ///
+  /// Returns whether an activity could be launched.
+  Future<bool?> openAppNotificationSettings() async =>
+      await _channel.invokeMethod<bool>('openAppNotificationSettings');
+
   /// Returns whether the app can schedule exact notifications.
   Future<bool?> canScheduleExactNotifications() async =>
       await _channel.invokeMethod<bool>('canScheduleExactNotifications');

--- a/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
+++ b/flutter_local_notifications/lib/src/platform_flutter_local_notifications.dart
@@ -629,6 +629,7 @@ class AndroidFlutterLocalNotificationsPlugin
   /// and falls back to the app details screen if needed.
   ///
   /// Returns whether an activity could be launched.
+  @override
   Future<bool?> openAppNotificationSettings() async =>
       await _channel.invokeMethod<bool>('openAppNotificationSettings');
 
@@ -806,6 +807,7 @@ class IOSFlutterLocalNotificationsPlugin
   /// OS version and device configuration.
   ///
   /// Returns whether the settings page could be opened.
+  @override
   Future<bool?> openAppNotificationSettings() async =>
       await _channel.invokeMethod<bool>('openAppNotificationSettings');
 

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -38,6 +38,8 @@ void main() {
               return <Map<String, Object?>>[];
             } else if (methodCall.method == 'getNotificationAppLaunchDetails') {
               return null;
+            } else if (methodCall.method == 'openAppNotificationSettings') {
+              return true;
             }
             return null;
           });
@@ -2983,6 +2985,19 @@ void main() {
       expect(
         log.last,
         isMethodCall('areNotificationsEnabled', arguments: null),
+      );
+    });
+
+    test('openAppNotificationSettings', () async {
+      final bool? opened = await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >()!
+          .openAppNotificationSettings();
+      expect(opened, isTrue);
+      expect(
+        log.last,
+        isMethodCall('openAppNotificationSettings', arguments: null),
       );
     });
 

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -3001,6 +3001,16 @@ void main() {
       );
     });
 
+    test('openAppNotificationSettings (cross-platform)', () async {
+      final bool? opened =
+          await flutterLocalNotificationsPlugin.openAppNotificationSettings();
+      expect(opened, isTrue);
+      expect(
+        log.last,
+        isMethodCall('openAppNotificationSettings', arguments: null),
+      );
+    });
+
     test('startForegroundServiceWithBlueBackgroundNotification', () async {
       const AndroidInitializationSettings androidInitializationSettings =
           AndroidInitializationSettings('app_icon');

--- a/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/android_flutter_local_notifications_test.dart
@@ -3002,8 +3002,8 @@ void main() {
     });
 
     test('openAppNotificationSettings (cross-platform)', () async {
-      final bool? opened =
-          await flutterLocalNotificationsPlugin.openAppNotificationSettings();
+      final bool? opened = await flutterLocalNotificationsPlugin
+          .openAppNotificationSettings();
       expect(opened, isTrue);
       expect(
         log.last,

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -31,6 +31,8 @@ void main() {
               return <Map<String, Object>?>[];
             } else if (methodCall.method == 'getNotificationAppLaunchDetails') {
               return null;
+            } else if (methodCall.method == 'openAppNotificationSettings') {
+              return true;
             }
             return null;
           });
@@ -916,6 +918,19 @@ void main() {
           >()!
           .checkPermissions();
       expect(log, <Matcher>[isMethodCall('checkPermissions', arguments: null)]);
+    });
+
+    test('openAppNotificationSettings', () async {
+      final bool? opened = await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin
+          >()!
+          .openAppNotificationSettings();
+      expect(opened, isTrue);
+      expect(
+        log.last,
+        isMethodCall('openAppNotificationSettings', arguments: null),
+      );
     });
 
     test('cancel', () async {

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -933,6 +933,16 @@ void main() {
       );
     });
 
+    test('openAppNotificationSettings (cross-platform)', () async {
+      final bool? opened =
+          await flutterLocalNotificationsPlugin.openAppNotificationSettings();
+      expect(opened, isTrue);
+      expect(
+        log.last,
+        isMethodCall('openAppNotificationSettings', arguments: null),
+      );
+    });
+
     test('cancel', () async {
       await flutterLocalNotificationsPlugin.cancel(id: 1);
       expect(log, <Matcher>[isMethodCall('cancel', arguments: 1)]);

--- a/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
+++ b/flutter_local_notifications/test/ios_flutter_local_notifications_test.dart
@@ -934,8 +934,8 @@ void main() {
     });
 
     test('openAppNotificationSettings (cross-platform)', () async {
-      final bool? opened =
-          await flutterLocalNotificationsPlugin.openAppNotificationSettings();
+      final bool? opened = await flutterLocalNotificationsPlugin
+          .openAppNotificationSettings();
       expect(opened, isTrue);
       expect(
         log.last,

--- a/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
+++ b/flutter_local_notifications_platform_interface/lib/flutter_local_notifications_platform_interface.dart
@@ -101,6 +101,16 @@ abstract class FlutterLocalNotificationsPlatform extends PlatformInterface {
     );
   }
 
+  /// Opens the system settings UI where the user can manage notification
+  /// permissions for the app.
+  ///
+  /// Returns whether the settings page could be opened.
+  Future<bool?> openAppNotificationSettings() async {
+    throw UnimplementedError(
+      'openAppNotificationSettings() has not been implemented',
+    );
+  }
+
   /// Returns a list of notifications pending to be delivered/shown
   Future<List<PendingNotificationRequest>> pendingNotificationRequests() {
     throw UnimplementedError(


### PR DESCRIPTION
Closes #2752

## Summary
- Add `openAppNotificationSettings()` to Android and iOS platform implementations.
- Android opens the app’s notification settings screen (falls back to app settings if needed).
- iOS attempts to open the app’s notification settings (iOS 15.4+), otherwise it falls back to app settings (iOS may still redirect depending on OS/device).

## Test plan
- `cd flutter_local_notifications && flutter test`
- Manual: verified from example app on Android emulator and iOS simulator/device