### PR TITLE
[flutter_local_notifications] fix typo in NotificationResponseType documentation

### DIFF
--- a/flutter_local_notifications_platform_interface/lib/src/types.dart
+++ b/flutter_local_notifications_platform_interface/lib/src/types.dart
@@ -164,6 +164,6 @@ enum NotificationResponseType {
   /// Indicates that a user has selected a notification.
   selectedNotification,
 
-  /// Indicates the a user has selected a notification action.
+  /// Indicates that a user has selected a notification action.
   selectedNotificationAction,
 }


### PR DESCRIPTION
## Description

Fixes a typo in the documentation for `NotificationResponseType.selectedNotificationAction`.

Changes:

- `Indicates the a user has selected a notification action.`
- `Indicates that a user has selected a notification action.`