### PR TITLE
[flutter_local_notifications] added references to FlutterFramework

### DIFF
--- a/flutter_local_notifications/CHANGELOG.md
+++ b/flutter_local_notifications/CHANGELOG.md
@@ -1,6 +1,7 @@
-## [Unreleased]
+## [22.1.0]
 
 * [Android] added support for `showBigPictureWhenCollapsed` in `BigPictureStyleInformation`. Thanks to the PR from [hiimax (Codematic)](https://github.com/hiimax)
+* [iOS][macOS] improved SPM compatibility
 
 ## [22.0.1]
 

--- a/flutter_local_notifications/ios/flutter_local_notifications/Package.swift
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "flutter-local-notifications", targets: ["flutter_local_notifications"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "flutter_local_notifications",
-            dependencies: [],
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
             ],

--- a/flutter_local_notifications/macos/flutter_local_notifications/Package.swift
+++ b/flutter_local_notifications/macos/flutter_local_notifications/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "flutter-local-notifications", targets: ["flutter_local_notifications"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "flutter_local_notifications",
-            dependencies: [],
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
             ],

--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_local_notifications
 description: A cross platform plugin for displaying and scheduling local
   notifications for Flutter applications with the ability to customise for each
   platform.
-version: 22.0.1
+version: 22.1.0
 homepage: https://github.com/MaikuB/flutter_local_notifications/tree/master/flutter_local_notifications
 issue_tracker: https://github.com/MaikuB/flutter_local_notifications/issues
 


### PR DESCRIPTION
Adds references to FlutterFramework per the updated SPM migration guide for plugin authors [here](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors)