### PR TITLE
fix(android): set background activity launch mode for PendingIntent

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -6,6 +6,7 @@ import static android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.ActivityOptions;
 import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -276,8 +277,16 @@ public class FlutterLocalNotificationsPlugin
     if (VERSION.SDK_INT >= VERSION_CODES.M) {
       flags |= PendingIntent.FLAG_IMMUTABLE;
     }
-    PendingIntent pendingIntent =
-        PendingIntent.getActivity(context, notificationDetails.id, intent, flags);
+    PendingIntent pendingIntent;
+    if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      ActivityOptions activityOptions = ActivityOptions.makeBasic();
+      activityOptions.setPendingIntentCreatorBackgroundActivityStartMode(
+          ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_DENIED);
+      pendingIntent = PendingIntent.getActivity(context, notificationDetails.id, intent, flags,
+          activityOptions.toBundle());
+    } else {
+      pendingIntent = PendingIntent.getActivity(context, notificationDetails.id, intent, flags);
+    }
     DefaultStyleInformation defaultStyleInformation =
         (DefaultStyleInformation) notificationDetails.styleInformation;
     NotificationCompat.Builder builder =
@@ -334,10 +343,22 @@ public class FlutterLocalNotificationsPlugin
         }
 
         @SuppressLint("UnspecifiedImmutableFlag")
-        final PendingIntent actionPendingIntent =
-            action.showsUserInterface != null && action.showsUserInterface
-                ? PendingIntent.getActivity(context, requestCode++, actionIntent, actionFlags)
-                : PendingIntent.getBroadcast(context, requestCode++, actionIntent, actionFlags);
+        final PendingIntent actionPendingIntent;
+        if (action.showsUserInterface != null && action.showsUserInterface) {
+          if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ActivityOptions activityOptions = ActivityOptions.makeBasic();
+            activityOptions.setPendingIntentCreatorBackgroundActivityStartMode(
+                ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_DENIED);
+            actionPendingIntent = PendingIntent.getActivity(context, requestCode++, actionIntent,
+                actionFlags, activityOptions.toBundle());
+          } else {
+            actionPendingIntent = PendingIntent.getActivity(context, requestCode++, actionIntent,
+                actionFlags);
+          }
+        } else {
+          actionPendingIntent = PendingIntent.getBroadcast(context, requestCode++, actionIntent,
+              actionFlags);
+        }
 
         final Spannable actionTitleSpannable = new SpannableString(action.title);
         if (action.titleColor != null) {


### PR DESCRIPTION
see https://github.com/MaikuB/flutter_local_notifications/issues/2795

## Summary
Adds explicit background activity launch handling for Android 14+ activity `PendingIntent`s created by the plugin.

This updates `PendingIntent.getActivity(...)` usage to pass an `ActivityOptions` bundle on API 34+ and explicitly set the pending intent creator background activity start mode.

## Motivation
Android 14 introduced stricter handling around background activity launches. When creating activity `PendingIntent`s, apps should explicitly opt in or opt out of background activity start behavior instead of relying on implicit or system-defined defaults.

Previously, the plugin created activity `PendingIntent`s for notification taps and notification actions without passing `ActivityOptions.setPendingIntentCreatorBackgroundActivityStartMode(...)`.

This made the behavior implicit on API 34+ and could trigger Android security/compliance findings. Making the behavior explicit allows the plugin to:

- align with Android guidance for activity pending intents
- avoid relying on system-defined background launch behavior
- use a secure default for notification-related activity launches

The change is backward compatible because it only applies on Android 14+ and keeps the existing behavior for older Android versions.

## Implementation notes

- Adds `ActivityOptions` usage to Android activity `PendingIntent` creation.
- Applies to the main notification tap `PendingIntent.getActivity(...)` path.
- Applies to notification action `PendingIntent.getActivity(...)` when `showsUserInterface` is true.
- Uses `Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE` to gate the new behavior.
- Uses `ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_DENIED` as the explicit default.
- Passes `activityOptions.toBundle()` to the 5-argument `PendingIntent.getActivity(...)` overload on API 34+.
- Preserves the existing 4-argument `PendingIntent.getActivity(...)` call on older Android versions.

## Testing
Tested using:

melos bootstrap
melos run analyze
melos run test:unit <default>