### PR TITLE
[flutter_local_notifications] raise iOS minimum to 13.0 in Package.swift to match plugin minimum

### DIFF
--- a/flutter_local_notifications/ios/flutter_local_notifications/Package.swift
+++ b/flutter_local_notifications/ios/flutter_local_notifications/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "flutter_local_notifications",
     platforms: [
-        .iOS("11.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "flutter-local-notifications", targets: ["flutter_local_notifications"])


### PR DESCRIPTION
## Description

`flutter_local_notifications/ios/flutter_local_notifications/Package.swift` declares `.iOS("11.0")`, but the package depends on `FlutterFramework`, which requires iOS 13.0. When Swift Package Manager is enabled in a Flutter app, this mismatch causes a **Target Integrity** build failure:

> The package product 'FlutterFramework' requires minimum platform version 13.0 for the iOS platform, but this target supports 11.0

FLN 21.0.0 already raised the Dart-side minimum to iOS 13, so this one-line change simply brings the SPM manifest into alignment with the plugin's actual minimum.

Fixes #2807

🤖 Generated with [Claude Code](https://claude.com/claude-code)