### PR TITLE
[various] suppress experimental coroutine deprecation warnings showing up for Windows plugin

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -207,7 +207,7 @@ jobs:
           dart run msix:create
   build_example_windows_min_flutter:
     name: Build Windows example app (3.38.1)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [22.0.1]
 
 * [Windows] Suppress warning around usage of experimental coroutines. This is to fix issue [#2777](https://github.com/MaikuB/flutter_local_notifications/issues/2777)
-* 
+
 ## [22.0.0]
 
 * [Android] calling the `requestNotificationPolicyAccess()` method belonging to the `AndroidFlutterLocalNotificationsPlugin` class will now highlight associated application. Thanks to the PR from [Claudius Kienle](https://github.com/claudius-kienle)

--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [22.0.1]
+
+* [Windows] Suppress warning around usage of experimental coroutines. This is to fix issue [#2777](https://github.com/MaikuB/flutter_local_notifications/issues/2777)
+* 
 ## [22.0.0]
 
 * [Android] calling the `requestNotificationPolicyAccess()` method belonging to the `AndroidFlutterLocalNotificationsPlugin` class will now highlight associated application. Thanks to the PR from [Claudius Kienle](https://github.com/claudius-kienle)

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 22.0.0
+version: 22.0.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_local_notifications_linux: ^8.0.1
-  flutter_local_notifications_windows: ^3.1.0
+  flutter_local_notifications_windows: ^3.1.1
   flutter_local_notifications_web: ^1.0.0
   flutter_local_notifications_platform_interface: ^12.0.0
   timezone: ^0.11.0

--- a/flutter_local_notifications_windows/CHANGELOG.md
+++ b/flutter_local_notifications_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.1]
+
+* Suppress warning around usage of experimental coroutines. This is to fix issue [#2777](https://github.com/MaikuB/flutter_local_notifications/issues/2777)
+
 ## [3.1.0]
 
 * Updated `periodicallyShow()` to accept `payload` and `notificationDetails` as optional parameters

--- a/flutter_local_notifications_windows/pubspec.yaml
+++ b/flutter_local_notifications_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_local_notifications_windows
 description: Windows implementation of the flutter_local_notifications plugin
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications_windows
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 

--- a/flutter_local_notifications_windows/src/CMakeLists.txt
+++ b/flutter_local_notifications_windows/src/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(flutter_local_notifications_windows_library VERSION 1.0.0 LANGUAGES CXX)
 
+add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 add_library(flutter_local_notifications_windows SHARED
   "ffi_api.cpp"
   "plugin.cpp"


### PR DESCRIPTION
Fixes #2777 

PR also updates the Windows minimum-Flutter CI job to restore compatibility for the example MSIX build