### PR TITLE
[flutter_local_notifications_windows] Fix Issue #2615 for windows build failure

### DIFF
--- a/flutter_local_notifications_windows/lib/src/ffi/bindings.dart
+++ b/flutter_local_notifications_windows/lib/src/ffi/bindings.dart
@@ -302,16 +302,16 @@ class NotificationsPluginBindings {
       .asFunction<void Function(ffi.Pointer<NativeNotificationDetails>)>();
 
   /// Releases the memory associated with a [NativeLaunchDetails].
-  void freeLaunchDetails(NativeLaunchDetails details) {
+  void freeLaunchDetails(ffi.Pointer<NativeLaunchDetails> details) {
     return _freeLaunchDetails(details);
   }
 
   late final _freeLaunchDetailsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(NativeLaunchDetails)>>(
-        'freeLaunchDetails',
-      );
+      _lookup<
+        ffi.NativeFunction<ffi.Void Function(ffi.Pointer<NativeLaunchDetails>)>
+      >('freeLaunchDetails');
   late final _freeLaunchDetails = _freeLaunchDetailsPtr
-      .asFunction<void Function(NativeLaunchDetails)>();
+      .asFunction<void Function(ffi.Pointer<NativeLaunchDetails>)>();
 }
 
 final class NativePlugin extends ffi.Opaque {}
@@ -353,7 +353,7 @@ enum NativeLaunchType {
 }
 
 /// Details about how the app was launched.
-final class NativeLaunchDetails extends ffi.Struct {
+base class NativeLaunchDetails extends ffi.Struct {
   /// Whether the app was launched by a notification
   @ffi.Bool()
   external bool didLaunch;
@@ -362,20 +362,24 @@ final class NativeLaunchDetails extends ffi.Struct {
   @ffi.UnsignedInt()
   external int launchTypeAsInt;
 
-  NativeLaunchType get launchType =>
-      NativeLaunchType.fromValue(launchTypeAsInt);
-
   /// The payload sent to the app by the notification. Usually the action that was pressed.
   external ffi.Pointer<pkg_ffi.Utf8> payload;
 
   /// The IDs and values of any text inputs in the notification.
-  external NativeStringMap data;
+  ///
+  /// Flattened from NativeStringMap to avoid AOT snapshotter crashes with
+  /// nested FFI structs. These two fields correspond to NativeStringMap's
+  /// `entries` and `size` at the same offsets.
+  external ffi.Pointer<StringMapEntry> data_entries;
+
+  @ffi.Int()
+  external int data_size;
 }
 
 typedef NativeNotificationCallbackFunction =
-    ffi.Void Function(NativeLaunchDetails details);
+    ffi.Void Function(ffi.Pointer<NativeLaunchDetails> details);
 typedef DartNativeNotificationCallbackFunction =
-    void Function(NativeLaunchDetails details);
+    void Function(ffi.Pointer<NativeLaunchDetails> details);
 
 /// A callback that is run with [NativeLaunchDetails] when a notification is pressed.
 ///

--- a/flutter_local_notifications_windows/lib/src/ffi/bindings.dart
+++ b/flutter_local_notifications_windows/lib/src/ffi/bindings.dart
@@ -301,17 +301,33 @@ class NotificationsPluginBindings {
   late final _freeDetailsArray = _freeDetailsArrayPtr
       .asFunction<void Function(ffi.Pointer<NativeNotificationDetails>)>();
 
-  /// Releases the memory associated with a [NativeLaunchDetails].
-  void freeLaunchDetails(ffi.Pointer<NativeLaunchDetails> details) {
-    return _freeLaunchDetails(details);
+  /// Releases memory allocated for launch details (payload and data entries).
+  void freeLaunchDetails(
+    ffi.Pointer<pkg_ffi.Utf8> payload,
+    ffi.Pointer<StringMapEntry> entries,
+    int size,
+  ) {
+    return _freeLaunchDetails(payload, entries, size);
   }
 
   late final _freeLaunchDetailsPtr =
       _lookup<
-        ffi.NativeFunction<ffi.Void Function(ffi.Pointer<NativeLaunchDetails>)>
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<pkg_ffi.Utf8>,
+            ffi.Pointer<StringMapEntry>,
+            ffi.Int,
+          )
+        >
       >('freeLaunchDetails');
   late final _freeLaunchDetails = _freeLaunchDetailsPtr
-      .asFunction<void Function(ffi.Pointer<NativeLaunchDetails>)>();
+      .asFunction<
+        void Function(
+          ffi.Pointer<pkg_ffi.Utf8>,
+          ffi.Pointer<StringMapEntry>,
+          int,
+        )
+      >();
 }
 
 final class NativePlugin extends ffi.Opaque {}
@@ -352,36 +368,24 @@ enum NativeLaunchType {
   };
 }
 
-/// Details about how the app was launched.
-base class NativeLaunchDetails extends ffi.Struct {
-  /// Whether the app was launched by a notification
-  @ffi.Bool()
-  external bool didLaunch;
-
-  /// What part of the notification launched the app.
-  @ffi.UnsignedInt()
-  external int launchTypeAsInt;
-
-  /// The payload sent to the app by the notification. Usually the action that was pressed.
-  external ffi.Pointer<pkg_ffi.Utf8> payload;
-
-  /// The IDs and values of any text inputs in the notification.
-  ///
-  /// Flattened from NativeStringMap to avoid AOT snapshotter crashes with
-  /// nested FFI structs. These two fields correspond to NativeStringMap's
-  /// `entries` and `size` at the same offsets.
-  external ffi.Pointer<StringMapEntry> data_entries;
-
-  @ffi.Int()
-  external int data_size;
-}
-
 typedef NativeNotificationCallbackFunction =
-    ffi.Void Function(ffi.Pointer<NativeLaunchDetails> details);
+    ffi.Void Function(
+      ffi.Int didLaunch,
+      ffi.Int launchType,
+      ffi.Pointer<pkg_ffi.Utf8> payload,
+      ffi.Pointer<StringMapEntry> dataEntries,
+      ffi.Int dataSize,
+    );
 typedef DartNativeNotificationCallbackFunction =
-    void Function(ffi.Pointer<NativeLaunchDetails> details);
+    void Function(
+      int didLaunch,
+      int launchType,
+      ffi.Pointer<pkg_ffi.Utf8> payload,
+      ffi.Pointer<StringMapEntry> dataEntries,
+      int dataSize,
+    );
 
-/// A callback that is run with [NativeLaunchDetails] when a notification is pressed.
+/// A callback that is run with raw launch details when a notification is pressed.
 ///
 /// This may be called at app launch or even while the app is running.
 typedef NativeNotificationCallback =

--- a/flutter_local_notifications_windows/lib/src/ffi/utils.dart
+++ b/flutter_local_notifications_windows/lib/src/ffi/utils.dart
@@ -16,6 +16,16 @@ extension NativeStringMapUtils on NativeStringMap {
   };
 }
 
+/// Helpful methods on launch details with flattened data fields.
+extension NativeLaunchDetailsUtils on NativeLaunchDetails {
+  /// Converts the flattened data fields back into a Dart map.
+  Map<String, String> dataToMap() => <String, String>{
+    for (int index = 0; index < data_size; index++)
+      data_entries[index].key.toDartString(): data_entries[index].value
+          .toDartString(),
+  };
+}
+
 /// Gets the [NotificationResponseType] from a [NativeLaunchType].
 NotificationResponseType getResponseType(NativeLaunchType launchType) {
   switch (launchType) {

--- a/flutter_local_notifications_windows/lib/src/ffi/utils.dart
+++ b/flutter_local_notifications_windows/lib/src/ffi/utils.dart
@@ -16,16 +16,6 @@ extension NativeStringMapUtils on NativeStringMap {
   };
 }
 
-/// Helpful methods on launch details with flattened data fields.
-extension NativeLaunchDetailsUtils on NativeLaunchDetails {
-  /// Converts the flattened data fields back into a Dart map.
-  Map<String, String> dataToMap() => <String, String>{
-    for (int index = 0; index < data_size; index++)
-      data_entries[index].key.toDartString(): data_entries[index].value
-          .toDartString(),
-  };
-}
-
 /// Gets the [NotificationResponseType] from a [NativeLaunchType].
 NotificationResponseType getResponseType(NativeLaunchType launchType) {
   switch (launchType) {

--- a/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
+++ b/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
@@ -9,7 +9,7 @@ import '../ffi/utils.dart';
 
 import 'base.dart';
 
-void _globalLaunchCallback(NativeLaunchDetails details) {
+void _globalLaunchCallback(Pointer<NativeLaunchDetails> details) {
   FlutterLocalNotificationsWindows.instance?._onDidReceiveNotificationResponse(
     details,
   );
@@ -56,7 +56,7 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
   /// If the app is opened with a notification, this can be read with
   /// [getNotificationAppLaunchDetails]. If a notification is pressed while the
   /// app is running, this will be passed to [userCallback].
-  NativeLaunchDetails? _details;
+  Pointer<NativeLaunchDetails>? _details;
 
   /// A callback from [initialize] to run when a notification is pressed.
   DidReceiveNotificationResponseCallback? userCallback;
@@ -116,18 +116,20 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
     _isReady = false;
   }
 
-  void _onDidReceiveNotificationResponse(NativeLaunchDetails details) {
+  void _onDidReceiveNotificationResponse(Pointer<NativeLaunchDetails> details) {
     if (!_isReady) {
       return;
     } else if (_details != null) {
       _bindings.freeLaunchDetails(_details!);
     }
     _details = details;
-    final Map<String, String> data = details.data.toMap();
+    final NativeLaunchDetails nativeDetails = details.ref;
+    final Map<String, String> data = nativeDetails.dataToMap();
     final NotificationResponse response = NotificationResponse(
-      notificationResponseType: getResponseType(details.launchType),
-      payload: details.payload.toDartString(),
-      actionId: details.payload.toDartString(),
+      notificationResponseType: getResponseType(
+          NativeLaunchType.fromValue(nativeDetails.launchTypeAsInt)),
+      payload: nativeDetails.payload.toDartString(),
+      actionId: nativeDetails.payload.toDartString(),
       data: data,
     );
     userCallback?.call(response);
@@ -197,17 +199,19 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
         'Flutter Local Notifications must be initialized before use',
       );
     }
-    final NativeLaunchDetails? details = _details;
+    final Pointer<NativeLaunchDetails>? details = _details;
     if (details == null) {
       return null;
     }
-    final Map<String, String> data = details.data.toMap();
+    final NativeLaunchDetails nativeDetails = details.ref;
+    final Map<String, String> data = nativeDetails.dataToMap();
     return NotificationAppLaunchDetails(
-      details.didLaunch,
+      nativeDetails.didLaunch,
       notificationResponse: NotificationResponse(
-        notificationResponseType: getResponseType(details.launchType),
-        payload: details.payload.toDartString(),
-        actionId: details.payload.toDartString(),
+        notificationResponseType: getResponseType(
+            NativeLaunchType.fromValue(nativeDetails.launchTypeAsInt)),
+        payload: nativeDetails.payload.toDartString(),
+        actionId: nativeDetails.payload.toDartString(),
         data: data,
       ),
     );

--- a/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
+++ b/flutter_local_notifications_windows/lib/src/plugin/ffi.dart
@@ -9,10 +9,49 @@ import '../ffi/utils.dart';
 
 import 'base.dart';
 
-void _globalLaunchCallback(Pointer<NativeLaunchDetails> details) {
+/// Holds launch details read from a native callback.
+/// Memory is freed immediately in the callback, so we store Dart values.
+class _LaunchDetails {
+  final bool didLaunch;
+  final NativeLaunchType launchType;
+  final String payload;
+  final Map<String, String> data;
+
+  _LaunchDetails({
+    required this.didLaunch,
+    required this.launchType,
+    required this.payload,
+    required this.data,
+  });
+}
+
+void _globalLaunchCallback(
+  int didLaunch,
+  int launchType,
+  Pointer<Utf8> payload,
+  Pointer<StringMapEntry> dataEntries,
+  int dataSize,
+) {
   FlutterLocalNotificationsWindows.instance?._onDidReceiveNotificationResponse(
-    details,
+    _LaunchDetails(
+      didLaunch: didLaunch != 0,
+      launchType: NativeLaunchType.fromValue(launchType),
+      payload: payload.toDartString(),
+      data: () {
+        final map = <String, String>{};
+        for (int i = 0; i < dataSize; i++) {
+          map[dataEntries[i].key.toDartString()] = dataEntries[i].value
+              .toDartString();
+        }
+        return map;
+      }(),
+    ),
   );
+  // Free native memory immediately; values are already copied into Dart.
+  final bindings = FlutterLocalNotificationsWindows.instance?._bindings;
+  if (bindings != null) {
+    bindings.freeLaunchDetails(payload, dataEntries, dataSize);
+  }
 }
 
 extension on String {
@@ -56,7 +95,7 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
   /// If the app is opened with a notification, this can be read with
   /// [getNotificationAppLaunchDetails]. If a notification is pressed while the
   /// app is running, this will be passed to [userCallback].
-  Pointer<NativeLaunchDetails>? _details;
+  _LaunchDetails? _details;
 
   /// A callback from [initialize] to run when a notification is pressed.
   DidReceiveNotificationResponseCallback? userCallback;
@@ -116,21 +155,16 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
     _isReady = false;
   }
 
-  void _onDidReceiveNotificationResponse(Pointer<NativeLaunchDetails> details) {
+  void _onDidReceiveNotificationResponse(_LaunchDetails details) {
     if (!_isReady) {
       return;
-    } else if (_details != null) {
-      _bindings.freeLaunchDetails(_details!);
     }
     _details = details;
-    final NativeLaunchDetails nativeDetails = details.ref;
-    final Map<String, String> data = nativeDetails.dataToMap();
     final NotificationResponse response = NotificationResponse(
-      notificationResponseType: getResponseType(
-          NativeLaunchType.fromValue(nativeDetails.launchTypeAsInt)),
-      payload: nativeDetails.payload.toDartString(),
-      actionId: nativeDetails.payload.toDartString(),
-      data: data,
+      notificationResponseType: getResponseType(details.launchType),
+      payload: details.payload,
+      actionId: details.payload,
+      data: details.data,
     );
     userCallback?.call(response);
   }
@@ -199,20 +233,17 @@ class FlutterLocalNotificationsWindows extends WindowsNotificationsBase {
         'Flutter Local Notifications must be initialized before use',
       );
     }
-    final Pointer<NativeLaunchDetails>? details = _details;
+    final _LaunchDetails? details = _details;
     if (details == null) {
       return null;
     }
-    final NativeLaunchDetails nativeDetails = details.ref;
-    final Map<String, String> data = nativeDetails.dataToMap();
     return NotificationAppLaunchDetails(
-      nativeDetails.didLaunch,
+      details.didLaunch,
       notificationResponse: NotificationResponse(
-        notificationResponseType: getResponseType(
-            NativeLaunchType.fromValue(nativeDetails.launchTypeAsInt)),
-        payload: nativeDetails.payload.toDartString(),
-        actionId: nativeDetails.payload.toDartString(),
-        data: data,
+        notificationResponseType: getResponseType(details.launchType),
+        payload: details.payload,
+        actionId: details.payload,
+        data: details.data,
       ),
     );
   }

--- a/flutter_local_notifications_windows/src/ffi_api.cpp
+++ b/flutter_local_notifications_windows/src/ffi_api.cpp
@@ -149,12 +149,13 @@ NativeNotificationDetails* getPendingNotifications(NativePlugin* plugin, int* si
 
 void freeDetailsArray(NativeNotificationDetails* ptr) { delete[] ptr; }
 
-void freeLaunchDetails(NativeLaunchDetails details) {
-  if (details.payload != nullptr) delete[] details.payload;
-  for (int index = 0; index < details.data.size; index++) {
-    const auto pair = details.data.entries[index];
+void freeLaunchDetails(NativeLaunchDetails* details) {
+  if (details->payload != nullptr) delete[] details->payload;
+  for (int index = 0; index < details->data.size; index++) {
+    const auto pair = details->data.entries[index];
     delete pair.key;
     delete pair.value;
   }
-  if (details.data.entries != nullptr) delete[] details.data.entries;
+  if (details->data.entries != nullptr) delete[] details->data.entries;
+  delete details;
 }

--- a/flutter_local_notifications_windows/src/ffi_api.cpp
+++ b/flutter_local_notifications_windows/src/ffi_api.cpp
@@ -149,13 +149,12 @@ NativeNotificationDetails* getPendingNotifications(NativePlugin* plugin, int* si
 
 void freeDetailsArray(NativeNotificationDetails* ptr) { delete[] ptr; }
 
-void freeLaunchDetails(NativeLaunchDetails* details) {
-  if (details->payload != nullptr) delete[] details->payload;
-  for (int index = 0; index < details->data.size; index++) {
-    const auto pair = details->data.entries[index];
+void freeLaunchDetails(const char* payload, const StringMapEntry* entries, int size) {
+  if (payload != nullptr) delete[] payload;
+  for (int index = 0; index < size; index++) {
+    const auto pair = entries[index];
     delete pair.key;
     delete pair.value;
   }
-  if (details->data.entries != nullptr) delete[] details->data.entries;
-  delete details;
+  if (entries != nullptr) delete[] entries;
 }

--- a/flutter_local_notifications_windows/src/ffi_api.h
+++ b/flutter_local_notifications_windows/src/ffi_api.h
@@ -62,7 +62,7 @@ typedef struct NativeLaunchDetails {
 /// A callback that is run with [NativeLaunchDetails] when a notification is pressed.
 ///
 /// This may be called at app launch or even while the app is running.
-typedef void (*NativeNotificationCallback)(NativeLaunchDetails details);
+typedef void (*NativeNotificationCallback)(NativeLaunchDetails* details);
 
 // See: https://learn.microsoft.com/en-us/uwp/api/windows.ui.notifications.notificationupdateresult
 typedef enum NativeUpdateResult {
@@ -134,7 +134,7 @@ FFI_PLUGIN_EXPORT NativeNotificationDetails* getPendingNotifications(
 FFI_PLUGIN_EXPORT void freeDetailsArray(NativeNotificationDetails* ptr);
 
 /// Releases the memory associated with a [NativeLaunchDetails].
-FFI_PLUGIN_EXPORT void freeLaunchDetails(NativeLaunchDetails details);
+FFI_PLUGIN_EXPORT void freeLaunchDetails(NativeLaunchDetails* details);
 
 #ifdef __cplusplus
 }

--- a/flutter_local_notifications_windows/src/ffi_api.h
+++ b/flutter_local_notifications_windows/src/ffi_api.h
@@ -47,22 +47,18 @@ typedef enum NativeLaunchType {
   action,
 } NativeLaunchType;
 
-/// Details about how the app was launched.
-typedef struct NativeLaunchDetails {
-  /// Whether the app was launched by a notification
-  bool didLaunch;
-  /// What part of the notification launched the app.
-  NativeLaunchType launchType;
-  /// The payload sent to the app by the notification. Usually the action that was pressed.
-  const char* payload;
-  /// The IDs and values of any text inputs in the notification.
-  NativeStringMap data;
-} NativeLaunchDetails;
-
-/// A callback that is run with [NativeLaunchDetails] when a notification is pressed.
+/// A callback that is run with raw launch details when a notification is pressed.
 ///
 /// This may be called at app launch or even while the app is running.
-typedef void (*NativeNotificationCallback)(NativeLaunchDetails* details);
+/// Parameters are passed individually instead of as a struct to avoid AOT
+/// snapshotter crashes with FFI structs containing bool fields.
+typedef void (*NativeNotificationCallback)(
+  int didLaunch,
+  int launchType,
+  const char* payload,
+  const StringMapEntry* data_entries,
+  int data_size
+);
 
 // See: https://learn.microsoft.com/en-us/uwp/api/windows.ui.notifications.notificationupdateresult
 typedef enum NativeUpdateResult {
@@ -133,8 +129,11 @@ FFI_PLUGIN_EXPORT NativeNotificationDetails* getPendingNotifications(
 /// Releases the memory associated with a [NativeNotificationDetails] array.
 FFI_PLUGIN_EXPORT void freeDetailsArray(NativeNotificationDetails* ptr);
 
-/// Releases the memory associated with a [NativeLaunchDetails].
-FFI_PLUGIN_EXPORT void freeLaunchDetails(NativeLaunchDetails* details);
+/// Releases the memory allocated for launch details.
+///
+/// Frees the payload string and the data entries array individually,
+/// since [NativeNotificationCallback] passes them as raw pointers.
+FFI_PLUGIN_EXPORT void freeLaunchDetails(const char* payload, const StringMapEntry* entries, int size);
 
 #ifdef __cplusplus
 }

--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -47,7 +47,8 @@ struct NotificationActivationCallback :
       launchDetails.launchType = launchType;
       launchDetails.payload = toNativeString(payload);
       launchDetails.data = toNativeMap(entries);
-      callback(launchDetails);
+      auto* pDetails = new NativeLaunchDetails(launchDetails);
+      callback(pDetails);
       return S_OK;
     } catch (...) {
       return winrt::to_hresult();

--- a/flutter_local_notifications_windows/src/plugin.cpp
+++ b/flutter_local_notifications_windows/src/plugin.cpp
@@ -42,13 +42,9 @@ struct NotificationActivationCallback :
       const auto payload = string(CW2A(args, CP_UTF8));
       const auto launchType =
         openedWithAction ? NativeLaunchType::action : NativeLaunchType::notification;
-      NativeLaunchDetails launchDetails;
-      launchDetails.didLaunch = true;
-      launchDetails.launchType = launchType;
-      launchDetails.payload = toNativeString(payload);
-      launchDetails.data = toNativeMap(entries);
-      auto* pDetails = new NativeLaunchDetails(launchDetails);
-      callback(pDetails);
+      auto* nativePayload = toNativeString(payload);
+      auto nativeData = toNativeMap(entries);
+      callback(true, launchType, nativePayload, nativeData.entries, nativeData.size);
       return S_OK;
     } catch (...) {
       return winrt::to_hresult();


### PR DESCRIPTION
Read the following for the rationale behind discarding the struct altogether:

https://github.com/MaikuB/flutter_local_notifications/issues/2615#issuecomment-4745825231

This MAY be a Dart-side bug actually, so this fix is more of a hack to get apps compiling; I'm not sure what exactly is fucking the AOT snapshotter and honestly I'm not going to investigate it. Thus, it may be a good idea to open up a channel with flutter devs to take a look at the issue too.