### PR TITLE
[flutter_local_notifications] highlight app row when opening DND access settings

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1984,9 +1984,15 @@ public class FlutterLocalNotificationsPlugin
       permissionRequestProgress = PermissionRequestProgress.None;
     } else {
       permissionRequestProgress = PermissionRequestProgress.RequestingNotificationPolicyAccess;
-      mainActivity.startActivityForResult(
-          new Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS),
-          NOTIFICATION_POLICY_ACCESS_REQUEST_CODE);
+      // Highlights the app's row on the settings list.
+      String pkg = applicationContext.getPackageName();
+      Bundle highlightArgs = new Bundle();
+      highlightArgs.putString(":settings:fragment_args_key", pkg);
+      Intent intent =
+          new Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+              .putExtra(":settings:fragment_args_key", pkg)
+              .putExtra(":settings:show_fragment_args", highlightArgs);
+      mainActivity.startActivityForResult(intent, NOTIFICATION_POLICY_ACCESS_REQUEST_CODE);
     }
   }
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1985,12 +1985,12 @@ public class FlutterLocalNotificationsPlugin
     } else {
       permissionRequestProgress = PermissionRequestProgress.RequestingNotificationPolicyAccess;
       // Highlights the app's row on the settings list.
-      String pkg = applicationContext.getPackageName();
+      String packageName = applicationContext.getPackageName();
       Bundle highlightArgs = new Bundle();
-      highlightArgs.putString(":settings:fragment_args_key", pkg);
+      highlightArgs.putString(":settings:fragment_args_key", packageName);
       Intent intent =
           new Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
-              .putExtra(":settings:fragment_args_key", pkg)
+              .putExtra(":settings:fragment_args_key", packageName)
               .putExtra(":settings:show_fragment_args", highlightArgs);
       mainActivity.startActivityForResult(intent, NOTIFICATION_POLICY_ACCESS_REQUEST_CODE);
     }


### PR DESCRIPTION
When `requestNotificationPolicyAccess()` is called, the plugin opens `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` - a system page listing every installed app. The user then has to scroll the list and locate the calling app themselves, which is a poor UX for a permission the app just prompted for.
                                                                                                                                                                                                                                  
This PR attaches the `:settings:fragment_args_key` and `:settings:show_fragment_args` extras (with the package name as the key) to the launch intent. Android's Settings app uses these to scroll the matching row into view and briefly highlight it.