### PR TITLE
[various] updated gitignore to match latest defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,37 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.build/
+.buildlog/
+.history
+.svn/
+.swiftpm/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# VS Code related
+.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
-.vscode
-*.idea
-*.DS_Store
-.dart_tool
-*.dll
+**/doc/api/
+.dart_tool/
+.flutter-plugins-dependencies
+/build/
+/coverage/
 
 # Melos
 pubspec_overrides.yaml
+
+# SPM related
+Package.resolved


### PR DESCRIPTION
Updated .gitignore file to match the latest out of the box .gitignore file when using the Flutter tooling to create a plugin.
