### PR TITLE
[flutter_local_notifications_windows] Feature parity for Windows apps without package identity

### DIFF
--- a/flutter_local_notifications_windows/README.md
+++ b/flutter_local_notifications_windows/README.md
@@ -5,7 +5,6 @@ The Windows implementation of `package:flutter_local_notifications` as an FFI pa
 ## Limitations
 
 - Windows does not support repeating notifications, so [`periodicallyShow`](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/FlutterLocalNotificationsPlugin/periodicallyShow.html) and [`periodicallyShowWithDuration`](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/FlutterLocalNotificationsPlugin/periodicallyShowWithDuration.html) will throw `UnsupportedError`s.
-- Windows only allows apps with package identity to retrieve previously shown notifications. This means that on an app that was not packaged as an [MSIX](https://learn.microsoft.com/en-us/windows/msix/overview) installer, [`cancel`](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/FlutterLocalNotificationsPlugin/cancel.html) does nothing and [getActiveNotifications](https://pub.dev/documentation/flutter_local_notifications/latest/flutter_local_notifications/FlutterLocalNotificationsPlugin/getActiveNotifications.html) will return an empty list. To package your app as an MSIX, see [`package:msix`](https://pub.dev/packages/msix) and the `msix` section in [the example's `pubspec.yaml`](https://github.com/MaikuB/flutter_local_notifications/blob/master/flutter_local_notifications/example/pubspec.yaml).
 
 ## Project structure
 

--- a/flutter_local_notifications_windows/src/ffi_api.cpp
+++ b/flutter_local_notifications_windows/src/ffi_api.cpp
@@ -8,6 +8,8 @@
 
 using winrt::Windows::Data::Xml::Dom::XmlDocument;
 
+static const winrt::hstring kDefaultGroup = L"flnpGroupNull";
+
 bool hasPackageIdentity() {
   if (!IsWindows8OrGreater()) return false;
   uint32_t length = 0;
@@ -58,6 +60,7 @@ bool showNotification(NativePlugin* plugin, int id, char* xml, NativeStringMap b
   ToastNotification notification(doc);
   const auto data = dataFromMap(bindings);
   notification.Tag(winrt::to_hstring(id));
+  if (!plugin->hasIdentity) notification.Group(kDefaultGroup);
   notification.Data(data);
   plugin->notifier.value().Show(notification);
   return true;
@@ -73,15 +76,18 @@ bool scheduleNotification(NativePlugin* plugin, int id, char* xml, int time) {
   }
   ScheduledToastNotification notification(doc, winrt::clock::from_time_t(time));
   notification.Tag(winrt::to_hstring(id));
+  if (!plugin->hasIdentity) notification.Group(kDefaultGroup);
   plugin->notifier.value().AddToSchedule(notification);
   return true;
 }
 
 NativeUpdateResult updateNotification(NativePlugin* plugin, int id, NativeStringMap bindings) {
-  if (!plugin->isReady) return NativeUpdateResult::failed;
+  if (!plugin->isReady) return failed;
   const auto tag = winrt::to_hstring(id);
   const auto data = dataFromMap(bindings);
-  const auto result = plugin->notifier.value().Update(data, tag);
+  const auto result = plugin->hasIdentity
+    ? plugin->notifier.value().Update(data, tag)
+    : plugin->notifier.value().Update(data, tag, kDefaultGroup);
   return (NativeUpdateResult) result;
 }
 
@@ -100,7 +106,12 @@ void cancelAll(NativePlugin* plugin) {
 void cancelNotification(NativePlugin* plugin, int id) {
   if (!plugin->isReady) return;
   const auto tag = winrt::to_hstring(id);
-  if (plugin->hasIdentity) plugin->history.value().Remove(tag);
+  try {
+    if (plugin->hasIdentity) plugin->history.value().Remove(tag);
+    else plugin->history.value().Remove(tag, kDefaultGroup, plugin->aumid);
+  } catch (winrt::hresult_error&) {
+    // Toast not found
+  }
   for (const auto notification : plugin->notifier.value().GetScheduledToastNotifications()) {
     if (notification.Tag() == tag) {
       plugin->notifier.value().RemoveFromSchedule(notification);
@@ -111,11 +122,13 @@ void cancelNotification(NativePlugin* plugin, int id) {
 
 NativeNotificationDetails* getActiveNotifications(NativePlugin* plugin, int* size) {
   // TODO: Get more details here
-  if (!plugin->isReady || !plugin->hasIdentity) {
+  if (!plugin->isReady) {
     *size = 0;
     return nullptr;
   }
-  const auto active = plugin->history.value().GetHistory();
+  const auto active = plugin->hasIdentity
+    ? plugin->history.value().GetHistory()
+    : plugin->history.value().GetHistory(plugin->aumid);
   *size = active.Size();
   const auto result = new NativeNotificationDetails[*size];
   int index = 0;


### PR DESCRIPTION
For Windows apps NOT packaged as MSIX
- Adds ability to cancel individual notifications
- Adds ability to get all active notifications

Removes text in README stating this was not possible

Follows the same format as https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/c8f76d072df53d3622fb5440d63afb06cb9e7a10/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotifierCompat.cs#L115-L117